### PR TITLE
Add automatic Alchemy potion colorization and custom color config

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
@@ -284,13 +284,11 @@ public class PotionConfig extends ConfigLoader {
         int green = 0;
         int blue = 0;
         for (Color color : colors) {
-            System.out.println("Input color: " + color);
             red += color.getRed();
             green += color.getGreen();
             blue += color.getBlue();
         }
         Color color = Color.fromRGB(red/colors.size(), green/colors.size(), blue/colors.size());
-        System.out.println("Output color: " + color);
         return color;
     }
     

--- a/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
@@ -165,6 +166,14 @@ public class PotionConfig extends ConfigLoader {
                     }
                 }
             }
+            
+            Color color = null;
+            if (potion_section.contains("Color")) {
+                color = Color.fromRGB(potion_section.getInt("Color"));
+            }
+            else {
+                color = this.generateColor(effects);
+            }
 
             Map<ItemStack, String> children = new HashMap<ItemStack, String>();
             if (potion_section.contains("Children")) {
@@ -179,7 +188,7 @@ public class PotionConfig extends ConfigLoader {
                 }
             }
 
-            return new AlchemyPotion(material, data, name, lore, effects, children);
+            return new AlchemyPotion(material, data, name, lore, effects, color, children);
         }
         catch (Exception e) {
             mcMMO.p.getLogger().warning("Failed to load Alchemy potion: " + potion_section.getName());
@@ -251,4 +260,38 @@ public class PotionConfig extends ConfigLoader {
         }
         return null;
     }
+    
+    public Color generateColor(List<PotionEffect> effects) {
+        if (effects != null && !effects.isEmpty()) {
+            List<Color> colors = new ArrayList<Color>();
+            for (PotionEffect effect : effects) {
+                if (effect.getType().getColor() != null) {
+                    colors.add(effect.getType().getColor());
+                }
+            }
+            if (!colors.isEmpty()) {
+                if (colors.size() > 1) {
+                    return calculateAverageColor(colors);
+                }
+                return colors.get(0);
+            }
+        }
+        return null;
+    }
+    
+    public Color calculateAverageColor(List<Color> colors) {
+        int red = 0;
+        int green = 0;
+        int blue = 0;
+        for (Color color : colors) {
+            System.out.println("Input color: " + color);
+            red += color.getRed();
+            green += color.getGreen();
+            blue += color.getBlue();
+        }
+        Color color = Color.fromRGB(red/colors.size(), green/colors.size(), blue/colors.size());
+        System.out.println("Output color: " + color);
+        return color;
+    }
+    
 }

--- a/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -19,15 +20,17 @@ public class AlchemyPotion {
     private String name;
     private List<String> lore;
     private List<PotionEffect> effects;
+    private Color color;
     private Map<ItemStack, String> children;
 
-    public AlchemyPotion(Material material, PotionData data, String name, List<String> lore, List<PotionEffect> effects, Map<ItemStack, String> children) {
+    public AlchemyPotion(Material material, PotionData data, String name, List<String> lore, List<PotionEffect> effects, Color color, Map<ItemStack, String> children) {
         this.material = material;
         this.data = data;
         this.lore = lore;
         this.name = name;
         this.effects = effects;
         this.children = children;
+        this.color = color;
     }
 
     public String toString() {
@@ -51,6 +54,10 @@ public class AlchemyPotion {
             for (PotionEffect effect : this.getEffects()) {
                 meta.addCustomEffect(effect, true);
             }
+        }
+        
+        if (this.getColor() != null) {
+            meta.setColor(this.getColor());
         }
 
         potion.setItemMeta(meta);
@@ -97,6 +104,14 @@ public class AlchemyPotion {
         this.effects = effects;
     }
 
+    public Color getColor() {
+        return color;
+    }
+    
+    public void setColor(Color color) {
+        this.color = color;
+    }
+    
     public Map<ItemStack, String> getChildren() {
         return children;
     }

--- a/src/main/resources/potions.yml
+++ b/src/main/resources/potions.yml
@@ -45,6 +45,7 @@ Concoctions:
 #       Name: <name>                    Custom display name for this potion (optional)
 #       Material: <material>            Material for this potion, defaults to POTION
 #       Data:  <data_value>             Data value for this potion (if this is not present it will read from identifier)
+#       Color: <color>                  Custom color for the potion in RGB integer (e.g. 0xFF000, optional)
 #       Lore: ["lore1","lore2"...]      Custom lore for this potion (section is optional)
 #       Children:                       The potential children of this potion (section is optional)
 #           <INGREDIENT>: <NEW_IDENTIFIER>      The ingredient used, and resultant potion's identifier


### PR DESCRIPTION
A feature apparently added in MInecraft 1.11 allows for definition of custom potion colors.  Update necessary Alchemy code to allow for automatic potion colorization (based on potion effects) and custom potion color definitions in the potions.yml configuration file.  This fixes a longstanding issue where all custom Alchemy potions are the exact same color (Pink).
If a potion has multiple effects, the Minecraft-defined colors of each effect are averaged and the result color applied to the potion.