### PR TITLE
Acrobatics: cap same-location fall counter for XP gain

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/acrobatics/AcrobaticsManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/acrobatics/AcrobaticsManager.java
@@ -148,7 +148,13 @@ public class AcrobaticsManager extends SkillManager {
         fallTries = sameLocation ? fallTries + 1 : Math.max(fallTries - 1, 0);
         lastFallLocation = fallLocation;
 
-        return fallTries > Config.getInstance().getAcrobaticsAFKMaxTries();
+        int maxTries = Config.getInstance().getAcrobaticsAFKMaxTries();
+
+        if (fallTries <= maxTries) {
+            return false;
+        }
+        fallTries = maxTries;
+        return true;
     }
 
     private boolean isFatal(double damage) {


### PR DESCRIPTION
It used to increase boundlessly, thus preventing players from gaining XP for a while even after moving to another place.
