### PR TITLE
Fix drops for stone types added in 1.8

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/mining/Mining.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/Mining.java
@@ -64,7 +64,12 @@ public class Mining {
             case QUARTZ_ORE:
             case REDSTONE_ORE:
             case STONE:
-                Misc.dropItem(blockState.getLocation(), new ItemStack(blockType));
+                if (blockState.getData().getData() == 0x0) {
+                    Misc.dropItem(blockState.getLocation(), new ItemStack(blockType));
+                }
+                else {
+                    handleMiningDrops(blockState);
+                }
                 return;
 
             default:


### PR DESCRIPTION
Fix: Makes new stone types double drop the correct stone when mined with silk touch.
Fixes #2466 