### PR TITLE
Update EventUtils.java

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/EventUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/EventUtils.java
@@ -293,7 +293,9 @@ public class EventUtils {
      */
     public static boolean shouldProcessEvent(Block block, boolean isExtendEvent) {
         String pistonAction = isExtendEvent ? "EXTEND" : "RETRACT";
-        String lastAction = block.hasMetadata(mcMMO.pistonDataKey) ? block.getMetadata(mcMMO.pistonDataKey).get(0).asString() : "";
+        try {
+            String lastAction = block.hasMetadata(mcMMO.pistonDataKey) ? block.getMetadata(mcMMO.pistonDataKey).get(0).asString() : "";
+        } catch(IndexOutOfBoundsException e) {}
 
         if (!lastAction.equals(pistonAction)) {
             block.setMetadata(mcMMO.pistonDataKey, new FixedMetadataValue(mcMMO.p, pistonAction));


### PR DESCRIPTION
Fixed IndexOutOfBoundsException that will throws when a Player use Pistons in automatic Pumpkin farms.

[18:51:41 ERROR]: Could not pass event BlockPistonRetractEvent to mcMMO v1.5.01-b8
org.bukkit.event.EventException
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:305) ~[spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:502) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:487) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.BlockPiston.e(BlockPiston.java:72) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.BlockPiston.doPhysics(BlockPiston.java:44) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.World.d(World.java:583) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.World.applyPhysics(World.java:532) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.World.update(World.java:496) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.World.notifyAndUpdatePhysics(World.java:450) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.World.setTypeAndData(World.java:426) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.BlockPiston.a(BlockPiston.java:148) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.WorldServer.a(WorldServer.java:1078) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.WorldServer.ak(WorldServer.java:1064) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.WorldServer.doTick(WorldServer.java:259) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.MinecraftServer.z(MinecraftServer.java:741) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.DedicatedServer.z(DedicatedServer.java:316) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.MinecraftServer.y(MinecraftServer.java:623) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at net.minecraft.server.v1_8_R1.MinecraftServer.run(MinecraftServer.java:526) [spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_31]
Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.rangeCheck(ArrayList.java:653) ~[?:1.8.0_31]
        at java.util.ArrayList.get(ArrayList.java:429) ~[?:1.8.0_31]
        at java.util.Collections$UnmodifiableList.get(Collections.java:1309) ~[?:1.8.0_31]
        at com.gmail.nossr50.util.EventUtils.shouldProcessEvent(EventUtils.java:296) ~[?:?]
        at com.gmail.nossr50.listeners.BlockListener.onBlockPistonRetract(BlockListener.java:97) ~[?:?]
        at sun.reflect.GeneratedMethodAccessor1102.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_31]
        at java.lang.reflect.Method.invoke(Method.java:483) ~[?:1.8.0_31]
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:301) ~[spigot_server.jar:git-Spigot-47b1dff-f233e7d]
        ... 19 more