### PR TITLE
Check for Unbreakable tag before handling durability changes

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.ItemMeta.Spigot;
 import org.bukkit.material.MaterialData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;

--- a/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
@@ -177,7 +177,9 @@ public class SkillUtils {
     }
 
     public static void handleDurabilityChange(ItemStack itemStack, int durabilityModifier) {
-        handleDurabilityChange(itemStack, durabilityModifier, 1.0);
+        if (!itemStack.isUnbreakable()) {
+            handleDurabilityChange(itemStack, durabilityModifier, 1.0);
+        }
     }
 
     /**


### PR DESCRIPTION
Unsure if this is the best way to stop durability loss when an item is Unbreakable, or if this should be checked before each call to handleDurabilityChange.