### PR TITLE
Adding db code to help avoid stale connections

### DIFF
--- a/src/main/java/com/gmail/nossr50/Database.java
+++ b/src/main/java/com/gmail/nossr50/Database.java
@@ -38,7 +38,10 @@ public class Database {
 	    try 
 	    {
 	        System.out.println("[mcMMO] Attempting connection to MySQL...");
-	        conn = DriverManager.getConnection(connectionString);
+	        java.util.Properties conProperties = new java.util.Properties();
+	        conProperties.put("autoReconnect", "true");
+	        conProperties.put("maxReconnects", "3");
+	        conn = DriverManager.getConnection(connectionString, conProperties);
 	        isConnected = true;
 	        System.out.println("[mcMMO] Connection to MySQL established!");
 	    } catch (SQLException ex) 


### PR DESCRIPTION
After going through all of my plugins to figure out the database connection error, I realized that the error messages were originating with mcMMO. I forked it, added the same auto-reconnect props I use in my plugins and ran a custom build, and after an hour of use on our live server I'm no longer seeing any database errors. 
