### PR TITLE
/mcconvert: Fix mismatched type in list.remove() call

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/database/McconvertCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/database/McconvertCommand.java
@@ -45,7 +45,7 @@ public class McconvertCommand implements TabExecutor {
         }
 
         // Custom stuff
-        databaseTypes.remove(DatabaseType.CUSTOM);
+        databaseTypes.remove(DatabaseType.CUSTOM.toString());
 
         if (mcMMO.getDatabaseManager().getDatabaseType() == DatabaseType.CUSTOM) {
             databaseTypes.add(DatabaseManagerFactory.getCustomDatabaseManagerClass().getName());


### PR DESCRIPTION
The databaseTypes collection is a List<String>, so attempting to remove a DatabaseType object will have no effect.
