### PR TITLE
Slightly reducing the processing required to load and unload chunks.

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/WorldListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/WorldListener.java
@@ -2,8 +2,6 @@ package com.gmail.nossr50.listeners;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import org.bukkit.Chunk;
 import org.bukkit.TreeType;
@@ -81,9 +79,9 @@ public class WorldListener implements Listener {
     @EventHandler
     public void onChunkLoad(ChunkLoadEvent event) {
         Chunk chunk = event.getChunk();
-        List<Entity> chunkMobs = new ArrayList(Arrays.asList(chunk.getEntities()));
+        Entity[] chunkMobs = chunk.getEntities();
 
-        if (chunkMobs.isEmpty())
+        if (chunkMobs.length <= 0)
             return;
 
         for(Entity entity : chunkMobs) {

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
@@ -8,7 +8,6 @@ import java.io.ObjectOutputStream;
 import java.lang.Boolean;
 import java.lang.Integer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -189,7 +188,7 @@ public class HashChunkManager implements ChunkManager {
 
         iteratingMobs = true;
 
-        List<Entity> chunkMobs = new ArrayList(Arrays.asList(world.getChunkAt(cx, cz).getEntities()));
+        Entity[] chunkMobs = world.getChunkAt(cx, cz).getEntities();
 
         for (Entity entity : chunkMobs) {
             if(!(entity instanceof LivingEntity) && !(entity instanceof FallingBlock))


### PR DESCRIPTION
This commit slightly reduces the power required to load and unload chunks. It also makes is so that fewer chunks are loaded into mcMMO storage automatically when they are loaded by bukkit, further reducing the processing required.
