### PR TITLE
Impact fix

### DIFF
--- a/src/main/java/com/gmail/nossr50/Combat.java
+++ b/src/main/java/com/gmail/nossr50/Combat.java
@@ -82,11 +82,13 @@ public class Combat
 				Axes.axeCriticalCheck(attacker, event, pluginx); //Critical hit
 				
 				//Impact
-				if(event.getEntity() instanceof LivingEntity)
-				    Axes.impact(attacker, (LivingEntity)event.getEntity());
-				
-				if (!(event instanceof FakeEntityDamageByEntityEvent) && PPa.getSkullSplitterMode())
-					Axes.applyAoeDamage(attacker, event, pluginx);
+				if(!(event instanceof FakeEntityDamageByEntityEvent))
+				{
+					Axes.impact(attacker, target);
+					
+					if (PPa.getSkullSplitterMode())
+						Axes.applyAoeDamage(attacker, event, pluginx);
+				}
 				
 				if(target instanceof Player)
 					PvPExperienceGain(attacker, PPa, (Player) target, event.getDamage(), SkillType.AXES);

--- a/src/main/java/com/gmail/nossr50/skills/Axes.java
+++ b/src/main/java/com/gmail/nossr50/skills/Axes.java
@@ -97,8 +97,6 @@ public class Axes {
 	public static void impact(Player attacker, LivingEntity target)
 	{
 	    //TODO: Finish this skill, the idea is you will greatly damage an opponents armor and when they are armor less you have a proc that will stun them and deal additional damage.
-	    boolean didImpact = false;
-	    
 	    if(target instanceof Player)
 	    {
 	        Player targetPlayer = (Player) target;
@@ -120,31 +118,21 @@ public class Axes {
 	        }
 	        
 	        if(emptySlots == 4)
-	        {
-	            didImpact = applyImpact(attacker, target);
-	            if(didImpact)
-	                targetPlayer.sendMessage(mcLocale.getString("Axes.GreaterImpactOnSelf"));
-	        }
-	    } else {
+	            applyImpact(attacker, target);
+	    }
+	    else
 	        //Since mobs are technically unarmored this will always trigger
-	        didImpact = applyImpact(attacker, target);
-	    }
-	    
-	    if(didImpact)
-	    {
-	        attacker.sendMessage(mcLocale.getString("Axes.GreaterImpactOnEnemy"));
-	    }
+	        applyImpact(attacker, target);
 	}
 	
-	public static boolean applyImpact(Player attacker, LivingEntity target)
+	public static void applyImpact(Player attacker, LivingEntity target)
 	{
 	    if(Math.random() * 100 > 75)
         {
             Combat.dealDamage(target, 2, attacker);
             target.setVelocity(attacker.getLocation().getDirection().normalize().multiply(1.5D));
-            return true;
+            attacker.sendMessage(mcLocale.getString("Axes.GreaterImpactOnEnemy"));
         }
-	    return false;
 	}
 	
 	public static void applyAoeDamage(Player attacker, EntityDamageByEntityEvent event, Plugin pluginx)


### PR DESCRIPTION
Impact could be called by the FakeEntityDamageEvent it threw (just got 3 triggers in one hit).

Removed unnecessary cast and instanceof, target is already a LivingEntity.

boolean didImpact wasn't really needed, moved the message in applyImpact(). Its just a suggestion and doesn't fix anything, but I think it improves readability.
