### PR TITLE
Get all logs in Tree Feller, and optimize performance

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
@@ -1,6 +1,7 @@
 package com.gmail.nossr50.skills.woodcutting;
 
 import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -25,8 +26,6 @@ import com.gmail.nossr50.util.skills.CombatUtils;
 import com.gmail.nossr50.util.skills.SkillUtils;
 
 public class WoodcuttingManager extends SkillManager {
-    protected static boolean treeFellerReachedThreshold = false;
-
     public WoodcuttingManager(McMMOPlayer mcMMOPlayer) {
         super(mcMMOPlayer, SkillType.WOODCUTTING);
     }
@@ -74,11 +73,13 @@ public class WoodcuttingManager extends SkillManager {
         Player player = getPlayer();
         LinkedHashSet<BlockState> treeFellerBlocks = new LinkedHashSet<BlockState>();
 
+        Woodcutting.treeFellerReachedThreshold = false;
+
         Woodcutting.processTree(blockState, treeFellerBlocks);
 
         // If the player is trying to break too many blocks
-        if (treeFellerReachedThreshold) {
-            treeFellerReachedThreshold = false;
+        if (Woodcutting.treeFellerReachedThreshold) {
+            Woodcutting.treeFellerReachedThreshold = false;
 
             player.sendMessage(LocaleLoader.getString("Woodcutting.Skills.TreeFellerThreshold"));
             return;
@@ -98,7 +99,7 @@ public class WoodcuttingManager extends SkillManager {
         }
 
         dropBlocks(treeFellerBlocks);
-        treeFellerReachedThreshold = false; // Reset the value after we're done with Tree Feller each time.
+        Woodcutting.treeFellerReachedThreshold = false; // Reset the value after we're done with Tree Feller each time.
     }
 
     /**
@@ -106,7 +107,7 @@ public class WoodcuttingManager extends SkillManager {
      *
      * @param treeFellerBlocks List of blocks to be dropped
      */
-    private void dropBlocks(LinkedHashSet<BlockState> treeFellerBlocks) {
+    private void dropBlocks(Set<BlockState> treeFellerBlocks) {
         Player player = getPlayer();
         int xp = 0;
 

--- a/src/main/java/com/gmail/nossr50/util/BlockUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/BlockUtils.java
@@ -200,16 +200,6 @@ public final class BlockUtils {
     }
 
     /**
-     * Determine if a given block should be affected by Tree Feller
-     *
-     * @param blockState The {@link BlockState} of the block to check
-     * @return true if the block should affected by Tree Feller, false otherwise
-     */
-    public static boolean affectedByTreeFeller(BlockState blockState) {
-        return isLog(blockState) || isLeaves(blockState);
-    }
-
-    /**
      * Check if a given block is a log
      *
      * @param blockState The {@link BlockState} of the block to check


### PR DESCRIPTION
Tree Feller has been shown, both anecdotally and with timings, to put a strain on the server, and therefore is worthy of the effort of optimization.
Prior to this change, on jungle trees, Tree Feller would take around 20-40 milliseconds to process a Jungle Tree after the JIT kicked in, and around 15-25 milliseconds for a normal tree.

Additionally, logs would be left up in the air for jungle trees.

After this change, Tree Feller takes 2-5 milliseconds on normal trees, and 10-15 milliseconds on jungle trees, and no logs are left up in the air.
## Breakdown

First, we use a `LinkedHashSet` for `treeFellerBlocks` because we're checking contains much more than we add, and a consistent iteration order is still expected.

An `int[][]` of X/Z directions is created on static class initialization, representing a cylinder with radius of about 2 - the `(0,0)` center and all `(±2, ±2)` corners are omitted.

`handleBlock()` is changed to return a boolean, which is used for the sole purpose of switching between these two behaviors:
1. **There is another log** above this log _(TRUNK)_  
      Only the flat cylinder in `directions` is searched.
2. **There is not another log** above this log _(BRANCH AND TOP)_  
      The cylinder in `directions` is extended up and down by 1 block in the Y-axis, and the block below this log is checked as well.

Due to the fact that `directions` will catch all blocks on a red mushroom, the special method for it is eliminated.
