### PR TITLE
Added Redstone treasure 800+ Fishing

### DIFF
--- a/src/main/resources/treasures.yml
+++ b/src/main/resources/treasures.yml
@@ -904,6 +904,16 @@ Treasures:
         Max_Level: -1
         Drops_From:
             Fishing: true
+    Redstone:
+        ID: 331
+        Data: 0
+        Amount: 20
+        XP: 200
+        Drop_Chance: 40.0
+        Drop_Level: 800
+        Max_Level: -1
+        Drops_From:
+            Fishing: true
     Diamonds:
         ID: 264
         Data: 0


### PR DESCRIPTION
Added Redstone 20 pieces treasure 800+ for fishing. Drop_Change 40%
Edit drop_chance to fit what you want.
