### PR TITLE
Update extrabiomesxl.blocks.yml

### DIFF
--- a/extras/mods/extrabiomesxl.blocks.yml
+++ b/extras/mods/extrabiomesxl.blocks.yml
@@ -86,6 +86,10 @@ Woodcutting:
         XP_Gain: 100
         Double_Drops_Enabled: true
         Is_Log: true
+    X2211|0:
+        XP_Gain: 100
+        Double_Drops_Enabled: true
+        Is_Log: true
     X2212|0:
         XP_Gain: 100
         Double_Drops_Enabled: true
@@ -99,6 +103,10 @@ Woodcutting:
         XP_Gain: 80
         Double_Drops_Enabled: true
         Is_Log: true
+    X2211|1:
+        XP_Gain: 100
+        Double_Drops_Enabled: true
+        Is_Log: true
     X2212|1:
         XP_Gain: 80
         Double_Drops_Enabled: true
@@ -110,6 +118,10 @@ Woodcutting:
     # Oak Quarters
     X2209|2:
         XP_Gain: 70
+        Double_Drops_Enabled: true
+        Is_Log: true
+    X2211|2:
+        XP_Gain: 100
         Double_Drops_Enabled: true
         Is_Log: true
     X2212|2:


### PR DESCRIPTION
Config file was missing a section of 2x2 trees, called Quarter logs.
Missing logs were added to appropriate divided sections.
