### PR TITLE
Fixed a bug where the list of edited blocks for the lowest quarter of a chunk were not loaded, allowing for duplication of certain blocks.

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/blockmeta/HashChunkletManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/HashChunkletManager.java
@@ -26,7 +26,7 @@ public class HashChunkletManager implements ChunkletManager {
         File czDir = new File(cxDir, "" + cz);
         if(!czDir.exists()) return;
 
-        for(int y = 1; y <= 4; y++) {
+        for(int y = 0; y <= 4; y++) {
             File yFile = new File(czDir, "" + y);
             if(!yFile.exists()) {
                 continue;
@@ -43,7 +43,7 @@ public class HashChunkletManager implements ChunkletManager {
     public void chunkUnloaded(int cx, int cz, World world) {
         File dataDir = new File(world.getWorldFolder(), "mcmmo_data");
 
-        for(int y = 1; y <= 4; y++) {
+        for(int y = 0; y <= 4; y++) {
             if(store.containsKey(world.getName() + "," + cx + "," + cz + "," + y)) {
                 File cxDir = new File(dataDir, "" + cx);
                 if(!cxDir.exists()) cxDir.mkdir();


### PR DESCRIPTION
The bug involved the fact that the plugin will look for four files per chunk, named "1", "2", "3", and "4", but in many cases would actually save the files as "0", "1", "2", and "3". Now it will look for "0", "1", "2", "3", and "4", to remain fully compatible with all current settings and minimal edits. The bug itself only showed up after a server had restarted, since the edited blocks are stored in local memory until the server shuts down. However, once the server started up again, it would only load the top three quarters of any given chunk, because it would skip the file named "0". This allowed for duplication of blocks, especially ores, by gathering them together, then placing them in the affected area. Once the server was restarted, all blocks in the affected area were no longer flagged as edited, and the ores could be mined once again for experience and extra drops.
