### PR TITLE
Require sneaking to activate abilities...

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -528,7 +528,7 @@ public class PlayerListener implements Listener {
 
         switch (event.getAction()) {
             case RIGHT_CLICK_BLOCK:
-                if(player.getInventory().getItemInOffHand().getType() != Material.AIR && !player.isSneaking()) {
+                if(player.getInventory().getItemInOffHand().getType() != Material.AIR && !player.isInsideVehicle()  && !player.isSneaking()) {
                     return false;
                 }
                 
@@ -573,7 +573,7 @@ public class PlayerListener implements Listener {
                 break;
 
             case RIGHT_CLICK_AIR:
-                if(player.getInventory().getItemInOffHand().getType() != Material.AIR && !player.isSneaking()) {
+                if(player.getInventory().getItemInOffHand().getType() != Material.AIR && !player.isInsideVehicle()  && !player.isSneaking()) {
                     return false;
                 }
                 

--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -528,6 +528,10 @@ public class PlayerListener implements Listener {
 
         switch (event.getAction()) {
             case RIGHT_CLICK_BLOCK:
+                if(player.getInventory().getItemInOffHand().getType() != Material.AIR && !player.isSneaking()) {
+                    return false;
+                }
+                
                 Block block = event.getClickedBlock();
                 BlockState blockState = block.getState();
 
@@ -569,7 +573,10 @@ public class PlayerListener implements Listener {
                 break;
 
             case RIGHT_CLICK_AIR:
-
+                if(player.getInventory().getItemInOffHand().getType() != Material.AIR && !player.isSneaking()) {
+                    return false;
+                }
+                
                 /* ACTIVATION CHECKS */
                 if (Config.getInstance().getAbilitiesEnabled()) {
                     mcMMOPlayer.processAbilityActivation(SkillType.AXES);


### PR DESCRIPTION
Require sneaking to activate abilities if the player is holding an item with the offhand.

This also affects the Chimaera Wing and blast mining, but that seems like an ok effect since you wouldn't want to use the Chimaera Wing if you place a torch with the offhand while holding it or at some similar scenario.

Excuse me if I've done it wrong, it seems to work just fine, I haven't used Java in a really long while.