### PR TITLE
Double smelting chance calculation while FluxMining success.

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
@@ -65,8 +65,17 @@ public class SmeltingManager extends SkillManager {
 
             Misc.dropItem(location, item);
 
-            if (Permissions.doubleDrops(player, skill) && SkillUtils.activationSuccessful(getSkillLevel(), getActivationChance(), Mining.doubleDropsMaxChance, Mining.doubleDropsMaxLevel)) {
-                Misc.dropItem(location, item);
+            if (Permissions.doubleDrops(player, skill)) {
+                if (SkillUtils.activationSuccessful(getSkillLevel(), getActivationChance(), Mining.doubleDropsMaxChance, Mining.doubleDropsMaxLevel)) {
+                    Misc.dropItem(location, item);
+                    if(SkillUtils.activationSuccessful(getSkillLevel(), getActivationChance(), Smelting.secondSmeltMaxChance, Smelting.secondSmeltMaxLevel)) {
+                        Misc.dropItem(location, item);
+                    }
+                }
+                
+                if (SkillUtils.activationSuccessful(getSkillLevel(), getActivationChance(), Smelting.secondSmeltMaxChance, Smelting.secondSmeltMaxLevel)) {
+                    Misc.dropItem(location, item);
+                }
             }
 
             blockState.setRawData((byte) 0x0);


### PR DESCRIPTION
Double smelting chance calculation while FluxMining success.
Breaking ore -> additional 1 ore (from double drop) -> additional 2 ores (from double smelting chance [one from normal drop second from double drop] )
