### PR TITLE
Fixes the broken /skillreset command.

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/general/SkillResetCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/general/SkillResetCommand.java
@@ -27,7 +27,7 @@ public class SkillResetCommand implements CommandExecutor {
         SkillType skillType = null; //simple initialization
 
         //make sure there's only one argument.  output at least some kind of error if not
-        if (args.length != 1 && args[0] != null) {
+        if (args.length == 0 || (args.length != 1 && args[0] != null)) {
             sender.sendMessage(LocaleLoader.getString("Commands.Skill.Invalid"));
             return true;
         }


### PR DESCRIPTION
This pull request fixes the error that occurs when /skillreset is run with no arguments, as mentioned in issue #365.
