### PR TITLE
Treat grass path as grass...

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/excavation/Excavation.java
+++ b/src/main/java/com/gmail/nossr50/skills/excavation/Excavation.java
@@ -25,6 +25,7 @@ public class Excavation {
                 return blockState.getRawData() == 0x2 ? TreasureConfig.getInstance().excavationFromPodzol : TreasureConfig.getInstance().excavationFromDirt;
 
             case GRASS:
+            case GRASS_PATH:
                 return TreasureConfig.getInstance().excavationFromGrass;
 
             case SAND:

--- a/src/main/java/com/gmail/nossr50/skills/herbalism/Herbalism.java
+++ b/src/main/java/com/gmail/nossr50/skills/herbalism/Herbalism.java
@@ -38,6 +38,7 @@ public class Herbalism {
                 return true;
 
             case DIRT:
+            case GRASS_PATH:
                 blockState.setType(Material.GRASS);
                 return true;
 
@@ -148,6 +149,7 @@ public class Herbalism {
         switch (blockState.getType()) {
             case DIRT:
             case GRASS:
+            case GRASS_PATH:
                 blockState.setType(Material.MYCEL);
                 return true;
 

--- a/src/main/java/com/gmail/nossr50/util/BlockUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/BlockUtils.java
@@ -109,6 +109,7 @@ public final class BlockUtils {
         switch (blockState.getType()) {
             case COBBLESTONE:
             case DIRT:
+            case GRASS_PATH:
                 return true;
 
             case SMOOTH_BRICK:
@@ -208,6 +209,7 @@ public final class BlockUtils {
             case CLAY:
             case DIRT:
             case GRASS:
+            case GRASS_PATH:
             case GRAVEL:
             case MYCEL:
             case SAND:
@@ -284,6 +286,7 @@ public final class BlockUtils {
         switch (blockState.getType()) {
             case DIRT:
             case GRASS:
+            case GRASS_PATH:
             case SOIL:
                 return false;
 
@@ -318,6 +321,7 @@ public final class BlockUtils {
         switch (blockState.getType()) {
             case DIRT:
             case GRASS:
+            case GRASS_PATH:
                 return true;
 
             default:


### PR DESCRIPTION
Treat grass path as grass in excavation and herbalism (treated as dirt in green terra checks, makes it so reverting back to grass is possible without having to break the block and place it again)