### PR TITLE
Fixed checked data values for carrots and potatoes.

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
+++ b/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
@@ -202,14 +202,14 @@ public class Herbalism {
             break;
 
         case CARROT:
-            if (((byte) data) == 0x3) {
+            if (data == CropState.RIPE.getData()) {
                 mat = Material.CARROT;
                 xp = Config.getInstance().getHerbalismXPCarrot();
             }
             break;
 
         case POTATO:
-            if (((byte) data) == 0x3) {
+            if (data == CropState.RIPE.getData()) {
                 mat = Material.POTATO;
                 xp = Config.getInstance().getHerbalismXPPotato();
             }


### PR DESCRIPTION
This fixes the data values I checked for carrots and potatoes, so that you get experience at full growth rather than partially through the first stage of growth. This pull request doesn't blank out a recent update.
