### PR TITLE
Don't activate abilities by opening an Ender Chest

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/BlockChecks.java
+++ b/src/main/java/com/gmail/nossr50/util/BlockChecks.java
@@ -84,6 +84,7 @@ public class BlockChecks {
         case CHEST:
         case DISPENSER:
         case ENCHANTMENT_TABLE:
+        case ENDER_CHEST:
         case FENCE_GATE:
         case FURNACE:
         case IRON_DOOR_BLOCK:


### PR DESCRIPTION
Just an addition to the list of blocks that shouldn't cause this.
