### PR TITLE
Remove redundant maxReconnects database connection property

### DIFF
--- a/src/main/java/com/gmail/nossr50/database/SQLDatabaseManager.java
+++ b/src/main/java/com/gmail/nossr50/database/SQLDatabaseManager.java
@@ -618,7 +618,6 @@ public final class SQLDatabaseManager implements DatabaseManager {
             connectionProperties.put("user", Config.getInstance().getMySQLUserName());
             connectionProperties.put("password", Config.getInstance().getMySQLUserPassword());
             connectionProperties.put("autoReconnect", "false");
-            connectionProperties.put("maxReconnects", "0");
             connection = DriverManager.getConnection(connectionString, connectionProperties);
 
             mcMMO.p.getLogger().info("Connection to MySQL was a success!");


### PR DESCRIPTION
'maxReconnects' only applies if 'autoReconnect' is set to true and setting it to 0 throws an SQLException as 0 is not a valid value in more recent versions of MySQL Connector/J, specifically:

```
[21:04:41 INFO]: [mcMMO] Attempting connection to MySQL...
[21:04:41 ERROR]: [mcMMO] Connection to MySQL failed!
[21:04:41 ERROR]: [mcMMO] SQLException: The connection property 'maxReconnects' only accepts integer values in the range of 1 - 2147483647, the value '0' exceeds this range.
[21:04:41 ERROR]: [mcMMO] SQLState: S1009
[21:04:41 ERROR]: [mcMMO] VendorError: 0
```
