### PR TITLE
Added block metadata support for storing 'unnatural' blocks.

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -21,6 +21,7 @@ import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
 
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.config.Config;
@@ -126,7 +127,9 @@ public class BlockListener implements Listener {
         /* Check if the blocks placed should be monitored so they do not give out XP in the future */
         if (BlockUtils.shouldBeWatched(blockState)) {
             mcMMO.getPlaceStore().setTrue(blockState);
+        	blockState.setMetadata("unnatural", new FixedMetadataValue(plugin, true));
         }
+        
 
         McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
 

--- a/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
@@ -27,6 +27,9 @@ public class ExcavationManager extends SkillManager {
      * @param blockState The {@link BlockState} to check ability activation for
      */
     public void excavationBlockCheck(BlockState blockState) {
+    	if (blockState.getMetadata("unnatural").size() != 0)
+    		return;
+    	
         int xp = Excavation.getBlockXP(blockState);
 
         if (Permissions.secondaryAbilityEnabled(getPlayer(), SecondaryAbility.EXCAVATION_TREASURE_HUNTER)) {

--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -56,6 +56,9 @@ public class MiningManager extends SkillManager {
      * @param blockState The {@link BlockState} to check ability activation for
      */
     public void miningBlockCheck(BlockState blockState) {
+    	if (blockState.getMetadata("unnatural").size() != 0)
+    		return;
+    	
         Player player = getPlayer();
 
         applyXpGain(Mining.getBlockXp(blockState), XPGainReason.PVE);

--- a/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
@@ -51,6 +51,9 @@ public class WoodcuttingManager extends SkillManager {
      * @param blockState Block being broken
      */
     public void woodcuttingBlockCheck(BlockState blockState) {
+    	if (blockState.getMetadata("unnatural").size() != 0)
+    		return;
+    	
         int xp = Woodcutting.getExperienceFromLog(blockState, ExperienceGainMethod.DEFAULT);
 
         switch (blockState.getType()) {


### PR DESCRIPTION
After seeing a player use an exploit on my server, I decided to create a fix for it. Blocks moved by stick pistions are not treat as 'unnatural' and still give experience and a chance for double drops and loot.

This adds a metadata value called unnatural and if set to any value when BlockCheck is called, returns straight away.
