### PR TITLE
Add Beetroot to herbalism skill

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/skills/HerbalismCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/skills/HerbalismCommand.java
@@ -87,7 +87,7 @@ public class HerbalismCommand extends SkillCommand {
     protected void permissionsCheck(Player player) {
         hasHylianLuck = Permissions.secondaryAbilityEnabled(player, SecondaryAbility.HYLIAN_LUCK);
         canGreenTerra = Permissions.greenTerra(player);
-        canGreenThumbPlants = Permissions.greenThumbPlant(player, Material.CROPS) || Permissions.greenThumbPlant(player, Material.CARROT) || Permissions.greenThumbPlant(player, Material.POTATO) || Permissions.greenThumbPlant(player, Material.NETHER_WARTS) || Permissions.greenThumbPlant(player, Material.COCOA);
+        canGreenThumbPlants = Permissions.greenThumbPlant(player, Material.CROPS) || Permissions.greenThumbPlant(player, Material.CARROT) || Permissions.greenThumbPlant(player, Material.POTATO) || Permissions.greenThumbPlant(player, Material.BEETROOT) || Permissions.greenThumbPlant(player, Material.NETHER_WARTS) || Permissions.greenThumbPlant(player, Material.COCOA);
         canGreenThumbBlocks = Permissions.greenThumbBlock(player, Material.DIRT) || Permissions.greenThumbBlock(player, Material.COBBLESTONE) || Permissions.greenThumbBlock(player, Material.COBBLE_WALL) || Permissions.greenThumbBlock(player, Material.SMOOTH_BRICK);
         canFarmersDiet = Permissions.secondaryAbilityEnabled(player, SecondaryAbility.FARMERS_DIET);
         canDoubleDrop = Permissions.secondaryAbilityEnabled(player, SecondaryAbility.HERBALISM_DOUBLE_DROPS) && !skill.getDoubleDropsDisabled();

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -576,6 +576,7 @@ public class EntityListener implements Listener {
                                 * RESTORES 3 HUNGER - RESTORES 5 1/2 HUNGER @
                                 * 1000
                                 */
+            case BEETROOT:
             case BREAD: /* RESTORES 2 1/2 HUNGER - RESTORES 5 HUNGER @ 1000 */
             case CARROT_ITEM: /*
                                * RESTORES 2 HUNGER - RESTORES 4 1/2 HUNGER @

--- a/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
@@ -322,6 +322,10 @@ public class HerbalismManager extends SkillManager {
                 seed = Material.POTATO_ITEM;
                 break;
 
+            case BEETROOT_BLOCK:
+                seed = Material.BEETROOT_SEEDS;
+                break;
+
             default:
                 return;
         }
@@ -349,6 +353,10 @@ public class HerbalismManager extends SkillManager {
         blockState.setMetadata(mcMMO.greenThumbDataKey, new FixedMetadataValue(mcMMO.p, (int) (System.currentTimeMillis() / Misc.TIME_CONVERSION_FACTOR)));
 
         switch (blockState.getType()) {
+
+            case POTATO:
+            case CARROT:
+            case BEETROOT_BLOCK:
             case CROPS:
                 Crops crops = (Crops) blockState.getData();
 
@@ -370,17 +378,6 @@ public class HerbalismManager extends SkillManager {
                             crops.setState(CropState.SEEDED);
                             break;
                     }
-                }
-
-                return true;
-
-            case CARROT:
-            case POTATO:
-                if (greenTerra) {
-                    blockState.setRawData(CropState.MEDIUM.getData());
-                }
-                else {
-                    blockState.setRawData(greenThumbStage);
                 }
 
                 return true;

--- a/src/main/java/com/gmail/nossr50/util/BlockUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/BlockUtils.java
@@ -147,10 +147,9 @@ public final class BlockUtils {
             case YELLOW_FLOWER:
                 return true;
 
+            case BEETROOT_BLOCK:
             case CARROT:
             case POTATO:
-                return blockState.getRawData() == CropState.RIPE.getData();
-
             case CROPS:
                 return ((Crops) blockState.getData()).getState() == CropState.RIPE;
 

--- a/src/main/java/com/gmail/nossr50/util/ItemUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/ItemUtils.java
@@ -592,6 +592,8 @@ public final class ItemUtils {
             case CHORUS_FRUIT:
             case CHORUS_FLOWER:
             case POTATO_ITEM:
+            case BEETROOT:
+            case BEETROOT_SEEDS:
             case NETHER_WARTS:
             case BROWN_MUSHROOM:
             case RED_MUSHROOM:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -408,6 +408,7 @@ Skills:
 ###
 Double_Drops:
     Herbalism:
+        Beetroot_Block: true
         Brown_Mushroom: true
         Cactus: true
         Carrot: true

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -151,6 +151,7 @@ Experience:
     Herbalism:
         Allium: 300
         Azure_Bluet: 150
+        Beetroot_Block: 50
         Blue_Orchid: 150
         Brown_Mushroom: 150
         Cactus: 30

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -340,6 +340,7 @@ permissions:
             mcmmo.ability.herbalism.greenthumb.plants.crops: true
             mcmmo.ability.herbalism.greenthumb.plants.netherwarts: true
             mcmmo.ability.herbalism.greenthumb.plants.potato: true
+            mcmmo.ability.herbalism.greenthumb.plants.beetroot: true
     mcmmo.ability.herbalism.greenthumb.plants.carrot:
         description: Allows access to the Green Thumb ability for carrots
     mcmmo.ability.herbalism.greenthumb.plants.cocoa:
@@ -350,6 +351,8 @@ permissions:
         description: Allows access to the Green Thumb ability for netherwart
     mcmmo.ability.herbalism.greenthumb.plants.potato:
         description: Allows access to the Green Thumb ability for potatoes
+    mcmmo.ability.herbalism.greenthumb.plants.beetroot:
+        description: Allows access to the Green Thumb ability for beetrootes
     mcmmo.ability.herbalism.hylianluck:
         description: Allows access to the Hylian Luck ability
     mcmmo.ability.herbalism.shroomthumb:


### PR DESCRIPTION
Extends the herbalism skill to include the 1.9 beetroot crops. I oriented myself by the implementation of carrots/potatos/crops. The different growth states are taken care of by the Bukkit API.

This version is running on our public server and is working for us.

Resolves #2851 and #2896 
