### PR TITLE
Fixed NPE when skill is not in config

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/Config.java
+++ b/src/main/java/com/gmail/nossr50/config/Config.java
@@ -451,6 +451,8 @@ public class Config extends AutoUpdateConfigLoader {
     public boolean getDoubleDropsDisabled(SkillType skill) {
         String skillName = StringUtils.getCapitalized(skill.toString());
         ConfigurationSection section = config.getConfigurationSection("Double_Drops." + skillName);
+        if (section == null)
+            return false;
         Set<String> keys = section.getKeys(false);
         boolean disabled = true;
 


### PR DESCRIPTION
When a skill is not configured this would throw an NPE as the section is not found.

Found while trying to get information from an McMMOLevelUp event