### PR TITLE
Exploit fix, turning spawned pigs into zombie pigmans using lightning stike allows you gain XP

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -31,6 +31,7 @@ import org.bukkit.event.entity.EntityTameEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.entity.PigZapEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.inventory.ItemStack;
@@ -701,5 +702,14 @@ public class EntityListener implements Listener {
                 entity.addPotionEffect(new PotionEffect(effect.getType(), duration, effect.getAmplifier(), effect.isAmbient()));
             }
         }
+    }
+    
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPigZapEvent(PigZapEvent event)
+    {
+    	if (event.getEntity().hasMetadata(mcMMO.entityMetadataKey))
+    	{
+    		event.getPigZombie().setMetadata(mcMMO.entityMetadataKey, mcMMO.metadataValue);
+    	}
     }
 }

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -705,10 +705,8 @@ public class EntityListener implements Listener {
     }
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onPigZapEvent(PigZapEvent event)
-    {
-    	if (event.getEntity().hasMetadata(mcMMO.entityMetadataKey))
-    	{
+    public void onPigZapEvent(PigZapEvent event) {
+    	if (event.getEntity().hasMetadata(mcMMO.entityMetadataKey)) {
     		event.getPigZombie().setMetadata(mcMMO.entityMetadataKey, mcMMO.metadataValue);
     	}
     }

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -706,8 +706,8 @@ public class EntityListener implements Listener {
     
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPigZapEvent(PigZapEvent event) {
-    	if (event.getEntity().hasMetadata(mcMMO.entityMetadataKey)) {
-    		event.getPigZombie().setMetadata(mcMMO.entityMetadataKey, mcMMO.metadataValue);
-    	}
+        if (event.getEntity().hasMetadata(mcMMO.entityMetadataKey)) {
+            event.getPigZombie().setMetadata(mcMMO.entityMetadataKey, mcMMO.metadataValue);
+        }
     }
 }


### PR DESCRIPTION
Some servers have option to spawn lightning stike if conditions are meet and abusing this to turn spawned pigs to zombie pigmans allowing crazy xp gains. This could also be abused by an abusive staff member.