### PR TITLE
Fixing a new duping bug. And this time it was NOT our fault!

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -87,7 +87,7 @@ public class BlockListener implements Listener {
     public void onBlockPistonRetract(BlockPistonRetractEvent event) {
         if (event.isSticky()) {
             //Needed only because under some circumstances Minecraft doesn't move the block
-            plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new StickyPistonTracker(event), 0);
+            plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new StickyPistonTracker(event), 2);
         }
     }
 

--- a/src/main/java/com/gmail/nossr50/runnables/StickyPistonTracker.java
+++ b/src/main/java/com/gmail/nossr50/runnables/StickyPistonTracker.java
@@ -15,13 +15,16 @@ public class StickyPistonTracker implements Runnable {
 
     @Override
     public void run() {
-        Block originalBlock = event.getRetractLocation().getBlock();
+        Block newBlock = event.getBlock().getRelative(event.getDirection());
+        Block originalBlock = newBlock.getRelative(event.getDirection());
 
-        if (originalBlock.getType() == Material.AIR && mcMMO.placeStore.isTrue(originalBlock)) {
-            Block newBlock = originalBlock.getRelative(event.getDirection().getOppositeFace());
+        if (originalBlock.getType() != Material.AIR)
+            return;
 
-            mcMMO.placeStore.setFalse(originalBlock);
-            mcMMO.placeStore.setTrue(newBlock);
-        }
+        if (!mcMMO.placeStore.isTrue(originalBlock))
+            return;
+
+        mcMMO.placeStore.setFalse(originalBlock);
+        mcMMO.placeStore.setTrue(newBlock);
     }
 }


### PR DESCRIPTION
A change in vanilla minecraft was to blame. They changed how blocks are affected when pistons retract, and it takes something like three ticks for all of the block changes to finish up now.
