### PR TITLE
Making it impossible to attempt to drop air

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/Misc.java
+++ b/src/main/java/com/gmail/nossr50/util/Misc.java
@@ -281,13 +281,15 @@ public class Misc {
      */
     public static void dropItem(Location location, ItemStack itemStack) {
 
+        if(itemStack.getType() == Material.AIR)
+            return;
+
         // We can't get the item until we spawn it and we want to make it cancellable, so we have a custom event.
         McMMOItemSpawnEvent event = new McMMOItemSpawnEvent(location, itemStack);
         mcMMO.p.getServer().getPluginManager().callEvent(event);
 
-        if (event.isCancelled()) {
+        if (event.isCancelled())
             return;
-        }
 
         Item newItem = location.getWorld().dropItemNaturally(location, itemStack);
 


### PR DESCRIPTION
This patches a bug described in issue #503, where it is possible for the plugin to attempt to drop air as an item.
