### PR TITLE
Fix ore dupe bug with ore blocks on pistons

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -58,11 +58,15 @@ public class BlockListener implements Listener {
     public void onBlockPistonExtend(BlockPistonExtendEvent event) {
         List<Block> blocks = event.getBlocks();
         BlockFace direction = event.getDirection();
+        // Block that would be air after piston is finished
+        Block futureEmptyBlock = event.getBlock().getRelative(direction);
 
         for (Block b : blocks) {
             if (mcMMO.placeStore.isTrue(b)) {
                 b.getRelative(direction).setMetadata("pistonTrack", new FixedMetadataValue(plugin, true));
-                mcMMO.placeStore.setFalse(b);
+                if (b.equals(futureEmptyBlock)) {
+                    mcMMO.placeStore.setFalse(b);
+                }
             }
         }
 


### PR DESCRIPTION
Putting multiple ore blocks on a piston will cause some of the blocks to be set to false in the ChunkletManager. This prevents that by checking that we only clear the flag for the first block near the piston.
