### PR TITLE
Enchanted book fixes

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
@@ -572,6 +572,11 @@ public class FishingManager extends SkillManager {
             double dropRate = TreasureConfig.getInstance().getEnchantmentDropRate(getLootTier(), rarity);
 
             if (diceRoll <= dropRate) {
+                // Make sure enchanted books always get some kind of enchantment.  --hoorigan
+                if (treasureDrop.getType() == Material.ENCHANTED_BOOK) {
+                    diceRoll = dropRate + 1;
+                    continue;
+                }
                 fishingEnchantments = TreasureConfig.getInstance().fishingEnchantments.get(rarity);
                 break;
             }

--- a/src/main/java/com/gmail/nossr50/util/ItemUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/ItemUtils.java
@@ -503,6 +503,7 @@ public final class ItemUtils {
      */
     public static boolean isEnchantable(ItemStack item) {
         switch (item.getType()) {
+            case ENCHANTED_BOOK:
             case SHEARS:
             case FISHING_ROD:
             case CARROT_STICK:


### PR DESCRIPTION
The aim of these changes is to make it possible to configure enchanted books as a type of fishing treasure, and guarantee that the enchanted books the player receives will have enchantments on them.