### PR TITLE
Taming prevent damage fix

### DIFF
--- a/src/main/java/com/gmail/nossr50/Combat.java
+++ b/src/main/java/com/gmail/nossr50/Combat.java
@@ -171,12 +171,12 @@ public class Combat
 		/*			 
 		 * DEFENSIVE CHECKS FOR WOLVES
 		 */
-		else if(target instanceof Wolf)
-		{
-			Wolf wolf = (Wolf) target;
-			if(wolf.isTamed() && (wolf.getOwner() instanceof Player))
-				Taming.preventDamage(event, pluginx);
-		}
+		//else if(target instanceof Wolf)
+		//{
+		//	Wolf wolf = (Wolf) target;
+		//	if(wolf.isTamed() && (wolf.getOwner() instanceof Player))
+		//		Taming.preventDamage(event, pluginx);
+		//}
 	}
 	
 	public static void combatAbilityChecks(Player attacker, PlayerProfile PPa)

--- a/src/main/java/com/gmail/nossr50/skills/Taming.java
+++ b/src/main/java/com/gmail/nossr50/skills/Taming.java
@@ -113,26 +113,47 @@ public class Taming
 	public static void preventDamage(EntityDamageEvent event, mcMMO plugin)
 	{
 		DamageCause cause = event.getCause();
-		Entity entity = event.getEntity();
-		Wolf theWolf = (Wolf)entity;
-		Player master = (Player)theWolf.getOwner();
+		Wolf wolf = (Wolf) event.getEntity();
+		Player master = (Player) wolf.getOwner();
 		int skillLevel = Users.getProfile(master).getSkillLevel(SkillType.TAMING);
 		
-		//Environmentally Aware
-		if((cause == DamageCause.CONTACT || cause == DamageCause.LAVA || cause == DamageCause.FIRE) && skillLevel >= 100)
+		switch(cause)
 		{
-			if(event.getDamage() < theWolf.getHealth())
+		//Environmentally Aware
+		case CONTACT:
+		case LAVA:
+		case FIRE:
+			if(skillLevel >= 100)
 			{
-				entity.teleport(master.getLocation());
+				if(event.getDamage() >= wolf.getHealth())
+					return;
+				
+				wolf.teleport(master.getLocation());
 				master.sendMessage(mcLocale.getString("mcEntityListener.WolfComesBack")); //$NON-NLS-1$
-				entity.setFireTicks(0);
 			}
-		}
-		if(cause == DamageCause.FALL && skillLevel >= 100)
-			event.setCancelled(true);
-		
+			break;
+		case FALL:
+			if(skillLevel >= 100)
+				event.setCancelled(true);
+			break;
+			
 		//Thick Fur
-		if(cause == DamageCause.FIRE_TICK)
-			event.getEntity().setFireTicks(0);
+		case FIRE_TICK:
+			if(skillLevel >= 250)
+				wolf.setFireTicks(0);
+			break;
+		case ENTITY_ATTACK:
+		case PROJECTILE:
+			if(skillLevel >= 250)
+				event.setDamage(event.getDamage() / 2);
+			break;
+			
+		//Shock Proof
+		case ENTITY_EXPLOSION:
+		case BLOCK_EXPLOSION:
+			if(skillLevel >= 500)
+				event.setDamage(event.getDamage() / 6);
+			break;
+		}
 	}
 }


### PR DESCRIPTION
According to /taming, preventDamage was missing a few things:
- Shock Proof
- Level requirement for Thick Fur
- Physical damage reduction in Thick Fur (maybe a little too OP with fastFoodService?)

Also removed fire ticks reset in Environmentally Aware, Thick Fur already does that.

Switched to switches (!).

Commented preventDamage() call in combatChecks(), it's already done in the listener. My test showed that both listener are called if the event is an EntityDamageByEntityEvent. However I don't know what are the other implications.
