### PR TITLE
Fix for combat XP gain

### DIFF
--- a/src/main/java/com/gmail/nossr50/Combat.java
+++ b/src/main/java/com/gmail/nossr50/Combat.java
@@ -59,12 +59,7 @@ public class Combat {
                     applyAbilityAoE(attacker, target, damage, pluginx, SkillType.SWORDS);
                 }
 
-                if (targetType.equals(EntityType.PLAYER)) {
-                    PvPExperienceGain(attacker, PPa, (Player) target, damage, SkillType.SWORDS);
-                }
-                else if (!pluginx.misc.mobSpawnerList.contains(target.getEntityId())){
-                    PvEExperienceGain(attacker, PPa, target, damage, SkillType.SWORDS);
-                }
+                startGainXp(attacker, PPa, target, SkillType.SWORDS, pluginx);
             }
             else if (ItemChecks.isAxe(itemInHand) && mcPermissions.getInstance().axes(attacker)) {
                 Axes.axesBonus(attacker, event);
@@ -74,13 +69,8 @@ public class Combat {
                 if (PPa.getSkullSplitterMode()) {
                     applyAbilityAoE(attacker, target, damage, pluginx, SkillType.AXES);
                 }
-                
-                if (targetType.equals(EntityType.PLAYER)) {
-                    PvPExperienceGain(attacker, PPa, (Player) target, event.getDamage(), SkillType.AXES); //use getDamage because damage is modified in earlier functions
-                }
-                else if (!pluginx.misc.mobSpawnerList.contains(target.getEntityId())) {
-                    PvEExperienceGain(attacker, PPa, target, event.getDamage(), SkillType.AXES); //use getDamage because damage is modified in earlier functions
-                }
+
+                startGainXp(attacker, PPa, target, SkillType.AXES, pluginx);
             }
             else if (itemInHand.getType().equals(Material.AIR) && mcPermissions.getInstance().unarmed(attacker)) {
                 Unarmed.unarmedBonus(attacker, event);
@@ -91,11 +81,9 @@ public class Combat {
 
                 if (targetType.equals(EntityType.PLAYER)) {
                     Unarmed.disarmProcCheck(attacker, (Player) target);
-                    PvPExperienceGain(attacker, PPa, (Player) target, event.getDamage(), SkillType.UNARMED); //use getDamage because damage is modified in earlier functions
                 }
-                else if (!pluginx.misc.mobSpawnerList.contains(target.getEntityId())) {
-                    PvEExperienceGain(attacker, PPa, target, event.getDamage(), SkillType.UNARMED); //use getDamage because damage is modified in earlier functions
-                }
+                
+                startGainXp(attacker, PPa, target, SkillType.UNARMED, pluginx);
             }
             else if (itemInHand.getType().equals(Material.BONE) && mcPermissions.getInstance().taming(attacker) && targetType.equals(EntityType.WOLF)) {
                 Wolf wolf = (Wolf) target;
@@ -126,7 +114,8 @@ public class Combat {
                     Taming.fastFoodService(PPo, wolf, event);
                     Taming.sharpenedClaws(PPo, event);
                     Taming.gore(PPo, event, master, pluginx);
-                    Taming.rewardXp(event, pluginx, master);
+
+                    startGainXp(master, PPo, target, SkillType.TAMING, pluginx);
                 }
             }
             break;
@@ -173,10 +162,10 @@ public class Combat {
     public static void archeryCheck(EntityDamageByEntityEvent event, mcMMO pluginx) {
         Arrow arrow = (Arrow) event.getDamager();
         LivingEntity shooter = arrow.getShooter();
-        Entity entity = event.getEntity();
+        LivingEntity target = (LivingEntity) event.getEntity();
 
-        if (entity instanceof Player) {
-            Player defender = (Player) entity;
+        if (target instanceof Player) {
+            Player defender = (Player) target;
             PlayerProfile PPd = Users.getProfile(defender);
             boolean deflect = false;
 
@@ -202,16 +191,13 @@ public class Combat {
             int damage = event.getDamage();
 
             if (mcPermissions.getInstance().archery(attacker) && damage > 0) {
-                Archery.trackArrows(pluginx, entity, PPa);
-                Archery.ignitionCheck(entity, attacker);
+                Archery.trackArrows(pluginx, target, PPa);
+                Archery.ignitionCheck(target, attacker);
 
-                if (!pluginx.misc.mobSpawnerList.contains(entity.getEntityId())) {
-                    int xp = getXp((LivingEntity) entity, damage);
-                    PPa.addXP(SkillType.ARCHERY, xp*10, attacker);
-                }
+                startGainXp(attacker, PPa, target, SkillType.ARCHERY, pluginx);
 
-                if (entity instanceof Player) {
-                    Player defender = (Player) entity;
+                if (target instanceof Player) {
+                    Player defender = (Player) target;
                     PlayerProfile PPd = Users.getProfile(defender);
 
                     if (PPa.inParty() && PPd.inParty() && Party.getInstance().inSameParty(defender, attacker)) {
@@ -219,16 +205,9 @@ public class Combat {
                         return;
                     }
 
-                    if (LoadProperties.pvpxp && (((PPd.getLastLogin() + 5) * 1000) < System.currentTimeMillis()) && !attacker.getName().equals(defender.getName())) {
-                        int xp = (damage * 2) * 10; //What's the 2 for? Should this be a multiplier from file instead?
-                        PPa.addXP(SkillType.ARCHERY, xp, attacker);
-                    }
-
                     Archery.dazeCheck(defender, attacker);
                 }
             }
-
-            Skills.XpCheckSkill(SkillType.ARCHERY, attacker);
         }
     }
 
@@ -286,149 +265,6 @@ public class Combat {
         else {
             target.damage(dmg);
         }
-    }
-
-    /**
-     * Process PVP experience gain.
-     *
-     * @param attacker The attacking player
-     * @param PPa The profile of the attacking player
-     * @param defender The defending player
-     * @param damage The initial damage amount
-     * @param skillType The skill being used
-     */
-    private static void PvPExperienceGain(Player attacker, PlayerProfile PPa, Player defender, int damage, SkillType skillType) {
-        if (!LoadProperties.pvpxp) {
-            return;
-        }
-
-        PlayerProfile PPd = Users.getProfile(defender);
-        int health = defender.getHealth();
-
-        if ((System.currentTimeMillis() >= (PPd.getRespawnATS()*1000) + 5000) && (((PPd.getLastLogin()+5)*1000) < System.currentTimeMillis()) && health >= 1) {
-            int xp = capXP(health, damage);
-
-            xp = (int) (xp * 2 * LoadProperties.pvpxprewardmodifier);
-            PPa.addXP(skillType, xp * 10, attacker);
-            Skills.XpCheckSkill(skillType, attacker);
-          }
-    }
-
-    /**
-     * Process PVE experience gain.
-     *
-     * @param attacker The attacking player
-     * @param PPa The profile of the attacking player
-     * @param target The defending entity
-     * @param damage The initial damage amount
-     * @param skillType The skill being used
-     */
-    private static void PvEExperienceGain(Player attacker, PlayerProfile PPa, LivingEntity target, int damage, SkillType skillType) {
-        int xp = getXp(target, damage);
-
-        PPa.addXP(skillType, xp * 10, attacker);
-        Skills.XpCheckSkill(skillType, attacker);
-    }
-
-    /**
-     * Cap the XP based on the remaining health of an entity.
-     *
-     * @param hpLeft Amount of HP remaining
-     * @param damage Amount of damage being dealt
-     * @return the modified XP amount
-     */
-    private static int capXP(int hpLeft, int damage) {
-        int xp;
-
-        if (hpLeft < damage) {
-            if (hpLeft > 0) {
-                xp = hpLeft;
-            }
-            else {
-                xp = 0;
-            }
-        }
-        else {
-            xp = damage;
-        }
-
-        return xp;
-    }
-
-    /**
-     * Get the XP gained from damaging a non-player mob
-     *
-     * @param entity Entity being damaged
-     * @param damage Damage to be dealt to the mob
-     * @return XP gained
-     */
-    public static int getXp(LivingEntity entity, int damage) {
-        int xp = capXP(entity.getHealth(), damage);
-
-        if (entity instanceof Animals) {
-            xp = (int) (xp * LoadProperties.animalXP);
-        }
-        else {
-            EntityType type = entity.getType();
-
-            switch (type) {
-            case BLAZE:
-                xp = (int) (xp * LoadProperties.blazeXP);
-                break;
-
-            case CAVE_SPIDER:
-                xp = (int) (xp * LoadProperties.cavespiderXP);
-                break;
-
-            case CREEPER:
-                xp = (int) (xp * LoadProperties.creeperXP);
-                break;
-
-            case ENDER_DRAGON:
-                xp = (int) (xp * LoadProperties.enderdragonXP);
-                break;
-
-            case ENDERMAN:
-                xp = (int) (xp * LoadProperties.endermanXP);
-                break;
-
-            case GHAST:
-                xp = (int) (xp * LoadProperties.ghastXP);
-                break;
-
-            case MAGMA_CUBE:
-                xp = (int) (xp * LoadProperties.magmacubeXP);
-                break;
-
-            case PIG_ZOMBIE:
-                xp = (int) (xp * LoadProperties.pigzombieXP);
-                break;
-
-            case SILVERFISH:
-                xp = (int) (xp * LoadProperties.silverfishXP);
-                break;
-
-            case SKELETON:
-                xp = (int) (xp * LoadProperties.skeletonXP);
-                break;
-
-            case SLIME:
-                xp = (int) (xp * LoadProperties.slimeXP);
-                break;
-
-            case SPIDER:
-                xp = (int) (xp * LoadProperties.spiderXP);
-                break;
-
-            case ZOMBIE:
-                xp = (int) (xp * LoadProperties.zombieXP);
-                break;
-
-            default:
-                break;
-            }
-        }
-        return xp;
     }
 
     /**
@@ -531,5 +367,129 @@ public class Combat {
                 }
             }
         }
+    }
+
+    /**
+     * Start the task that gives combat XP.
+     *
+     * @param attacker The attacking player
+     * @param PP The player's PlayerProfile
+     * @param target The defending entity
+     * @param skillType The skill being used
+     * @param plugin mcMMO plugin instance
+     */
+    public static void startGainXp(Player attacker, PlayerProfile PP, LivingEntity target, SkillType skillType, mcMMO pluginx)
+    {
+        double baseXP = 0;
+
+        if (target instanceof Player) {
+            if (!LoadProperties.pvpxp) {
+                return;
+            }
+
+            Player defender = (Player) target;
+            PlayerProfile PPd = Users.getProfile(defender);
+
+            if (System.currentTimeMillis() >= (PPd.getRespawnATS() * 1000) + 5000 &&
+               ((PPd.getLastLogin() + 5) * 1000) < System.currentTimeMillis() &&
+               defender.getHealth() >= 1) {
+                baseXP = 20 * LoadProperties.pvpxprewardmodifier;
+            }
+        }
+        else if (!pluginx.misc.mobSpawnerList.contains(target.getEntityId())) {
+            if (target instanceof Animals) {
+                baseXP = 10 * LoadProperties.animalXP;
+            }
+            else
+            {
+                EntityType type = target.getType();
+
+                switch (type) {
+                case BLAZE:
+                    baseXP = LoadProperties.blazeXP;
+                    break;
+                case CAVE_SPIDER:
+                    baseXP = LoadProperties.cavespiderXP;
+                    break;
+                case CREEPER:
+                    baseXP = LoadProperties.creeperXP;
+                    break;
+                case ENDER_DRAGON:
+                    baseXP = LoadProperties.enderdragonXP;
+                    break;
+                case ENDERMAN:
+                    baseXP = LoadProperties.endermanXP;
+                    break;
+                case GHAST:
+                    baseXP = LoadProperties.ghastXP;
+                    break;
+                case MAGMA_CUBE:
+                    baseXP = LoadProperties.magmacubeXP;
+                    break;
+                case PIG_ZOMBIE:
+                    baseXP = LoadProperties.pigzombieXP;
+                    break;
+                case SILVERFISH:
+                    baseXP = LoadProperties.silverfishXP;
+                    break;
+                case SKELETON:
+                    baseXP = LoadProperties.skeletonXP;
+                    break;
+                case SLIME:
+                    baseXP = LoadProperties.slimeXP;
+                    break;
+                case SPIDER:
+                    baseXP = LoadProperties.spiderXP;
+                    break;
+                case ZOMBIE:
+                    baseXP = LoadProperties.zombieXP;
+                    break;
+                }
+            }
+
+            baseXP *= 10;
+        }
+
+        if (baseXP != 0)
+            Bukkit.getScheduler().scheduleSyncDelayedTask(pluginx, new GainXp(attacker, PP, skillType, baseXP, target), 0);
+    }
+
+}
+
+class GainXp implements Runnable
+{
+    private Player player = null;
+    private PlayerProfile PP = null;
+    private double baseXp = 0;
+    private SkillType skillType = null;
+    private LivingEntity target = null;
+    private int baseHealth = 0;
+
+    public GainXp(Player player, PlayerProfile PP, SkillType skillType, double baseXp, LivingEntity target)
+    {
+        this.player = player;
+        this.PP = PP;
+        this.skillType = skillType;
+        this.baseXp = baseXp;
+        this.target = target;
+        baseHealth = target.getHealth();
+    }
+
+    @Override
+    public void run()
+    {
+        int health = target.getHealth();
+        int damage =  baseHealth - health;
+
+        //May avoid negative xp, we don't know what other plugins do with the entity health
+        if (damage <= 0)
+            return;
+
+        //Don't reward the player for overkills
+        if (health < 0)
+            damage += health;
+
+        PP.addXP(skillType, (int) (damage * baseXp), player);
+        Skills.XpCheckSkill(skillType, player);
     }
 }

--- a/src/main/java/com/gmail/nossr50/skills/Taming.java
+++ b/src/main/java/com/gmail/nossr50/skills/Taming.java
@@ -11,7 +11,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.inventory.ItemStack;
 
-import com.gmail.nossr50.Combat;
 import com.gmail.nossr50.Users;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.config.LoadProperties;
@@ -21,23 +20,6 @@ import com.gmail.nossr50.locale.mcLocale;
 
 public class Taming 
 {
-	public static void rewardXp(EntityDamageEvent event, mcMMO pluginx, Player master)
-	{
-		Entity entity = event.getEntity();
-		if(!pluginx.misc.mobSpawnerList.contains(entity.getEntityId()))
-		{
-			int xp = Combat.getXp((LivingEntity) entity, event.getDamage());
-			Users.getProfile(master).addXP(SkillType.TAMING, xp*10, master);
-			
-			if(entity instanceof Player)
-			{
-				xp = (event.getDamage() * 2);
-				Users.getProfile(master).addXP(SkillType.TAMING, (int)((xp*10)*1.5), master);
-			}
-			Skills.XpCheckSkill(SkillType.TAMING, master);
-		}
-	}
-	
 	public static void fastFoodService(PlayerProfile PPo, Wolf theWolf, EntityDamageEvent event)
 	{
 		int health = theWolf.getHealth();


### PR DESCRIPTION
Summary:
- Should fix double xp reward in archery (against players), but it wasn't a confirmed bug.
- By comparing entity health in the event and at the end of the tick, real damage is now used to calculate xp gain: So enchanted swords are taken into account, and an entity should no longer be able to provide more xp than its maxHealth allows (more detail on that below).

There is one problem with bukkit, totally unrelated to mcMMO: Event damage doesn't take enchants into account. So, in the event, a diamond sword always does 7 damage (without critical hit) and mcMMO use that for XP rewarding.
Since enchants damage are random (at least for swords), the only fix I'm aware of is to use a delayed task to compare healths right at the end of the current server tick. That's what the class gainXP I propose does, used in startGainXP (which replace PvPExperienceGain, PvEExperienceGain and getXp).

I also moved Taming.rewardXp, replaced by one line in Combat.combatCheks(). The exp gain versus player is also a little different now (previously configValue_2_10_1.5, now configValue_20), but that's because I haven't thought about it in the first place. All skills had the same multiplier (once added) except for Taming versus Player, I'm not sure if this was intended or not.

Anyway, here's the most interesting part. It worth mentioning because experience gain is based on that. As we know entities have an invulnerability timer (0.5sec) which is bypassed when the new damage is superior to the previous one. For example you're fighting a burning creature and you hit right after a fire tick damage, the listener will report 1 damage for the fire tick then 7 damage for the hit (diamond sword let's say).
Well, the thing is, the damage of the second hit isn't 7, but 6 (new damage minus previous damage). The same can happens with critical hit, which in this case does less damage than a normal hit (but is done sooner, since it bypass the invulnerability timer, I guess that's what Notch thought when he made this).
The only way to tell what is the real damage done is to save the entity health somewhere and to subtract the new health from it. Once added, the total will be exactly the same as the entity's maxHealth. If we use event.getDamage() the sum can be superior to the entity's max health (almost always if the player jumps a lot), so too much xp would be rewarded.

Apart from that I also tweaked archeryChecks a bit. I suspect that addXP was called twice when shotting another player. If this pull request is accepted I'll propose to make this method clearer.
