### PR TITLE
Fix to NPE in the Party API getPartyName method when the target isn't in a party

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -9,7 +9,8 @@ Key:
 
 Version 1.4.04-dev
  = Fixed bug where trying to activate a Chimaera Wing would require one item too much
-  = Fixed bug where Treefeller would try to cut too many leaves and reach the threshold when it shouldn't
+ = Fixed bug where Treefeller would try to cut too many leaves and reach the threshold when it shouldn't
+ = Fixed bug where the API would fail if the name of a player's current party is requested when the player isn't in one.
 
 Version 1.4.03
  + Added option to advanced.yml to determine the # of enchant levels used when buffing Super Breaker & Giga Drill Breaker

--- a/src/main/java/com/gmail/nossr50/api/PartyAPI.java
+++ b/src/main/java/com/gmail/nossr50/api/PartyAPI.java
@@ -19,9 +19,12 @@ public final class PartyAPI {
      * This function is designed for API usage.
      *
      * @param player The player to check the party name of
-     * @return the name of the player's party
+     * @return the name of the player's party, or null if not in a party
      */
     public static String getPartyName(Player player) {
+        if (!inParty(player)) {
+            return null;
+        }
         return UserManager.getPlayer(player).getParty().getName();
     }
 


### PR DESCRIPTION
When using the Party API, if you request the party name of a player that isn't in a party using getPartyName, a NPE is thrown, as the getParty() method on the mcMMO player returns a null, meaning that the getName() method cannot be called.

This patch causes the method to return null instead if the player isn't in a party, rather than throw an NPE.
