### PR TITLE
Implement checkStructure() in FlatfileDatabaseManager, improve purge

### DIFF
--- a/src/main/java/com/gmail/nossr50/database/FlatfileDatabaseManager.java
+++ b/src/main/java/com/gmail/nossr50/database/FlatfileDatabaseManager.java
@@ -119,13 +119,16 @@ public final class FlatfileDatabaseManager implements DatabaseManager {
                 while ((line = in.readLine()) != null) {
                     String[] character = line.split(":");
                     String name = character[0];
-                    long lastPlayed;
+                    long lastPlayed = 0;
                     boolean rewrite = false;
                     try {
                         lastPlayed = Long.parseLong(character[37]) * Misc.TIME_CONVERSION_FACTOR;
                     } catch (NumberFormatException e) {
+                    }
+                    if (lastPlayed == 0) {
+                        OfflinePlayer player = Bukkit.getOfflinePlayer(name);
+                        lastPlayed = player.getLastPlayed();
                         rewrite = true;
-                        lastPlayed = System.currentTimeMillis();
                     }
 
                     if (currentTime - lastPlayed > PURGE_TIME) {
@@ -624,14 +627,9 @@ public final class FlatfileDatabaseManager implements DatabaseManager {
                                 // Making old-purge work with flatfile
                                 // Version 1.4.00-dev
                                 // commmit 3f6c07ba6aaf44e388cc3b882cac3d8f51d0ac28
-                                String playerName = character[0];
-                                // Try to get a accurate time, instead of "right now"
-                                OfflinePlayer player = Bukkit.getOfflinePlayer(playerName);
-                                long time = player.getLastPlayed();
-                                if (time == 0) {
-                                    time = System.currentTimeMillis();
-                                }
-                                newLine.append(time / Misc.TIME_CONVERSION_FACTOR).append(":");
+
+                                // XXX Cannot create an OfflinePlayer at startup, use 0 and fix in purge
+                                newLine.append("0").append(":");
                                 announce = true; // TODO move this down
                                 if (oldVersion == null) oldVersion = "1.4.00";
                             }


### PR DESCRIPTION
Summary of changes:
- Old algorithm for flatfile purge is restored, with `OfflinePlayer` being used as an added backup method if the number is unparsable.
- If that backup method is triggered, the line will be rewritten in the database so that we don't need to use OfflinePlayer again next time.
- The flatfile `checkStructure()` TODO section is implemented. First, a colon is put on the end if there isn't one there already (something only possible from someone manually editing the file). If the length is greater than our maximum addressed item, it is passed over, otherwise, repair begins.
  - A chained series of if's begin. Each one is an entry point, and if one is satisfied, all of its successors are satisfied too. The first one entered sets `oldVersion`, which will be output in the log, unless output is not set to true, which is currently done for only the most recent change.
  - Each if appends some text to the end of the line representing a default value for the new field, always ending in a colon.
  - A message is output to the server log (unless it was only a suppressed-message change) and the new line is written to the database.
