### PR TITLE
Cancel Mob Health Display Updater if entity is not valid. Fixes #1396

### DIFF
--- a/src/main/java/com/gmail/nossr50/runnables/MobHealthDisplayUpdaterTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/MobHealthDisplayUpdaterTask.java
@@ -15,6 +15,8 @@ public class MobHealthDisplayUpdaterTask extends BukkitRunnable {
             this.target = target;
             this.oldName = target.getMetadata(mcMMO.customNameKey).get(0).asString();
             this.oldNameVisible = target.getMetadata(mcMMO.customVisibleKey).get(0).asBoolean();
+        }else{
+            this.cancel();
         }
     }
 


### PR DESCRIPTION
MobHealthDisplayTask is run regardless of whether an entity is valid. However, if the entity is not valid, when the task is called it will create a NPE as target was not set. This aims to fix that.

Fixes #1396
