### PR TITLE
Added block metadata support for storing 'unnatural' blocks.

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -127,7 +127,7 @@ public class BlockListener implements Listener {
         /* Check if the blocks placed should be monitored so they do not give out XP in the future */
         if (BlockUtils.shouldBeWatched(blockState)) {
             mcMMO.getPlaceStore().setTrue(blockState);
-        	blockState.setMetadata("unnatural", new FixedMetadataValue(plugin, true));
+            blockState.setMetadata("mmo_bin", new FixedMetadataValue(plugin, true));
         }
         
 

--- a/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import org.bukkit.Location;
 import org.bukkit.block.BlockState;
+import org.bukkit.metadata.MetadataValue;
 
+import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.config.Config;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.SecondaryAbility;
@@ -27,8 +29,11 @@ public class ExcavationManager extends SkillManager {
      * @param blockState The {@link BlockState} to check ability activation for
      */
     public void excavationBlockCheck(BlockState blockState) {
-    	if (blockState.getMetadata("unnatural").size() != 0)
-    		return;
+    	for (MetadataValue value : blockState.getMetadata("unnatural"))
+    	{
+    		if (value.getOwningPlugin().equals(mcMMO.p) && value.asBoolean()==true)
+	    		return;
+    	}
     	
         int xp = Excavation.getBlockXP(blockState);
 

--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -9,6 +9,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
+import org.bukkit.metadata.MetadataValue;
 
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.config.Config;
@@ -56,8 +57,11 @@ public class MiningManager extends SkillManager {
      * @param blockState The {@link BlockState} to check ability activation for
      */
     public void miningBlockCheck(BlockState blockState) {
-    	if (blockState.getMetadata("unnatural").size() != 0)
-    		return;
+    	for (MetadataValue value : blockState.getMetadata("mmo_bin"))
+    	{
+    		if (value.getOwningPlugin().equals(mcMMO.p) && value.asBoolean()==true)
+	    		return;
+    	}
     	
         Player player = getPlayer();
 

--- a/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
@@ -10,6 +10,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Tree;
+import org.bukkit.metadata.MetadataValue;
 
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.datatypes.mods.CustomBlock;
@@ -51,8 +52,11 @@ public class WoodcuttingManager extends SkillManager {
      * @param blockState Block being broken
      */
     public void woodcuttingBlockCheck(BlockState blockState) {
-    	if (blockState.getMetadata("unnatural").size() != 0)
-    		return;
+    	for (MetadataValue value : blockState.getMetadata("unnatural"))
+    	{
+    		if (value.getOwningPlugin().equals(mcMMO.p) && value.asBoolean()==true)
+	    		return;
+    	}
     	
         int xp = Woodcutting.getExperienceFromLog(blockState, ExperienceGainMethod.DEFAULT);
 


### PR DESCRIPTION
After seeing a player use an exploit on my server, I decided to create a fix for it. Blocks moved by stick pistons are not treat as 'unnatural' and still give experience and a chance for double drops and loot.

This adds a metadata value called mc_bin and if set to any value when BlockCheck is called, returns straight away.

Previous pull request didn't give experience on natural blocks, this has been fixed.
