### PR TITLE
[d-DRr] Don't calculate diminshed returns when subtracting XP

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/SelfListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/SelfListener.java
@@ -39,7 +39,12 @@ public class SelfListener implements Listener {
         int threshold = Config.getInstance().getExperienceDeminishedReturnsThreshold();
 
         if (threshold <= 0) {
-            return;
+            return; // Dim. returns is turned off
+        }
+
+        final int rawXp = event.getRawXpGained();
+        if (rawXp < 0) {
+            return; // Don't calculate for XP subtraction
         }
 
         Player player = event.getPlayer();
@@ -58,7 +63,7 @@ public class SelfListener implements Listener {
 //            System.out.println(difference * 100 + "% over the threshold!");
 //            System.out.println("Previous: " + event.getRawXpGained());
 //            System.out.println("Adjusted XP " + (event.getRawXpGained() - (event.getRawXpGained() * difference)));
-            float newValue = event.getRawXpGained() - (event.getRawXpGained() * difference);
+            float newValue = rawXp - (rawXp * difference);
 
             if (newValue > 0) {
                 event.setRawXpGained(newValue);


### PR DESCRIPTION
#### BRANCH: dev-diminishedreturns-rolling

Any penalty XP that goes through the event after diminished returns has activated would be cancelled by this listener. This bails out early if the event is subtracting.

I used final because, well, to be explicit that the XP from the event shouldn't change until the end.
