### PR TITLE
Correcting loop conditions related to "ghost block" mitigation.

### DIFF
--- a/src/main/java/com/gmail/nossr50/runnables/skills/AbilityDisableTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/skills/AbilityDisableTask.java
@@ -70,8 +70,8 @@ public class AbilityDisableTask extends BukkitRunnable {
         int chunkX = chunk.getX();
         int chunkZ = chunk.getZ();
 
-        for (int x = chunkX - radius; x < chunkX + radius; x++) {
-            for (int z = chunkZ - radius; z < chunkZ + radius; z++) {
+        for (int x = chunkX - radius; x <= chunkX + radius; x++) {
+            for (int z = chunkZ - radius; z <= chunkZ + radius; z++) {
                 world.refreshChunk(x, z);
             }
         }


### PR DESCRIPTION
If radius is 1 (as it is when called elsewhere in the class), the loop
conditions fail to refresh some of the neighboring chunks, allowing for
ghost blocks to continue to occur on eastern and southern edges of the
chunk the player is in.

This commit fixes the loop conditions.

= Chunk diagram of old behavior =
```
-----
-RR--
-RP--
-----
-----
```

= Chunk diagram of new behavior =
```
-----
-RRR-
-RPR-
-RRR-
-----
```

= Legend =
P: the chunk the player is in
R and P: chunks that are refreshed
-: chunks that do not get refreshed