### PR TITLE
Prevent disarming, bleed, and axe passives when dealing thorns damage

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -55,6 +55,10 @@ public final class CombatUtils {
     private CombatUtils() {}
 
     private static void processSwordCombat(LivingEntity target, Player player, EntityDamageByEntityEvent event) {
+        if (event.getCause() == DamageCause.THORNS) {
+            return;
+        }
+        
         McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
         SwordsManager swordsManager = mcMMOPlayer.getSwordsManager();
         double initialDamage = event.getDamage();
@@ -76,6 +80,10 @@ public final class CombatUtils {
     }
 
     private static void processAxeCombat(LivingEntity target, Player player, EntityDamageByEntityEvent event) {
+        if (event.getCause() == DamageCause.THORNS) {
+            return;
+        }
+        
         double initialDamage = event.getDamage();
         double finalDamage = initialDamage;
         Map<DamageModifier, Double> modifiers = getModifiers(event);
@@ -111,6 +119,10 @@ public final class CombatUtils {
     }
 
     private static void processUnarmedCombat(LivingEntity target, Player player, EntityDamageByEntityEvent event) {
+        if (event.getCause() == DamageCause.THORNS) {
+            return;
+        }
+        
         double initialDamage = event.getDamage();
         double finalDamage = initialDamage;
 


### PR DESCRIPTION
Corrects behavior of passive abilities such as critical hits from axes, bleed from swords, and disarming from the unarmed skill. The behavior that was in error is that they would trigger if a player deals damage using thorns instead of only when using the appropriate weapon to attack.

Old behavior:
Player A is wearing armor with thorns and is holding a sword. Player B attacks player A and gets damaged by thorns used by player A but also sustains a bleed effect because player A was holding a sword.

New behavior:
Player A is wearing armor with thorns and is holding a sword. Player B attacks player A and only sustains the normal damage from thorns as intended.