### PR TITLE
Renaming a call to patch new errors.

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/gathering/Fishing.java
+++ b/src/main/java/com/gmail/nossr50/skills/gathering/Fishing.java
@@ -392,9 +392,12 @@ public class Fishing {
             case SQUID:
                 ItemStack item;
                 try {
-                    item = (new MaterialData(Material.INK_SACK, DyeColor.BLACK.getDyeData())).toItemStack(1);
+                    item = (new MaterialData(Material.INK_SACK, DyeColor.BLACK.getData())).toItemStack(1);
                 }
                 catch(Exception e) {
+                    item = (new MaterialData(Material.INK_SACK, (byte) 0)).toItemStack(1);
+                }
+                catch(NoSuchMethodError e) {
                     item = (new MaterialData(Material.INK_SACK, (byte) 0)).toItemStack(1);
                 }
 

--- a/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
+++ b/src/main/java/com/gmail/nossr50/skills/gathering/Herbalism.java
@@ -266,9 +266,12 @@ public class Herbalism {
             else {
                 if (mat == Material.COCOA) {
                     try {
-                        is = new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getDyeData());
+                        is = new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getData());
                     }
                     catch (Exception e) {
+                        is = new ItemStack(Material.INK_SACK, 1, (short) 3);
+                    }
+                    catch (NoSuchMethodError e) {
                         is = new ItemStack(Material.INK_SACK, 1, (short) 3);
                     }
                 }
@@ -423,9 +426,12 @@ public class Herbalism {
             break;
         case COCOA:
             try {
-                hasSeeds = inventory.containsAtLeast(new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getDyeData()), 1);
+                hasSeeds = inventory.containsAtLeast(new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getData()), 1);
             }
             catch(Exception e) {
+                hasSeeds = inventory.containsAtLeast(new ItemStack(Material.INK_SACK, 1, (short) 3), 1);
+            }
+            catch(NoSuchMethodError e) {
                 hasSeeds = inventory.containsAtLeast(new ItemStack(Material.INK_SACK, 1, (short) 3), 1);
             }
             break;
@@ -462,10 +468,14 @@ public class Herbalism {
                 break;
             case COCOA:
                 try {
-                    Misc.dropItems(location, new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getDyeData()), 3);
-                    inventory.removeItem(new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getDyeData()));
+                    Misc.dropItems(location, new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getData()), 3);
+                    inventory.removeItem(new ItemStack(Material.INK_SACK, 1, DyeColor.BROWN.getData()));
                 }
                 catch(Exception e) {
+                    Misc.dropItems(location, new ItemStack(Material.INK_SACK, 1, (short) 3), 3);
+                    inventory.removeItem(new ItemStack(Material.INK_SACK, 1, (short) 3));
+                }
+                catch(NoSuchMethodError e) {
                     Misc.dropItems(location, new ItemStack(Material.INK_SACK, 1, (short) 3), 3);
                     inventory.removeItem(new ItemStack(Material.INK_SACK, 1, (short) 3));
                 }

--- a/src/main/java/com/gmail/nossr50/skills/mining/Mining.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/Mining.java
@@ -244,9 +244,12 @@ public class Mining {
         case LAPIS_ORE:
             if (config.getLapisDoubleDropsEnabled()) {
                 try {
-                    item = (new MaterialData(Material.INK_SACK, DyeColor.BLUE.getDyeData())).toItemStack(1);
+                    item = (new MaterialData(Material.INK_SACK, DyeColor.BLUE.getData())).toItemStack(1);
                 }
                 catch(Exception e) {
+                    item = (new MaterialData(Material.INK_SACK, (byte) 4)).toItemStack(1);
+                }
+                catch(NoSuchMethodError e) {
                     item = (new MaterialData(Material.INK_SACK, (byte) 4)).toItemStack(1);
                 }
 


### PR DESCRIPTION
The bukkit devs renamed a new function and didn't leave a mirror method for plugins already using it. This breaks plugins already using the call.
