### PR TITLE
Fixes Nuker Dupe

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/Misc.java
+++ b/src/main/java/com/gmail/nossr50/util/Misc.java
@@ -121,7 +121,7 @@ public class Misc {
         FakeBlockBreakEvent breakEvent = new FakeBlockBreakEvent(block, player);
         pluginManger.callEvent(breakEvent);
 
-        if (!damageEvent.isCancelled() || !breakEvent.isCancelled()) {
+        if (!damageEvent.isCancelled() && !breakEvent.isCancelled()) {
             return true;
         }
         else {


### PR DESCRIPTION
Researched this dupe a while back and submitted an issue report when the attempts to fix broke superbreaker and gigadrill entirely. While working on fixes for the server I dev for, I stumbled upon this line that was the root cause of the dupe.

Not all anti-cheat plugins block the block damage event, so it would make since to make sure both are allowed before proceeding.

Have no idea if this was solved earlier. Tried testing before I submitted this, but wasn't going to waste time downloading a client with nuker on it. (Originally tested with Nodus on 1.3.2).
