### PR TITLE
Added McMMOPlayerLoadedEvent

### DIFF
--- a/src/main/java/com/gmail/nossr50/events/McMMOPlayerLoadedEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/McMMOPlayerLoadedEvent.java
@@ -1,0 +1,41 @@
+package com.gmail.nossr50.events;
+
+import com.gmail.nossr50.datatypes.player.McMMOPlayer;
+
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+
+/**
+ * Called after the mcMMO player profile was successful loaded from data storage. This happens if the player recently
+ * joined the server or the data was reloaded (e.g. database convert, reset stats, convert experience)
+ * while the player is online.
+ */
+public class McMMOPlayerLoadedEvent extends PlayerEvent {
+
+    private final McMMOPlayer mcMMOPlayer;
+
+    public McMMOPlayerLoadedEvent(McMMOPlayer mcMMOPlayer) {
+        super(mcMMOPlayer.getPlayer());
+
+        this.mcMMOPlayer = mcMMOPlayer;
+    }
+
+    /**
+     * @return mcMMO player profile associated to the player
+     */
+    public McMMOPlayer getMcMMOPlayer() {
+        return mcMMOPlayer;
+    }
+
+    /** Rest of file is required boilerplate for custom events **/
+    private static final HandlerList handlers = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/com/gmail/nossr50/runnables/player/PlayerProfileLoadingTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/player/PlayerProfileLoadingTask.java
@@ -1,18 +1,20 @@
 package com.gmail.nossr50.runnables.player;
 
-import org.bukkit.Server;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-
-import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.config.Config;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.player.PlayerProfile;
+import com.gmail.nossr50.events.McMMOPlayerLoadedEvent;
 import com.gmail.nossr50.locale.LocaleLoader;
+import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.runnables.commands.McScoreboardKeepTask;
 import com.gmail.nossr50.util.Misc;
 import com.gmail.nossr50.util.player.UserManager;
 import com.gmail.nossr50.util.scoreboards.ScoreboardManager;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class PlayerProfileLoadingTask extends BukkitRunnable {
     private static final int MAX_TRIES = 5;
@@ -87,6 +89,13 @@ public class PlayerProfileLoadingTask extends BukkitRunnable {
                 ScoreboardManager.enablePlayerStatsScoreboard(player);
                 new McScoreboardKeepTask(player).runTaskLater(mcMMO.p, 1 * Misc.TICK_CONVERSION_FACTOR);
             }
+
+            Bukkit.getScheduler().runTask(mcMMO.p, new Runnable() {
+                @Override
+                public void run() {
+                    Bukkit.getPluginManager().callEvent(new McMMOPlayerLoadedEvent(mcMMOPlayer));
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
The mcMMO player profile is loaded async. This means plugins that depend on mcMMO and needs the data directly after player join have to implement some waiting task which asks every x seconds if the account is loaded yet and aborts after y tries. This is unreliable and delays the operations the plugin can do on that data. 

Furthermore plugins won't notice if the player profile was reloaded, because for example the admin removed the profile (/mcremove) or changed the experience formula (/mcconvert) while the player is online.