### PR TITLE
Fix for custom potions being missed in potion stage calculation. #2386

### DIFF
--- a/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/PotionStage.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/PotionStage.java
@@ -1,6 +1,9 @@
 package com.gmail.nossr50.datatypes.skills.alchemy;
 
+import java.util.List;
+
 import org.bukkit.potion.Potion;
+import org.bukkit.potion.PotionEffect;
 
 public enum PotionStage {
     FIVE(5),
@@ -44,17 +47,27 @@ public enum PotionStage {
 
     public static PotionStage getPotionStage(AlchemyPotion alchemyPotion) {
         Potion potion = alchemyPotion.toPotion(1);
+        List<PotionEffect> effects = alchemyPotion.getEffects();
 
         int stage = 1;
 
         // Check if potion isn't awkward or mundane
-        if (potion.getType() != null) {
+        // Check for custom effects added by mcMMO
+        if (potion.getType() != null || !effects.isEmpty()) {
             stage++;
         }
 
         // Check if potion has a glowstone dust amplifier
+        // Else check if the potion has a custom effect with an amplifier added by mcMMO 
         if (potion.getLevel() > 1) {
             stage++;
+        }else if(!effects.isEmpty()){
+            for (PotionEffect effect : effects){
+                if(effect.getAmplifier() > 0){
+                    stage++;
+                    break;
+                }
+            }
         }
 
         // Check if potion has a redstone dust amplifier


### PR DESCRIPTION
This bug only became apparent when the scaled XP system was implemented.  I found it when the server I play on updated to the latest version, as well I found ticket #2386 to confirm my findings. 

The custom mcMMO potions have no vanilla type, and subsequently no level.  It is all handled on the meta potion level.  ie. Every change from awkward to haste would return an equal value causing Potion Stage to be set to 5.  Same as when going to Haste II for Haste I.  

Changes: 

I have added checks to see if there are any effects, implying that it's at least stage 2.  And later, check every effect to see if there is an amplified one.  

Now you can technically get more than one effect on a potion, as to not mess up the counter, the loop breaks after finding at least one.