### PR TITLE
Fix for removed methods in Bukkit 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.11.2-R0.1-SNAPSHOT</version>
+            <version>1.12-pre2-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
+++ b/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
@@ -25,7 +25,7 @@ public abstract class AutoUpdateConfigLoader extends ConfigLoader {
     @Override
     protected void loadFile() {
         super.loadFile();
-        FileConfiguration internalConfig = YamlConfiguration.loadConfiguration(plugin.getResource(fileName));
+        FileConfiguration internalConfig = YamlConfiguration.loadConfiguration(plugin.getResourceAsReader(fileName));
 
         Set<String> configKeys = config.getKeys(true);
         Set<String> internalConfigKeys = internalConfig.getKeys(true);

--- a/src/main/java/com/gmail/nossr50/config/HiddenConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/HiddenConfig.java
@@ -1,5 +1,7 @@
 package com.gmail.nossr50.config;
 
+import java.io.InputStreamReader;
+
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import com.gmail.nossr50.mcMMO;
@@ -29,8 +31,9 @@ public class HiddenConfig {
     }
 
     public void load() {
-        if (mcMMO.p.getResource(fileName) != null) {
-            config = YamlConfiguration.loadConfiguration(mcMMO.p.getResource(fileName));
+        InputStreamReader reader = mcMMO.p.getResourceAsReader(fileName);
+        if (reader != null) {
+            config = YamlConfiguration.loadConfiguration(reader);
             chunkletsEnabled = config.getBoolean("Options.Chunklets", true);
             conversionRate = config.getInt("Options.ConversionRate", 1);
             useEnchantmentBuffs = config.getBoolean("Options.EnchantmentBuffs", true);

--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -2,6 +2,8 @@ package com.gmail.nossr50;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,6 +66,7 @@ import com.gmail.nossr50.util.experience.FormulaManager;
 import com.gmail.nossr50.util.player.UserManager;
 import com.gmail.nossr50.util.scoreboards.ScoreboardManager;
 import com.gmail.nossr50.util.upgrade.UpgradeManager;
+import com.google.common.base.Charsets;
 
 import net.shatteredlands.shatt.backup.ZipLibrary;
 
@@ -507,5 +510,10 @@ public class mcMMO extends JavaPlugin {
             getLogger().warning("Cauldron implementation found, but the custom entity config for mcMMO is disabled!");
             getLogger().info("To enable, set Mods.Entity_Mods_Enabled to TRUE in config.yml.");
         }
+    }
+
+    public InputStreamReader getResourceAsReader(String fileName) {
+        InputStream in = getResource(fileName);
+        return in == null ? null : new InputStreamReader(in, Charsets.UTF_8);
     }
 }

--- a/src/main/java/com/gmail/nossr50/skills/child/ChildConfig.java
+++ b/src/main/java/com/gmail/nossr50/skills/child/ChildConfig.java
@@ -16,7 +16,7 @@ public class ChildConfig extends AutoUpdateConfigLoader {
 
     @Override
     protected void loadKeys() {
-        config.setDefaults(YamlConfiguration.loadConfiguration(plugin.getResource("child.yml")));
+        config.setDefaults(YamlConfiguration.loadConfiguration(plugin.getResourceAsReader("child.yml")));
 
         FamilyTree.clearRegistrations(); // when reloading, need to clear statics
 


### PR DESCRIPTION
`YamlConfiguration#loadConfiguration(InputStream)` was removed in this Bukkit commit, preventing mcMMO from loading on 1.12.

https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/f2a9b248754b4fd91c0ae69d659a8bbf64ed4929