### PR TITLE
Resolve duplication Bug #2419

### DIFF
--- a/src/main/java/com/gmail/nossr50/runnables/StickyPistonTrackerTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/StickyPistonTrackerTask.java
@@ -31,6 +31,6 @@ public class StickyPistonTrackerTask extends BukkitRunnable {
 
         // The sticky piston actually pulled the block so move the PlaceStore data
         mcMMO.getPlaceStore().setFalse(movedBlock);
-        mcMMO.getPlaceStore().setTrue(block.getRelative(direction));
+        mcMMO.getPlaceStore().setTrue(movedBlock.getRelative(direction));
     }
 }


### PR DESCRIPTION
With the current file, upon retracting the piston, the current block position gets unset and the block behind the piston is set to true. This causes a bug/ opportunity to duplicate.

With my PR, this issue get's resolved and the correct block (the block which is retracted) is being set to true.

https://github.com/mcMMO-Dev/mcMMO/issues/2419