### PR TITLE
Fix issue #2464 and #2715

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -165,7 +165,8 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
      */
 
     /* Curve settings */
-    public FormulaType getFormulaType() { return FormulaType.getFormulaType(config.getString("Experience_Formula.Curve")); }
+    public FormulaType getFormulaType() { return FormulaType.getFormulaType(config.getString("Experience_Formula.Curve.DEFAULT")); }
+    public FormulaType getFormulaType(SkillType skill) { return FormulaType.getFormulaType(config.getString("Experience_Formula.Curve." + StringUtils.getCapitalized(skill.toString()))); }
     public boolean getCumulativeCurveEnabled() { return config.getBoolean("Experience_Formula.Cumulative_Curve", false); }
 
     /* Curve values */

--- a/src/main/java/com/gmail/nossr50/datatypes/player/PlayerProfile.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/player/PlayerProfile.java
@@ -345,7 +345,7 @@ public class PlayerProfile {
      */
     public int getXpToLevel(SkillType skillType) {
         int level = (ExperienceConfig.getInstance().getCumulativeCurveEnabled()) ? UserManager.getPlayer(playerName).getPowerLevel() : skills.get(skillType);
-        FormulaType formulaType = ExperienceConfig.getInstance().getFormulaType();
+        FormulaType formulaType = ExperienceConfig.getInstance().getFormulaType(skillType);
 
         return mcMMO.getFormulaManager().getCachedXpToLevel(level, formulaType);
     }

--- a/src/main/java/com/gmail/nossr50/util/experience/FormulaManager.java
+++ b/src/main/java/com/gmail/nossr50/util/experience/FormulaManager.java
@@ -124,7 +124,7 @@ public class FormulaManager {
 
             case EXPONENTIAL:
                 if (!experienceNeededExponential.containsKey(level)) {
-                    experience = (int) Math.floor(multiplier * Math.pow(level, exponent) + base);
+                    experience = (int) Math.floor(multiplier * Math.pow(exponent, level) * base);
                     experienceNeededExponential.put(level, experience);
                 }
 

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -35,8 +35,8 @@ Experience_Formula:
         base: 1020
         multiplier: 20
     Exponential_Values:
-        multiplier: 0.1
-        exponent: 1.80
+        multiplier: 1
+        exponent: 1.05
         base: 2000
 
     # Cumulative experience curves will use a players power level instead of their skill level,

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -14,7 +14,21 @@ Experience_Formula:
     # If an invalid value is entered, this will reset to the default setting, which is LINEAR
     # LINEAR:      base + (level * multiplier)
     # EXPONENTIAL: multiplier * level ^ exponent + base
-    Curve: LINEAR
+    Curve:
+        Swords: LINEAR
+        Taming: EXPONENTIAL
+        Acrobatics: LINEAR
+        Excavation: EXPONENTIAL
+        Herbalism: LINEAR
+        Unarmed: EXPONENTIAL
+        Woodcutting: LINEAR
+        Mining: EXPONENTIAL
+        Archery: LINEAR
+        Axes: EXPONENTIAL
+        Repair: LINEAR
+        Fishing: EXPONENTIAL
+        Alchemy: LINEAR
+        DEFAULT: LINEAR
 
     # If invalid values are entered mcMMO will not start and print an error in the console
     Linear_Values:

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -16,17 +16,17 @@ Experience_Formula:
     # EXPONENTIAL: multiplier * level ^ exponent + base
     Curve:
         Swords: LINEAR
-        Taming: EXPONENTIAL
+        Taming: LINEAR
         Acrobatics: LINEAR
-        Excavation: EXPONENTIAL
+        Excavation: LINEAR
         Herbalism: LINEAR
-        Unarmed: EXPONENTIAL
+        Unarmed: LINEAR
         Woodcutting: LINEAR
-        Mining: EXPONENTIAL
+        Mining: LINEAR
         Archery: LINEAR
-        Axes: EXPONENTIAL
+        Axes: LINEAR
         Repair: LINEAR
-        Fishing: EXPONENTIAL
+        Fishing: LINEAR
         Alchemy: LINEAR
         DEFAULT: LINEAR
 


### PR DESCRIPTION
Fix issues: mcMMO-Dev/mcMMO#2464 and mcMMO-Dev/mcMMO#2715.

Issue #2715 is well explained in the issue section. 
As for issue #2464, user could configure experience curve per skill after this fix goes in and we have used the key DEFAULT for the other non-skill experience curve such as party. 
