### PR TITLE
McMMOChatEvent: added a field to hold the dispatching plugin

### DIFF
--- a/src/main/java/com/gmail/nossr50/api/ChatAPI.java
+++ b/src/main/java/com/gmail/nossr50/api/ChatAPI.java
@@ -1,5 +1,7 @@
 package com.gmail.nossr50.api;
 
+import org.bukkit.plugin.Plugin;
+
 import com.gmail.nossr50.party.PartyManager;
 import com.gmail.nossr50.util.ChatManager;
 
@@ -11,10 +13,27 @@ public final class ChatAPI {
      * </br>
      * This function is designed for API usage.
      *
+     * @param plugin The plugin sending the message
      * @param sender The name of the sender to display in the chat
      * @param party The name of the party to send to
      * @param message The message to send
      */
+    public static void sendPartyChat(Plugin plugin, String sender, String party, String message) {
+        ChatManager.handlePartyChat(plugin, PartyManager.getParty(party), sender, message);
+    }
+
+    /**
+     * Send a message to all members of a party
+     * </br>
+     * This function is designed for API usage.
+     *
+     * @deprecated Replaced by sendPartyChat(Plugin, String, String, String)
+     *
+     * @param sender The name of the sender to display in the chat
+     * @param party The name of the party to send to
+     * @param message The message to send
+     */
+    @Deprecated
     public static void sendPartyChat(String sender, String party, String message) {
         ChatManager.handlePartyChat(PartyManager.getParty(party), sender, message);
     }
@@ -24,9 +43,25 @@ public final class ChatAPI {
      * </br>
      * This function is designed for API usage.
      *
+     * @param plugin The plugin sending the message
      * @param sender The name of the sender to display in the chat
      * @param message The message to send
      */
+    public static void sendAdminChat(Plugin plugin, String sender, String message) {
+        ChatManager.handleAdminChat(plugin, sender, message);
+    }
+
+    /**
+     * Send a message to administrators
+     * </br>
+     * This function is designed for API usage.
+     *
+     * @deprecated Replaced by sendAdminChat(Plugin, String, String)
+     *
+     * @param sender The name of the sender to display in the chat
+     * @param message The message to send
+     */
+    @Deprecated
     public static void sendAdminChat(String sender, String message) {
         ChatManager.handleAdminChat(sender, message);
     }

--- a/src/main/java/com/gmail/nossr50/events/chat/McMMOAdminChatEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/chat/McMMOAdminChatEvent.java
@@ -1,10 +1,16 @@
 package com.gmail.nossr50.events.chat;
 
+import org.bukkit.plugin.Plugin;
+
 /**
  * Called when a chat is sent to the admin chat channel
  */
 public class McMMOAdminChatEvent extends McMMOChatEvent {
+    public McMMOAdminChatEvent(Plugin plugin, String sender, String message) {
+        super(plugin, sender, message);
+    }
+
     public McMMOAdminChatEvent(String sender, String message) {
-        super(sender, message);
+        this(null, sender, message);
     }
 }

--- a/src/main/java/com/gmail/nossr50/events/chat/McMMOChatEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/chat/McMMOChatEvent.java
@@ -3,15 +3,31 @@ package com.gmail.nossr50.events.chat;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
+
+import com.gmail.nossr50.mcMMO;
 
 public class McMMOChatEvent extends Event implements Cancellable {
     private boolean cancelled;
+    private Plugin plugin;
     private String sender;
     private String message;
 
-    protected McMMOChatEvent(String sender, String message) {
+    protected McMMOChatEvent(Plugin plugin, String sender, String message) {
+        if (plugin == null) {
+            plugin = mcMMO.p;
+        }
+
+        this.plugin = plugin;
         this.sender = sender;
         this.message = message;
+    }
+
+    /**
+     * @return The plugin responsible for this event
+     */
+    public Plugin getPlugin() {
+        return plugin;
     }
 
     /**

--- a/src/main/java/com/gmail/nossr50/events/chat/McMMOPartyChatEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/chat/McMMOPartyChatEvent.java
@@ -1,14 +1,20 @@
 package com.gmail.nossr50.events.chat;
 
+import org.bukkit.plugin.Plugin;
+
 /**
  * Called when a chat is sent to a party channel
  */
 public class McMMOPartyChatEvent extends McMMOChatEvent {
     private String party;
 
-    public McMMOPartyChatEvent(String sender, String party, String message) {
-        super(sender, message);
+    public McMMOPartyChatEvent(Plugin plugin, String sender, String party, String message) {
+        super(plugin, sender, message);
         this.party = party;
+    }
+
+    public McMMOPartyChatEvent(String sender, String party, String message) {
+        this(null, sender, party, message);
     }
 
     /**

--- a/src/main/java/com/gmail/nossr50/util/ChatManager.java
+++ b/src/main/java/com/gmail/nossr50/util/ChatManager.java
@@ -1,6 +1,7 @@
 package com.gmail.nossr50.util;
 
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.events.chat.McMMOAdminChatEvent;
@@ -11,8 +12,8 @@ import com.gmail.nossr50.party.Party;
 public final class ChatManager {
     public ChatManager () {}
 
-    public static void handleAdminChat(String playerName, String message) {
-        McMMOAdminChatEvent chatEvent = new McMMOAdminChatEvent(playerName, message);
+    public static void handleAdminChat(Plugin plugin, String playerName, String message) {
+        McMMOAdminChatEvent chatEvent = new McMMOAdminChatEvent(plugin, playerName, message);
         mcMMO.p.getServer().getPluginManager().callEvent(chatEvent);
 
         if (chatEvent.isCancelled()) {
@@ -30,10 +31,14 @@ public final class ChatManager {
         }
     }
 
-    public static void handlePartyChat(Party party, String playerName, String message) {
+    public static void handleAdminChat(String playerName, String message) {
+        handleAdminChat(null, playerName, message);
+    }
+
+    public static void handlePartyChat(Plugin plugin, Party party, String playerName, String message) {
         String partyName = party.getName();
 
-        McMMOPartyChatEvent chatEvent = new McMMOPartyChatEvent(playerName, partyName, message);
+        McMMOPartyChatEvent chatEvent = new McMMOPartyChatEvent(plugin, playerName, partyName, message);
         mcMMO.p.getServer().getPluginManager().callEvent(chatEvent);
 
         if (chatEvent.isCancelled()) {
@@ -47,5 +52,9 @@ public final class ChatManager {
         for (Player member : party.getOnlineMembers()) {
             member.sendMessage(LocaleLoader.getString("Commands.Party.Chat.Prefix", new Object[] {playerName}) + partyMessage);
         }
+    }
+
+    public static void handlePartyChat(Party party, String playerName, String message) {
+        handlePartyChat(null, party, playerName, message);
     }
 }


### PR DESCRIPTION
Currently, there is no sane way to detect which plugin dispatched
an McMMOChatEvent. This is problematic for plugins using the ChatAPI
while also listening for McMMOChatEvents as it leads to a message loop
being created.

A "simple" solution is to store a reference to the dispatching plugin in
the McMMOChatEvent. This allows for a plugin to determine if it is an
event dispatched by itself, or some other plugin. In addition, this can
allow for better control within third party plugins to determine where
McMMOChatEvents are dispatched from.

This patch is backwards with existing interfaces.
