### PR TITLE
Alleviating excessive lag.

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/WorldListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/WorldListener.java
@@ -38,6 +38,8 @@ public class WorldListener implements Listener {
         mcMMO.placeStore.unloadWorld(event.getWorld());
     }
 
+    // This gets called every 45 seconds, by default.
+    // The call can and does result in excessive lag, especially on larger servers.
     //@EventHandler
     //public void onWorldSave(WorldSaveEvent event) {
     //    mcMMO.placeStore.saveWorld(event.getWorld());


### PR DESCRIPTION
The placed block storage system was performing a saveWorld() command every time the server saved a world. Due to the nature of the block store, and the fact that most servers perform this action every 45 seconds, this can and will cause excessive lag, especially on larger servers.
