### PR TITLE
Optimization in combatChecks()

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/Taming.java
+++ b/src/main/java/com/gmail/nossr50/skills/Taming.java
@@ -1,18 +1,18 @@
 /*
 	This file is part of mcMMO.
 
-    mcMMO is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	mcMMO is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    mcMMO is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	mcMMO is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with mcMMO.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+	along with mcMMO.  If not, see <http://www.gnu.org/licenses/>.
 */
 package com.gmail.nossr50.skills;
 
@@ -34,71 +34,71 @@ import com.gmail.nossr50.locale.mcLocale;
 
 public class Taming 
 {
-    public static void rewardXp(EntityDamageEvent event, mcMMO pluginx, Player master)
-    {
-    	Entity entity = event.getEntity();
-        if(!pluginx.misc.mobSpawnerList.contains(entity.getEntityId()))
-        {
-            int xp = Combat.getXp(entity, event);
-            Users.getProfile(master).addXP(SkillType.TAMING, xp*10, master);
-            
-            if(entity instanceof Player)
-            {
-                xp = (event.getDamage() * 2);
-                Users.getProfile(master).addXP(SkillType.TAMING, (int)((xp*10)*1.5), master);
-            }
-            Skills.XpCheckSkill(SkillType.TAMING, master);
-        }
-    }
-    
-    public static void fastFoodService(PlayerProfile PPo, Wolf theWolf, EntityDamageEvent event)
-    {
-    	int health = theWolf.getHealth();
-    	int maxHealth = theWolf.getMaxHealth();
-    	int damage = event.getDamage();
-        if(PPo.getSkillLevel(SkillType.TAMING) >= 50)
-        {
-            if(health < maxHealth)
-            {
-                if(Math.random() * 10 > 5)
-                {
-                    if(health + damage <= maxHealth)
-                        theWolf.setHealth(health + damage);
-                    else
-                        theWolf.setHealth(maxHealth);
-                }
-            }
-        }
-    }
-    
-    public static void sharpenedClaws(PlayerProfile PPo, EntityDamageEvent event)
-    {
-        if(PPo.getSkillLevel(SkillType.TAMING) >= 750)
-        {
-            event.setDamage(event.getDamage() + 2);
-        }
-    }
-    
-    public static void gore(PlayerProfile PPo, EntityDamageEvent event, Player master, mcMMO pluginx)
-    {
-        if(Math.random() * 1000 <= PPo.getSkillLevel(SkillType.TAMING))
-        {
-        	Entity entity = event.getEntity();
-            event.setDamage(event.getDamage() * 2);
-            
-            if(entity instanceof Player)
-            {
-                Player target = (Player)entity;
-                target.sendMessage(mcLocale.getString("Combat.StruckByGore")); //$NON-NLS-1$
-                Users.getProfile(target).setBleedTicks(2);
-            }
-            else
-                pluginx.misc.addToBleedQue((LivingEntity)entity);
-            
-            master.sendMessage(mcLocale.getString("Combat.Gore")); //$NON-NLS-1$
-        }
-    }
-    
+	public static void rewardXp(EntityDamageEvent event, mcMMO pluginx, Player master)
+	{
+		Entity entity = event.getEntity();
+		if(!pluginx.misc.mobSpawnerList.contains(entity.getEntityId()))
+		{
+			int xp = Combat.getXp(entity, event.getDamage());
+			Users.getProfile(master).addXP(SkillType.TAMING, xp*10, master);
+			
+			if(entity instanceof Player)
+			{
+				xp = (event.getDamage() * 2);
+				Users.getProfile(master).addXP(SkillType.TAMING, (int)((xp*10)*1.5), master);
+			}
+			Skills.XpCheckSkill(SkillType.TAMING, master);
+		}
+	}
+	
+	public static void fastFoodService(PlayerProfile PPo, Wolf theWolf, EntityDamageEvent event)
+	{
+		int health = theWolf.getHealth();
+		int maxHealth = theWolf.getMaxHealth();
+		int damage = event.getDamage();
+		if(PPo.getSkillLevel(SkillType.TAMING) >= 50)
+		{
+			if(health < maxHealth)
+			{
+				if(Math.random() * 10 > 5)
+				{
+					if(health + damage <= maxHealth)
+						theWolf.setHealth(health + damage);
+					else
+						theWolf.setHealth(maxHealth);
+				}
+			}
+		}
+	}
+	
+	public static void sharpenedClaws(PlayerProfile PPo, EntityDamageEvent event)
+	{
+		if(PPo.getSkillLevel(SkillType.TAMING) >= 750)
+		{
+			event.setDamage(event.getDamage() + 2);
+		}
+	}
+	
+	public static void gore(PlayerProfile PPo, EntityDamageEvent event, Player master, mcMMO pluginx)
+	{
+		if(Math.random() * 1000 <= PPo.getSkillLevel(SkillType.TAMING))
+		{
+			Entity entity = event.getEntity();
+			event.setDamage(event.getDamage() * 2);
+			
+			if(entity instanceof Player)
+			{
+				Player target = (Player)entity;
+				target.sendMessage(mcLocale.getString("Combat.StruckByGore")); //$NON-NLS-1$
+				Users.getProfile(target).setBleedTicks(2);
+			}
+			else
+				pluginx.misc.addToBleedQue((LivingEntity)entity);
+			
+			master.sendMessage(mcLocale.getString("Combat.Gore")); //$NON-NLS-1$
+		}
+	}
+	
 	public static boolean ownerOnline(Wolf theWolf, Plugin pluginx)
 	{
 		for(Player x : pluginx.getServer().getOnlinePlayers())


### PR DESCRIPTION
Removed unnecessary checks and casts.

Item and permission verifications are now only done once in the method. However they're still done in bleedCheck(), axeCritialCheck() and probably elsewhere too. It can now be avoided.

Two methods were added: Combat.PvPExperienceGain() and Combat.PvEExperienceGain(), both are private and called in combatChecks(). SkillType is passed as an argument to avoid checks that have already been done.

I hope it works well, I couldn't properly test it, I have some trouble with the export (messages replaced by strings between exclamation marks, for example). Sorry for that, tell me if you think more test is needed.
