### PR TITLE
Replacement of m.getDistance()

### DIFF
--- a/src/main/java/com/gmail/nossr50/datatypes/PlayerProfile.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/PlayerProfile.java
@@ -929,7 +929,7 @@ public class PlayerProfile
 				if(x.isOnline() && !x.getName().equals(thisplayer.getName()) && Party.getInstance().isPartyLeader(x.getName(), this.getParty()))
 				{
 					//leaderName = x.getName();
-					if(m.getDistance(thisplayer.getLocation(), x.getLocation()) < 25)
+					if(m.isNear(thisplayer.getLocation(), x.getLocation(), 25))
 					{
 						PlayerProfile PartyLeader = Users.getProfile(x);
 						if(PartyLeader.getSkillLevel(skillType) >= this.getSkillLevel(skillType))

--- a/src/main/java/com/gmail/nossr50/m.java
+++ b/src/main/java/com/gmail/nossr50/m.java
@@ -189,13 +189,19 @@ public class m
 		
 		return 1;
 	}
-
-	public static double getDistance(Location loca, Location locb)
-	{
-		return Math.sqrt(Math.pow(loca.getX() - locb.getX(), 2) + Math.pow(loca.getY() - locb.getY(), 2)
-				+ Math.pow(loca.getZ() - locb.getZ(), 2));
+	
+	public static boolean isNear(Location first, Location second, int maxDistance) {
+		double relX = first.getX() - second.getX();
+		double relY = first.getY() - second.getY();
+		double relZ = first.getZ() - second.getZ();
+		double dist = relX * relX + relY * relY + relZ * relZ;
+		
+		if (dist < maxDistance * maxDistance)
+			return true;
+		
+		return false;
 	}
-
+	
 	public static boolean abilityBlockCheck(Block block)
 	{
 		switch(block.getType()){

--- a/src/main/java/com/gmail/nossr50/skills/Skills.java
+++ b/src/main/java/com/gmail/nossr50/skills/Skills.java
@@ -274,7 +274,7 @@ public class Skills
     			player.sendMessage(ability.getAbilityOn());
     			for(Player y : player.getWorld().getPlayers())
 	    		{
-	    			if(y != player && m.getDistance(player.getLocation(), y.getLocation()) < 10)
+    				if(y != player && m.isNear(player.getLocation(), y.getLocation(), 10))
 	    				y.sendMessage(ability.getAbilityPlayer(player));
 	    		}
     			PP.setSkillDATS(ability, System.currentTimeMillis()+(ticks*1000));


### PR DESCRIPTION
sqrt() is a very CPU intensive method, it shouldn't be used if not necessary. In our case, we don't need to know the exact distance between the two points.
pow() can also be CPU intensive. If we only need to multiply a number by itself X times, where X is an integer (and small), it's better to not use it. pow() shows its power (no pun intended) with big decimal numbers.

The difference is pretty huge (approximately 240x faster on my hardware), but probably not noticeable since m.getDistance() isn't called frequently enough. Still, it's a simple change that doesn't affect much the rest of the code.
