### PR TITLE
Fix brewing stand fuel refill loop.

### DIFF
--- a/src/main/java/com/gmail/nossr50/runnables/skills/AlchemyBrewTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/skills/AlchemyBrewTask.java
@@ -69,8 +69,10 @@ public class AlchemyBrewTask extends BukkitRunnable {
 
             return;
         }
-        
-        ((BrewingStand) brewingStand).setFuelLevel(fuel);
+
+        if (fuel != 0 || ((BrewingStand) brewingStand).getFuelLevel() != 20) {
+            ((BrewingStand) brewingStand).setFuelLevel(fuel);
+        }
 
         brewTimer -= brewSpeed;
 


### PR DESCRIPTION
If a brewing stand had 1 as a fuel value, and a brew was started (setting the fuel level to 0), the brewing stand would refill on its own while mcMMO would keep setting the fuel value back to 0. This used up all of the available blaze powder.