### PR TITLE
Fix infinite GreenThumb & ShroomThumb usage bug

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
@@ -50,13 +50,21 @@ public class HerbalismManager extends SkillManager {
 
     public boolean canGreenThumbBlock(BlockState blockState) {
         Player player = getPlayer();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        
+        if (item.getAmount() <= 0)
+            return false;
 
-        return player.getItemInHand().getType() == Material.SEEDS && BlockUtils.canMakeMossy(blockState) && Permissions.greenThumbBlock(player, blockState.getType());
+        return item.getType() == Material.SEEDS && BlockUtils.canMakeMossy(blockState) && Permissions.greenThumbBlock(player, blockState.getType());
     }
 
     public boolean canUseShroomThumb(BlockState blockState) {
         Player player = getPlayer();
-        Material itemType = player.getItemInHand().getType();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        Material itemType = item.getType();
+        
+        if (item.getAmount() <= 0)
+            return false;
 
         return (itemType == Material.RED_MUSHROOM || itemType == Material.BROWN_MUSHROOM) && BlockUtils.canMakeShroomy(blockState) && Permissions.secondaryAbilityEnabled(player, SecondaryAbility.SHROOM_THUMB);
     }


### PR DESCRIPTION
Green Thumb and Shroom Thumb don't check for 0 or lower itemstacks, allowing players to continuously green or shroom thumb well into negative itemstack amounts provided they don't let go of the mouse button