### PR TITLE
Fix for ClassCastException

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/gathering/Fishing.java
+++ b/src/main/java/com/gmail/nossr50/skills/gathering/Fishing.java
@@ -191,6 +191,10 @@ public class Fishing {
      * @param event The event to modify
      */
     public static void shakeMob(PlayerFishEvent event) {
+        if (!(event.getCaught() instanceof LivingEntity)) {
+            return;
+        }
+
         int randomChance = 100;
 
         if (event.getPlayer().hasPermission("mcmmo.perks.lucky.fishing")) {


### PR DESCRIPTION
Fixes the ClassCastException thrown when a user is at a high enough fishing level to use ShakeMob and casts his/her fishing rod at a boat.
