### PR TITLE
add alias to mcscoreboard

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -107,6 +107,7 @@ commands:
         aliases: [mcmobhealth]
         description: Change the style of the mob healthbar
     mcscoreboard:
+        aliases: [mcsb]
         description: Manage your mcMMO Scoreboard
     kraken:
         aliases: [mckraken]


### PR DESCRIPTION
"/mcscoreboard keep" is quite a bit to type after you type /stats, it's something that some people can't do in time, because not everyone is a fast typer. /mcsb should help.
