### PR TITLE
fix #2979

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/blockmeta/HashChunkletManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/HashChunkletManager.java
@@ -187,6 +187,17 @@ public class HashChunkletManager implements ChunkletManager {
         int cx = x / 16;
         int cz = z / 16;
         int cy = y / 64;
+        
+        if(x < 0){
+            --cx;
+        }
+        if(z < 0){
+            --cz;
+        }
+        if(y < 0){
+            --cy;
+        }
+        
         String key = world.getName() + "," + cx + "," + cz + "," + cy;
 
         if (!store.containsKey(key)) {
@@ -215,7 +226,17 @@ public class HashChunkletManager implements ChunkletManager {
         int cx = x / 16;
         int cz = z / 16;
         int cy = y / 64;
-
+        
+        if(x < 0){
+            --cx;
+        }
+        if(z < 0){
+            --cz;
+        }
+        if(y < 0){
+            --cy;
+        }
+        
         int ix = Math.abs(x) % 16;
         int iz = Math.abs(z) % 16;
         int iy = Math.abs(y) % 64;
@@ -248,6 +269,16 @@ public class HashChunkletManager implements ChunkletManager {
         int cz = z / 16;
         int cy = y / 64;
 
+        if(x < 0){
+            --cx;
+        }
+        if(z < 0){
+            --cz;
+        }
+        if(y < 0){
+            --cy;
+        }
+        
         int ix = Math.abs(x) % 16;
         int iz = Math.abs(z) % 16;
         int iy = Math.abs(y) % 64;

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
@@ -295,6 +295,14 @@ public class HashChunkManager implements ChunkManager {
 
         int cx = x / 16;
         int cz = z / 16;
+        
+        if(x < 0){
+            --cx;
+        }
+        if(z < 0){
+            --cz;
+        }
+        
         String key = world.getName() + "," + cx + "," + cz;
 
         if (!store.containsKey(key)) {
@@ -339,6 +347,13 @@ public class HashChunkManager implements ChunkManager {
         int cx = x / 16;
         int cz = z / 16;
 
+        if(x < 0){
+            --cx;
+        }
+        if(z < 0){
+            --cz;
+        }
+        
         int ix = Math.abs(x) % 16;
         int iz = Math.abs(z) % 16;
 
@@ -384,6 +399,13 @@ public class HashChunkManager implements ChunkManager {
 
         int cx = x / 16;
         int cz = z / 16;
+        
+        if(x < 0){
+            --cx;
+        }
+        if(z < 0){
+            --cz;
+        }
 
         int ix = Math.abs(x) % 16;
         int iz = Math.abs(z) % 16;


### PR DESCRIPTION
I fixed #2979.(the reporter of this is my friend.)
This is caused by that negative values of chunk coordinates start from -1, not -0.
For example, a block positioned at (-1, 0, 0) is in the chunk whose coordinates is **(-1, 0, 0)** actually, but mcMMO  regard this block as in the chunk **(0, 0, 0)**.
The reason of this behavior is that this plugin divide x or z or y value by 16 or 64 to get which chunk a block is positioned at.
So I simply change this to subtract 1 from that value if that is less than 0.