### PR TITLE
Added Player to addXP arguments, avoids getPlayer call

### DIFF
--- a/src/main/java/com/gmail/nossr50/api/ExperienceAPI.java
+++ b/src/main/java/com/gmail/nossr50/api/ExperienceAPI.java
@@ -61,7 +61,7 @@ public class ExperienceAPI {
      * @param XP The amount of XP to add
      */
     public void addXP(Player player, SkillType skillType, int XP) {
-        Users.getProfile(player).addXP(skillType, XP);
+        Users.getProfile(player).addXP(player, skillType, XP);
         checkXP(player, skillType);
     }
 

--- a/src/main/java/com/gmail/nossr50/datatypes/PlayerProfile.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/PlayerProfile.java
@@ -1008,13 +1008,11 @@ public class PlayerProfile {
     /**
      * Adds XP to the player, this is affected by skill modifiers and XP Rate
      *
+     * @param player The player to add XP to
      * @param skillType The skill to add XP to
      * @param newvalue The amount of XP to add
-     * @param player The player to add XP to
      */
-    public void addXP(SkillType skillType, int newValue) {
-        Player player = Bukkit.getPlayer(playerName);
-
+    public void addXP(Player player, SkillType skillType, int newValue) {
         if (System.currentTimeMillis() < ((xpGainATS * 1000) + 250) || player.getGameMode().equals(GameMode.CREATIVE)) {
             return;
         }

--- a/src/main/java/com/gmail/nossr50/listeners/mcEntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/mcEntityListener.java
@@ -309,7 +309,7 @@ public class mcEntityListener implements Listener {
                 break;
             }
 
-            PP.addXP(SkillType.TAMING, xp);
+            PP.addXP(player, SkillType.TAMING, xp);
             Skills.XpCheckSkill(SkillType.TAMING, player);
         }
     }

--- a/src/main/java/com/gmail/nossr50/runnables/GainXp.java
+++ b/src/main/java/com/gmail/nossr50/runnables/GainXp.java
@@ -39,7 +39,7 @@ public class GainXp implements Runnable {
             damage += health;
         }
 
-        PP.addXP(skillType, (int) (damage * baseXp));
+        PP.addXP(player, skillType, (int) (damage * baseXp));
         Skills.XpCheckSkill(skillType, player);
     }
 }

--- a/src/main/java/com/gmail/nossr50/skills/Acrobatics.java
+++ b/src/main/java/com/gmail/nossr50/skills/Acrobatics.java
@@ -58,7 +58,7 @@ public class Acrobatics {
 
             /* Check for death */
             if (health - damage >= 1) {
-                PP.addXP(SkillType.ACROBATICS, damage * ROLL_XP_MODIFIER);
+                PP.addXP(player, SkillType.ACROBATICS, damage * ROLL_XP_MODIFIER);
                 Skills.XpCheckSkill(SkillType.ACROBATICS, player);
 
                 event.setDamage(newDamage);
@@ -76,7 +76,7 @@ public class Acrobatics {
             }
         }
         else if (health - damage >= 1) {
-            PP.addXP(SkillType.ACROBATICS, event.getDamage() * FALL_XP_MODIFIER);
+            PP.addXP(player, SkillType.ACROBATICS, event.getDamage() * FALL_XP_MODIFIER);
             Skills.XpCheckSkill(SkillType.ACROBATICS, player);
         }
     }
@@ -111,7 +111,7 @@ public class Acrobatics {
                 defender.sendMessage(mcLocale.getString("Acrobatics.Dodge"));
 
                 if (System.currentTimeMillis() >= (5000 + PPd.getRespawnATS()) && defender.getHealth() >= 1) {
-                    PPd.addXP(SkillType.ACROBATICS, damage * DODGE_MODIFIER);
+                    PPd.addXP(defender, SkillType.ACROBATICS, damage * DODGE_MODIFIER);
                     Skills.XpCheckSkill(SkillType.ACROBATICS, defender);
                 }
 

--- a/src/main/java/com/gmail/nossr50/skills/Excavation.java
+++ b/src/main/java/com/gmail/nossr50/skills/Excavation.java
@@ -120,7 +120,7 @@ public class Excavation {
         }
 
         //Handle XP related tasks
-        PP.addXP(SkillType.EXCAVATION, xp);
+        PP.addXP(player, SkillType.EXCAVATION, xp);
         Skills.XpCheckSkill(SkillType.EXCAVATION, player);
     }
 

--- a/src/main/java/com/gmail/nossr50/skills/Fishing.java
+++ b/src/main/java/com/gmail/nossr50/skills/Fishing.java
@@ -102,7 +102,7 @@ public class Fishing {
                 FishingTreasure treasure = rewards.get(random.nextInt(rewards.size()));
 
                 if (random.nextDouble() * 100 <= treasure.getDropChance()) {
-                    Users.getProfile(player).addXP(SkillType.FISHING, treasure.getXp());
+                    Users.getProfile(player).addXP(player, SkillType.FISHING, treasure.getXp());
                     theCatch.setItemStack(treasure.getDrop());
                 }
             }
@@ -117,7 +117,7 @@ public class Fishing {
             theCatch.getItemStack().setDurability((short) (random.nextInt(maxDurability))); //Change durability to random value
         }
 
-        PP.addXP(SkillType.FISHING, LoadProperties.mfishing);
+        PP.addXP(player, SkillType.FISHING, LoadProperties.mfishing);
         Skills.XpCheckSkill(SkillType.FISHING, player);
     }
 

--- a/src/main/java/com/gmail/nossr50/skills/Herbalism.java
+++ b/src/main/java/com/gmail/nossr50/skills/Herbalism.java
@@ -252,7 +252,7 @@ public class Herbalism {
             }
         }
         
-        PP.addXP(SkillType.HERBALISM, xp);
+        PP.addXP(player, SkillType.HERBALISM, xp);
         Skills.XpCheckSkill(SkillType.HERBALISM, player);
     }
 

--- a/src/main/java/com/gmail/nossr50/skills/Mining.java
+++ b/src/main/java/com/gmail/nossr50/skills/Mining.java
@@ -145,7 +145,7 @@ public class Mining {
             break;
         }
 
-        PP.addXP(SkillType.MINING, xp);
+        PP.addXP(player, SkillType.MINING, xp);
         Skills.XpCheckSkill(SkillType.MINING, player);
     }
 

--- a/src/main/java/com/gmail/nossr50/skills/Repair.java
+++ b/src/main/java/com/gmail/nossr50/skills/Repair.java
@@ -138,7 +138,7 @@ public class Repair {
             dif = (short) (dif / 2);
         }
 
-        PP.addXP(SkillType.REPAIR, dif * 10);
+        PP.addXP(player, SkillType.REPAIR, dif * 10);
         Skills.XpCheckSkill(SkillType.REPAIR, player);
 
         //CLANG CLANG

--- a/src/main/java/com/gmail/nossr50/skills/WoodCutting.java
+++ b/src/main/java/com/gmail/nossr50/skills/WoodCutting.java
@@ -156,7 +156,7 @@ public class WoodCutting {
             }
         }
 
-        PP.addXP(SkillType.WOODCUTTING, xp); //Tree Feller gives nerf'd XP
+        PP.addXP(player, SkillType.WOODCUTTING, xp); //Tree Feller gives nerf'd XP
         Skills.XpCheckSkill(SkillType.WOODCUTTING, player);
     }
 
@@ -301,7 +301,7 @@ public class WoodCutting {
         }
 
         WoodCutting.woodCuttingProcCheck(player, block);
-        PP.addXP(SkillType.WOODCUTTING, xp);
+        PP.addXP(player, SkillType.WOODCUTTING, xp);
         Skills.XpCheckSkill(SkillType.WOODCUTTING, player);
     }
 


### PR DESCRIPTION
Not sure if you wish to keep the gainXp task (which is still useful actually, talked to GJ about it). Anyway, this task triggers an error:

<pre> 2012-04-13 12:22:17 [INFO] Glucas007 lost connection: disconnect.endOfStream
 2012-04-13 12:22:17 [WARNING] Task of 'mcMMO' generated an exception
 java.lang.NullPointerException
        at com.gmail.nossr50.datatypes.PlayerProfile.addXP(PlayerProfile.java:1047)
        at com.gmail.nossr50.runnables.GainXp.run(GainXp.java:42)
        at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:126)
        at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:517)
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:449)
        at net.minecraft.server.ThreadServerApplication.run(SourceFile:492)</pre>


It happens because Bukkit.getPlayer (in PlayerProfile.addXP) returns null if the player is offline, which is possible because .addXP is called at the end of the server tick (I guess).

I think the most efficient and cleaner way to avoid this, is not to do a null check or even to call player.isOnline in gainXp.run, but to directly pass the player to PlayerProfile.addXP. Every method calling addXP already have a reference to the player.

Also thought of adding PlayerProfile to XpCheckSkill arguments. Unneeded, but it would avoid a Users.getProfile call most of the time.
