### PR TITLE
Re-added handlersList

### DIFF
--- a/src/main/java/com/gmail/nossr50/events/experience/McMMOPlayerExperienceEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/experience/McMMOPlayerExperienceEvent.java
@@ -2,6 +2,7 @@ package com.gmail.nossr50.events.experience;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
 
 import com.gmail.nossr50.datatypes.skills.SkillType;
@@ -62,5 +63,16 @@ public abstract class McMMOPlayerExperienceEvent extends PlayerEvent implements 
     @Override
     public void setCancelled(boolean cancelled) {
         this.cancelled = cancelled;
+    }
+    
+    private static final HandlerList handlers = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }


### PR DESCRIPTION
Other events implementing really dont need handlerslist, but the class from where is implementing needs.