### PR TITLE
Ignition fix

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/Archery.java
+++ b/src/main/java/com/gmail/nossr50/skills/Archery.java
@@ -53,7 +53,10 @@ public class Archery
 			ignition += (PPa.getSkillLevel(SkillType.ARCHERY)/200)*20;
 			
 			if(ignition > 120)
-			    ignition = 120;
+				ignition = 120;
+			
+			if(x.getFireTicks() > ignition)
+				return;
 			
 			if(x instanceof Player)
 			{


### PR DESCRIPTION
Currently Ignition replaces fire ticks count no matter what the original length is, which tend to make Flame enchant pretty ineffective for example (~120 ticks replaced by 20+(skillLevel/200*20)).

I think mcMMO shouldn't overwrite enchants, nor fire ticks due to walks into fire. This quick fix forces the effect to be applied only when it's useful to the player.
