### PR TITLE
Fix permission error

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1900,7 +1900,7 @@ permissions:
         description: Allow reset of skill levels
         children:
             mcmmo.commands.skillreset.all: true
-            mcmmo.commands.skillreset.others.all: false
+            mcmmo.commands.skillreset.others.all: true
     mcmmo.skills.*:
         default: false
         description: Implies all mcmmo.skills permissions.


### PR DESCRIPTION
The child permission has the value set to false. From http://bukkit.gamepedia.com/Plugin_YAML: "a child node of false inherits the inverse parent permission". Having the value set to false grants the permission to reset other players' skills to everyone that doesn't have the mcmmo.skillreset permission, which by default nobody has.