### PR TITLE
Fix Ininsufficient permissions error in console when running /mcremove

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/database/McremoveCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/database/McremoveCommand.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
 public class McremoveCommand implements TabExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!Permissions.mcremove(sender)) {
+        if (!Permissions.mcremove(sender) && sender instanceof Player) {
             sender.sendMessage(command.getPermissionMessage());
             return true;
         }


### PR DESCRIPTION
Fixes issue: https://github.com/mcMMO-Dev/mcMMO/issues/1016
