### PR TITLE
Fixing case where /party chat (on|off) would throw a NullPointerException

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -28,6 +28,7 @@ Version 1.4.03-dev
  = Fixed bug where the 'mcmmo.commands.ptp.world.all' was registered twice
  = Fixed bug where Beast Lore wouldn't work on friendly pets
  = Fixed bug where Deflect was calculated based on the attacker, not the defender. (We really did this time!)
+ = Fixed bug where /party chat (on|off) would not work
  ! Moved the Salvage unlock level from config.yml to advanced.yml
  ! Changed how Chimaera Wings are acquired, you need to craft them now. (By default, use 5 feathers in a shapeless recipe)
  - Removed option to disable Salvage via the config file. This should be handled via permissions instead.

--- a/src/main/java/com/gmail/nossr50/commands/chat/ChatCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/chat/ChatCommand.java
@@ -42,6 +42,8 @@ public abstract class ChatCommand implements CommandExecutor {
                         return false;
                     }
 
+                    mcMMOPlayer = UserManager.getPlayer((Player) sender);
+
                     enableChatMode(sender);
                     return true;
                 }
@@ -50,6 +52,8 @@ public abstract class ChatCommand implements CommandExecutor {
                     if (!(sender instanceof Player)) {
                         return false;
                     }
+
+                    mcMMOPlayer = UserManager.getPlayer((Player) sender);
 
                     disableChatMode(sender);
                     return true;


### PR DESCRIPTION
If a player types <code>/party chat on</code> or <code>/party chat off</code>, the plugin throws a NullPointerException as the mcMMOPlayer variable isn't set for these cases. This PR fixes that issue by treating it the same way that <code>/p (on|off)</code> is treated.

<code>/party chat [message]</code> is otherwise unaffected.
