### PR TITLE
Fix shake from WITHER-SKELETON. avoid to use depredated method: getSkeltonType().

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/treasure/TreasureConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/treasure/TreasureConfig.java
@@ -14,7 +14,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.material.Dye;
-import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
 
@@ -46,31 +45,32 @@ public class TreasureConfig extends ConfigLoader {
     public List<HylianTreasure> hylianFromFlowers = new ArrayList<HylianTreasure>();
     public List<HylianTreasure> hylianFromPots    = new ArrayList<HylianTreasure>();
 
-    public List<ShakeTreasure> shakeFromBlaze         = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromCaveSpider    = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromSpider        = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromChicken       = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromCow           = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromCreeper       = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromEnderman      = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromGhast         = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromHorse         = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromIronGolem     = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromMagmaCube     = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromMushroomCow   = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromPig           = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromPigZombie     = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromPlayer        = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromSheep         = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromSkeleton      = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromSlime         = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromSnowman       = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromSquid         = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromWitch         = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromZombie        = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromRabbit        = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromElderGuardian = new ArrayList<ShakeTreasure>();
-    public List<ShakeTreasure> shakeFromGuardian      = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromBlaze          = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromCaveSpider     = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromSpider         = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromChicken        = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromCow            = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromCreeper        = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromEnderman       = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromGhast          = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromHorse          = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromIronGolem      = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromMagmaCube      = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromMushroomCow    = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromPig            = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromPigZombie      = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromPlayer         = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromSheep          = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromSkeleton       = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromSlime          = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromSnowman        = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromSquid          = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromWitch          = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromWitherSkeleton = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromZombie         = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromRabbit         = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromElderGuardian  = new ArrayList<ShakeTreasure>();
+    public List<ShakeTreasure> shakeFromGuardian       = new ArrayList<ShakeTreasure>();
 
     public HashMap<Rarity, List<FishingTreasure>>     fishingRewards      = new HashMap<Rarity, List<FishingTreasure>>();
     public HashMap<Rarity, List<EnchantmentTreasure>> fishingEnchantments = new HashMap<Rarity, List<EnchantmentTreasure>>();
@@ -133,19 +133,19 @@ public class TreasureConfig extends ConfigLoader {
             return;
         }
 
-        loadTreaures("Fishing");
-        loadTreaures("Excavation");
-        loadTreaures("Hylian_Luck");
+        loadTreasures("Fishing");
+        loadTreasures("Excavation");
+        loadTreasures("Hylian_Luck");
         loadEnchantments();
 
         for (EntityType entity : EntityType.values()) {
             if (entity.isAlive()) {
-                loadTreaures("Shake." + entity.toString());
+                loadTreasures("Shake." + entity.toString());
             }
         }
     }
 
-    private void loadTreaures(String type) {
+    private void loadTreasures(String type) {
         boolean isFishing = type.equals("Fishing");
         boolean isShake = type.contains("Shake");
         boolean isExcavation = type.equals("Excavation");
@@ -178,7 +178,9 @@ public class TreasureConfig extends ConfigLoader {
 
             if (materialName.contains("INK_SACK")) {
                 material = Material.INK_SACK;
-            } else if (materialName.contains("INVENTORY")) {
+            } else if(materialName.contains("COAL")){
+            	material = Material.COAL;
+        	} else if (materialName.contains("INVENTORY")) {
                 // Use magic material BED_BLOCK to know that we're grabbing something from the inventory and not a normal treasure
                 shakeFromPlayer.add(new ShakeTreasure(new ItemStack(Material.BED_BLOCK, 1, (byte) 0), 1, getInventoryStealDropChance(), getInventoryStealDropLevel()));
                 continue;
@@ -365,6 +367,8 @@ public class TreasureConfig extends ConfigLoader {
                         shakeFromSquid.add(shakeTreasure);
                     } else if (type.equals("Shake.WITCH")) {
                         shakeFromWitch.add(shakeTreasure);
+                    } else if (type.equals("Shake.WITHER_SKELETON")) {
+                        shakeFromWitherSkeleton.add(shakeTreasure);
                     } else if (type.equals("Shake.ZOMBIE")) {
                         shakeFromZombie.add(shakeTreasure);
                     } else if (type.equals("Shake.RABBIT")) {

--- a/src/main/java/com/gmail/nossr50/skills/fishing/Fishing.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/Fishing.java
@@ -1,6 +1,5 @@
 package com.gmail.nossr50.skills.fishing;
 
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -131,13 +130,15 @@ public final class Fishing {
 
             case WITCH:
                 return TreasureConfig.getInstance().shakeFromWitch;
+            case WITHER_SKELETON:
+            	return TreasureConfig.getInstance().shakeFromWitherSkeleton;
 
             case ZOMBIE:
                 return TreasureConfig.getInstance().shakeFromZombie;
-                
+
             case RABBIT:
                 return TreasureConfig.getInstance().shakeFromRabbit;
-                
+
             case GUARDIAN:
                 if (((Guardian) target).isElder())
                     return TreasureConfig.getInstance().shakeFromElderGuardian;

--- a/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.Sound;
 import org.bukkit.WeatherType;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -23,8 +22,6 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Sheep;
-import org.bukkit.entity.Skeleton;
-import org.bukkit.entity.Skeleton.SkeletonType;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -448,26 +445,13 @@ public class FishingManager extends SkillManager {
                         sheep.setSheared(true);
                     }
                     break;
-
-                case SKELETON:
-                    if (((Skeleton) target).getSkeletonType() == SkeletonType.WITHER) {
-                        switch (drop.getType()) {
-                            case SKULL_ITEM:
-                                drop.setDurability((short) 1);
-                                break;
-
-                            case ARROW:
-                                drop.setType(Material.COAL);
-                                break;
-
-                            default:
-                                break;
-                        }
+                case WITHER_SKELETON:
+                    if(drop.getType() == Material.SKULL_ITEM){
+                    	drop.setDurability((short) 1);
                     }
                     break;
-
                 default:
-                    break;
+                	break;
             }
 
             McMMOPlayerShakeEvent shakeEvent = new McMMOPlayerShakeEvent(getPlayer(), drop);

--- a/src/main/resources/treasures.yml
+++ b/src/main/resources/treasures.yml
@@ -453,14 +453,12 @@ Excavation:
         Drop_Chance: 10.0
         Drop_Level: 75
         Drops_From: [Gravel]
-#<2016/07/16 changed Start>
-#    BONE:
-#        Amount: 1
-#        XP: 30
-#        Drop_Chance: 10.0
-#        Drop_Level: 175
-#        Drops_From: [Gravel]
-#<2016/07/16 changed End>
+    BONE:
+        Amount: 1
+        XP: 30
+        Drop_Chance: 10.0
+        Drop_Level: 175
+        Drops_From: [Gravel]
     APPLE:
         Amount: 1
         XP: 100
@@ -485,26 +483,24 @@ Excavation:
         Drop_Chance: 0.5
         Drop_Level: 850
         Drops_From: [Gravel]
-#<2016/07/16 changed Start>
-#    RED_MUSHROOM:
-#        Amount: 1
-#        XP: 80
-#        Drop_Chance: 0.5
-#        Drop_Level: 500
-#        Drops_From: [Dirt, Podzol, Grass, Mycelium]
-#    BROWN_MUSHROOM:
-#        Amount: 1
-#        XP: 80
-#        Drop_Chance: 0.5
-#        Drop_Level: 500
-#        Drops_From: [Dirt, Podzol, Grass, Mycelium]
-#    EGG:
-#        Amount: 1
-#        XP: 100
-#        Drop_Chance: 1.0
-#        Drop_Level: 250
-#        Drops_From: [Grass]
-#<2016/07/16 changed End>
+    RED_MUSHROOM:
+        Amount: 1
+        XP: 80
+        Drop_Chance: 0.5
+        Drop_Level: 500
+        Drops_From: [Dirt, Podzol, Grass, Mycelium]
+    BROWN_MUSHROOM:
+        Amount: 1
+        XP: 80
+        Drop_Chance: 0.5
+        Drop_Level: 500
+        Drops_From: [Dirt, Podzol, Grass, Mycelium]
+    EGG:
+        Amount: 1
+        XP: 100
+        Drop_Chance: 1.0
+        Drop_Level: 250
+        Drops_From: [Grass]
     SOUL_SAND:
         Amount: 1
         XP: 80
@@ -523,152 +519,54 @@ Excavation:
         Drop_Chance: 5.0
         Drop_Level: 750
         Drops_From: [Clay]
-#<2016/07/16 changed Start>
-#    STRING:
-#        Amount: 1
-#        XP: 200
-#        Drop_Chance: 5.0
-#        Drop_Level: 250
-#        Drops_From: [Clay]
-#<2016/07/16 changed End>
+    STRING:
+        Amount: 1
+        XP: 200
+        Drop_Chance: 5.0
+        Drop_Level: 250
+        Drops_From: [Clay]
     GLOWSTONE_DUST:
         Amount: 1
         XP: 80
         Drop_Chance: 5.0
         Drop_Level: 25
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Mycelium]
-#<2016/07/16 changed Start>
-#    GOLD_RECORD:
-#        Amount: 1
-#        XP: 3000
-#        Drop_Chance: 0.05
-#        Drop_Level: 250
-#        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-#    GREEN_RECORD:
-#        Amount: 1
-#        XP: 3000:
-#        Drop_Chance: 0.05
-#        Drop_Level: 250
-#        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
     GOLD_RECORD:
         Amount: 1
         XP: 3000
-        Drop_Chance: 0.0001
+        Drop_Chance: 0.05
         Drop_Level: 250
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
     GREEN_RECORD:
         Amount: 1
         XP: 3000
-        Drop_Chance: 0.0001
+        Drop_Chance: 0.05
         Drop_Level: 250
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_3:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_4:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_5:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_6:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_7:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_8:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_9:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_10:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_11:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    RECORD_12:
-        Amount: 1
-        XP: 3000
-        Drop_Chance: 0.0001
-        Drop_Level: 250
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-#<2016/07/16 changed End>
     DIAMOND:
         Amount: 1
         XP: 1000
         Drop_Chance: 0.13
         Drop_Level: 350
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-#<2016/07/16 changed Start>
-#    INK_SACK_BROWN:
-#        Amount: 1
-#        XP: 100
-#        Drop_Chance: 1.33
-#        Drop_Level: 350
-#        Drops_From: [Dirt, Podzol, Grass, Mycelium]
-#    QUARTZ:
-#        Amount: 1
-#        XP: 100
-#        Drop_Chance: 0.5
-#        Drop_Level: 850
-#        Drops_From: [Dirt, Podzol, Sand, Red_Sand, Gravel, Mycelium, Soul_Sand]
+    INK_SACK_BROWN:
+        Amount: 1
+        XP: 100
+        Drop_Chance: 1.33
+        Drop_Level: 350
+        Drops_From: [Dirt, Podzol, Grass, Mycelium]
     QUARTZ:
         Amount: 1
         XP: 100
-        Drop_Chance: 5.0
-        Drop_Level: 350
+        Drop_Chance: 0.5
+        Drop_Level: 850
         Drops_From: [Dirt, Podzol, Sand, Red_Sand, Gravel, Mycelium, Soul_Sand]
-#<2016/07/16 changed End>
     NAME_TAG:
         Amount: 1
         XP: 3000
         Drop_Chance: 0.05
         Drop_Level: 250
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-#<2016/07/16 changed Start>
-    CLAY_BALL:
-        Amount: 1
-        XP: 80
-        Drop_Chance: 5.0
-        Drop_Level: 25
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Mycelium]
-    GOLDEN_APPLE:
-        Amount: 1
-        XP: 9800
-        Drop_Chance: 0.5
-        Drop_Level: 500
-        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Mycelium]
-#<2016/07/16 changed End>
 #
 #  Settings for Hylian Luck
 ###

--- a/src/main/resources/treasures.yml
+++ b/src/main/resources/treasures.yml
@@ -453,12 +453,14 @@ Excavation:
         Drop_Chance: 10.0
         Drop_Level: 75
         Drops_From: [Gravel]
-    BONE:
-        Amount: 1
-        XP: 30
-        Drop_Chance: 10.0
-        Drop_Level: 175
-        Drops_From: [Gravel]
+#<2016/07/16 changed Start>
+#    BONE:
+#        Amount: 1
+#        XP: 30
+#        Drop_Chance: 10.0
+#        Drop_Level: 175
+#        Drops_From: [Gravel]
+#<2016/07/16 changed End>
     APPLE:
         Amount: 1
         XP: 100
@@ -483,24 +485,26 @@ Excavation:
         Drop_Chance: 0.5
         Drop_Level: 850
         Drops_From: [Gravel]
-    RED_MUSHROOM:
-        Amount: 1
-        XP: 80
-        Drop_Chance: 0.5
-        Drop_Level: 500
-        Drops_From: [Dirt, Podzol, Grass, Mycelium]
-    BROWN_MUSHROOM:
-        Amount: 1
-        XP: 80
-        Drop_Chance: 0.5
-        Drop_Level: 500
-        Drops_From: [Dirt, Podzol, Grass, Mycelium]
-    EGG:
-        Amount: 1
-        XP: 100
-        Drop_Chance: 1.0
-        Drop_Level: 250
-        Drops_From: [Grass]
+#<2016/07/16 changed Start>
+#    RED_MUSHROOM:
+#        Amount: 1
+#        XP: 80
+#        Drop_Chance: 0.5
+#        Drop_Level: 500
+#        Drops_From: [Dirt, Podzol, Grass, Mycelium]
+#    BROWN_MUSHROOM:
+#        Amount: 1
+#        XP: 80
+#        Drop_Chance: 0.5
+#        Drop_Level: 500
+#        Drops_From: [Dirt, Podzol, Grass, Mycelium]
+#    EGG:
+#        Amount: 1
+#        XP: 100
+#        Drop_Chance: 1.0
+#        Drop_Level: 250
+#        Drops_From: [Grass]
+#<2016/07/16 changed End>
     SOUL_SAND:
         Amount: 1
         XP: 80
@@ -519,54 +523,152 @@ Excavation:
         Drop_Chance: 5.0
         Drop_Level: 750
         Drops_From: [Clay]
-    STRING:
-        Amount: 1
-        XP: 200
-        Drop_Chance: 5.0
-        Drop_Level: 250
-        Drops_From: [Clay]
+#<2016/07/16 changed Start>
+#    STRING:
+#        Amount: 1
+#        XP: 200
+#        Drop_Chance: 5.0
+#        Drop_Level: 250
+#        Drops_From: [Clay]
+#<2016/07/16 changed End>
     GLOWSTONE_DUST:
         Amount: 1
         XP: 80
         Drop_Chance: 5.0
         Drop_Level: 25
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Mycelium]
+#<2016/07/16 changed Start>
+#    GOLD_RECORD:
+#        Amount: 1
+#        XP: 3000
+#        Drop_Chance: 0.05
+#        Drop_Level: 250
+#        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+#    GREEN_RECORD:
+#        Amount: 1
+#        XP: 3000:
+#        Drop_Chance: 0.05
+#        Drop_Level: 250
+#        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
     GOLD_RECORD:
         Amount: 1
         XP: 3000
-        Drop_Chance: 0.05
+        Drop_Chance: 0.0001
         Drop_Level: 250
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
     GREEN_RECORD:
         Amount: 1
         XP: 3000
-        Drop_Chance: 0.05
+        Drop_Chance: 0.0001
         Drop_Level: 250
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_3:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_4:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_5:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_6:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_7:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_8:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_9:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_10:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_11:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+    RECORD_12:
+        Amount: 1
+        XP: 3000
+        Drop_Chance: 0.0001
+        Drop_Level: 250
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+#<2016/07/16 changed End>
     DIAMOND:
         Amount: 1
         XP: 1000
         Drop_Chance: 0.13
         Drop_Level: 350
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
-    INK_SACK_BROWN:
-        Amount: 1
-        XP: 100
-        Drop_Chance: 1.33
-        Drop_Level: 350
-        Drops_From: [Dirt, Podzol, Grass, Mycelium]
+#<2016/07/16 changed Start>
+#    INK_SACK_BROWN:
+#        Amount: 1
+#        XP: 100
+#        Drop_Chance: 1.33
+#        Drop_Level: 350
+#        Drops_From: [Dirt, Podzol, Grass, Mycelium]
+#    QUARTZ:
+#        Amount: 1
+#        XP: 100
+#        Drop_Chance: 0.5
+#        Drop_Level: 850
+#        Drops_From: [Dirt, Podzol, Sand, Red_Sand, Gravel, Mycelium, Soul_Sand]
     QUARTZ:
         Amount: 1
         XP: 100
-        Drop_Chance: 0.5
-        Drop_Level: 850
+        Drop_Chance: 5.0
+        Drop_Level: 350
         Drops_From: [Dirt, Podzol, Sand, Red_Sand, Gravel, Mycelium, Soul_Sand]
+#<2016/07/16 changed End>
     NAME_TAG:
         Amount: 1
         XP: 3000
         Drop_Chance: 0.05
         Drop_Level: 250
         Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Gravel, Clay, Mycelium, Soul_Sand]
+#<2016/07/16 changed Start>
+    CLAY_BALL:
+        Amount: 1
+        XP: 80
+        Drop_Chance: 5.0
+        Drop_Level: 25
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Mycelium]
+    GOLDEN_APPLE:
+        Amount: 1
+        XP: 9800
+        Drop_Chance: 0.5
+        Drop_Level: 500
+        Drops_From: [Dirt, Podzol, Grass, Sand, Red_Sand, Mycelium]
+#<2016/07/16 changed End>
 #
 #  Settings for Hylian Luck
 ###
@@ -918,6 +1020,23 @@ Shake:
             Amount: 1
             XP: 0
             Drop_Chance: 15.0
+            Drop_Level: 0
+    WITHER_SKELETON:
+        SKULL_ITEM:
+            Data: 0
+            Amount: 1
+            XP: 0
+            Drop_Chance: 2.0
+            Drop_Level: 0
+        BONE:
+            Amount: 1
+            XP: 0
+            Drop_Chance: 49.0
+            Drop_Level: 0
+        COAL:
+            Amount: 2
+            XP: 0
+            Drop_Chance: 49.0
             Drop_Level: 0
     ZOMBIE:
         SKULL_ITEM:


### PR DESCRIPTION
As reported on issue #3101, Shake from wither-skeleton isn't woking because method "getSkeletonType()" is deprecated on 1.11.2.
So I changed not to use it and to check which the caught entity is WITHER_SKELETON or not in FishingManager.