### PR TITLE
Escape apostrophes in localised strings

### DIFF
--- a/src/main/java/com/gmail/nossr50/locale/LocaleLoader.java
+++ b/src/main/java/com/gmail/nossr50/locale/LocaleLoader.java
@@ -57,7 +57,7 @@ public final class LocaleLoader {
     public static String formatString(String string, Object... messageArguments) {
         if (messageArguments != null) {
             MessageFormat formatter = new MessageFormat("");
-            formatter.applyPattern(string);
+            formatter.applyPattern(string.replace("'", "''"));
             string = formatter.format(messageArguments);
         }
 


### PR DESCRIPTION
> The java.text.MessageFormat class uses the apostrophe (\u0027) as an escape character. Consequently, you need to write two consecutive apostrophes in your translation if you wish to display a single apostrophe.

User who reported the issue seems to think this fixes his problem: https://korobi.io/esper/drtshock/logs/2015/04/25#L768