### PR TITLE
Finished adding skill checks for Emerald Ore and Cocoa.

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
+++ b/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
@@ -218,7 +218,12 @@ public class Herbalism {
                 is = new ItemStack(ModChecks.getCustomBlock(block).getItemDrop());
             }
             else {
-                is = new ItemStack(mat);
+                if (mat == Material.COCOA) {
+                    is = new ItemStack(Material.INK_SACK, 1, (short) 3);
+                }
+                else {
+                    is = new ItemStack(mat);
+                }
             }
 
             if (herbLevel > MAX_BONUS_LEVEL || random.nextInt(randomChance) <= herbLevel) {

--- a/src/main/java/com/gmail/nossr50/util/BlockChecks.java
+++ b/src/main/java/com/gmail/nossr50/util/BlockChecks.java
@@ -52,8 +52,8 @@ public class BlockChecks {
         case VINE:
         case WATER_LILY:
         case YELLOW_FLOWER:
-	case COCOA:
-	case EMERALD_ORE:
+        case COCOA:
+        case EMERALD_ORE:
             return true;
 
         default:
@@ -125,7 +125,7 @@ public class BlockChecks {
         case IRON_ORE:
         case LAPIS_ORE:
         case REDSTONE_ORE:
-	case EMERALD_ORE:
+        case EMERALD_ORE:
             return true;
 
         default:
@@ -178,7 +178,7 @@ public class BlockChecks {
         case VINE:
         case WATER_LILY:
         case YELLOW_FLOWER:
-	case COCOA:
+        case COCOA:
             return true;
 
         case CROPS:
@@ -221,7 +221,7 @@ public class BlockChecks {
         case REDSTONE_ORE:
         case SANDSTONE:
         case STONE:
-	case EMERALD_ORE:
+        case EMERALD_ORE:
             return true;
 
         default:


### PR DESCRIPTION
Emerald Ore and Cocoa were added to the config and the checks, but not the the skill use checks in BlockChecks.java. Further, in the skill use check, cocoa looked for an incorrect data value, which prevented players from earning Herbalism experience. This pull request includes fixed spacing and a fix so that the herbalism double drops give cocoa beans (brown dye) rather than a cocoa block.
