### PR TITLE
Fix 1.11 brewing, remove health bar from armor stands

### DIFF
--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: com.gmail.nossr50.mcMMO
+

--- a/src/main/java/com/gmail/nossr50/events/fake/FakeBrewEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeBrewEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.inventory.BrewerInventory;
 
 public class FakeBrewEvent extends BrewEvent {
-    public FakeBrewEvent(Block brewer, BrewerInventory contents) {
-        super(brewer, contents);
+    public FakeBrewEvent(Block brewer, BrewerInventory contents, int fuelLevel) {
+        super(brewer, contents, fuelLevel);
     }
 }

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -4,17 +4,7 @@ import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.AnimalTamer;
-import org.bukkit.entity.Arrow;
-import org.bukkit.entity.Enderman;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.FallingBlock;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
-import org.bukkit.entity.TNTPrimed;
-import org.bukkit.entity.Tameable;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -152,6 +142,10 @@ public class EntityListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
         if (event instanceof FakeEntityDamageByEntityEvent) {
+            return;
+        }
+
+        if (event.getEntity() instanceof ArmorStand) {
             return;
         }
 

--- a/src/main/java/com/gmail/nossr50/skills/alchemy/AlchemyPotionBrewer.java
+++ b/src/main/java/com/gmail/nossr50/skills/alchemy/AlchemyPotionBrewer.java
@@ -128,7 +128,7 @@ public final class AlchemyPotionBrewer {
             }
         }
 
-        FakeBrewEvent event = new FakeBrewEvent(brewingStand.getBlock(), inventory);
+        FakeBrewEvent event = new FakeBrewEvent(brewingStand.getBlock(), inventory, ((BrewingStand) brewingStand).getFuelLevel());
         mcMMO.p.getServer().getPluginManager().callEvent(event);
 
         if (event.isCancelled() || inputList.isEmpty()) {


### PR DESCRIPTION
This fixes brewing on the newest Spigot API builds. The Alchemy skill was completely broken due to a change in the Spigot BrewEvent constructor, which this fixes via the changes to FakeBrewEvent.java and AlchemyPotionBrewer.java. This also adds a check in EntityListener.java for armor stands, so that health bars aren't displayed for them. The health bars never really displayed properly (armor stand health acts differently from most entities), and it allowed players to punch invisible armor stands server admins may have been intentionally hiding to temporarily reveal them via a health bar, which is an issue.