### PR TITLE
Don't award double drops to mossified cobblestone

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
+++ b/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
@@ -62,6 +62,8 @@ public class Herbalism {
             }
             else if (Config.getInstance().getHerbalismGreenThumbCobbleToMossy() && type == Material.COBBLESTONE) {
                 block.setType(Material.MOSSY_COBBLESTONE);
+                // Don't award double drops to mossified cobblestone
+                mcMMO.placeStore.setTrue(block);
             }
         }
     }


### PR DESCRIPTION
Cobblestone isn't tracked to prevent double drops, however mossy cobblestone is. Ensure all played created mossy cobblestone does not award double drops.
