### PR TITLE
Don't fire Party Change event if player can't change parties

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/party/PartyCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/party/PartyCommand.java
@@ -137,6 +137,13 @@ public class PartyCommand implements CommandExecutor {
                 }
             }
             else {
+                Party newParty = partyManagerInstance.getParty(args[0]);
+
+                // Check to see if the party exists, and if it does, can the player join it?
+                if (newParty != null && !partyManagerInstance.checkJoinability(player, playerProfile, newParty, null)) {
+                    return true; // End before any event is fired.
+                }
+
                 if (party != null) {
                     McMMOPartyChangeEvent event = new McMMOPartyChangeEvent(player, party.getName(), args[0], EventReason.CHANGED_PARTIES);
                     plugin.getServer().getPluginManager().callEvent(event);
@@ -208,6 +215,13 @@ public class PartyCommand implements CommandExecutor {
                     }
                 }
                 else {
+                    Party newParty = partyManagerInstance.getParty(args[0]);
+
+                    // Check to see if the party exists, and if it does, can the player join it?
+                    if (newParty != null && !partyManagerInstance.checkJoinability(player, playerProfile, newParty, args[1])) {
+                        return true; // End before any event is fired.
+                    }
+
                     McMMOPartyChangeEvent event = new McMMOPartyChangeEvent(player, party.getName(), args[0], EventReason.CHANGED_PARTIES);
                     plugin.getServer().getPluginManager().callEvent(event);
 
@@ -220,6 +234,13 @@ public class PartyCommand implements CommandExecutor {
                 }
             }
             else {
+                Party newParty = partyManagerInstance.getParty(args[0]);
+
+                // Check to see if the party exists, and if it does, can the player join it?
+                if (newParty != null && !partyManagerInstance.checkJoinability(player, playerProfile, newParty, args[1])) {
+                    return true; // End before any event is fired.
+                }
+
                 McMMOPartyChangeEvent event = new McMMOPartyChangeEvent(player, null, args[0], EventReason.JOINED_PARTY);
                 plugin.getServer().getPluginManager().callEvent(event);
 

--- a/src/main/java/com/gmail/nossr50/party/PartyManager.java
+++ b/src/main/java/com/gmail/nossr50/party/PartyManager.java
@@ -241,7 +241,7 @@ public class PartyManager {
      * @param password The password provided by the player
      * @return true if the player can join the party
      */
-    private boolean checkJoinability(Player player, PlayerProfile playerProfile, Party party, String password) {
+    public boolean checkJoinability(Player player, PlayerProfile playerProfile, Party party, String password) {
         //Don't care about passwords if it isn't locked
         if (party.isLocked()) {
             String partyPassword = party.getPassword();


### PR DESCRIPTION
Currently, the mcMMOPlayerChangeEvent is fired before any party changes take place. The event should not be raised if the player is ineligible to change parties. Plugins subscribing to this event, particularly on MONITOR priority, might assume that the party change is going through when it actually hasn't.

This patch tests if a player can join a party before firing the event, and doesn't fire it if the target party has a lock on it and/or the password provided is incorrect.
