### PR TITLE
Fixed the luckyperk modifier of 'Shake' skill

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/gathering/Fishing.java
+++ b/src/main/java/com/gmail/nossr50/skills/gathering/Fishing.java
@@ -107,7 +107,7 @@ public class Fishing {
             int randomChance = 100;
 
             if (player.hasPermission("mcmmo.perks.lucky.fishing")) {
-                randomChance = (int) (randomChance * 0.75);
+                randomChance = (int) (randomChance * 1.75);
             }
 
             if (random.nextDouble() * randomChance <= treasure.getDropChance()) {


### PR DESCRIPTION
If its \* 0,75 randomChance will never exeed 99, thus disabling certain
drops like Milk Buckets / Skulls.
