### PR TITLE
Small fix for Fishing

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/skills/FishingCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/skills/FishingCommand.java
@@ -23,7 +23,11 @@ public class FishingCommand extends SkillCommand {
     protected void dataCalculations() {
         lootTier = Fishing.getFishingLootTier(profile);
         magicChance = percent.format((float) lootTier / 15);
-        shakeChance = String.valueOf(Fishing.getShakeChance(lootTier));
+        int dropChance = Fishing.getShakeChance(lootTier);
+        if (player.hasPermission("mcmmo.perks.lucky.fishing")) {
+            dropChance = (int) (dropChance * 1.25);
+        }
+        shakeChance = String.valueOf(dropChance);
     }
 
     @Override


### PR DESCRIPTION
Fixes a small issue:
- The lucky perk modifier wasn't displayed when a user types /fishing. @1bf0cd1
