### PR TITLE
Calculate experience gain before processing green thumb.

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
@@ -148,10 +148,6 @@ public class HerbalismManager extends SkillManager {
             }
         }
         else {
-            if (Permissions.greenThumbPlant(player, material)) {
-                processGreenThumbPlants(blockState, greenTerra);
-            }
-
             if(material == Material.CHORUS_FLOWER && blockState.getRawData() != 5) {
                 return;
             }
@@ -164,6 +160,10 @@ public class HerbalismManager extends SkillManager {
             if (!oneBlockPlant) {
                 amount = Herbalism.calculateMultiBlockPlantDrops(blockState);
                 xp *= amount;
+            }
+            
+            if (Permissions.greenThumbPlant(player, material)) {
+                processGreenThumbPlants(blockState, greenTerra);
             }
         }
 


### PR DESCRIPTION
Should fix #3284 
Not sure whether it is related to #3359 or #3311

Basically before the change, XP was calculated looking at the newly planted block after green thumb instead of what was harvested.
Now first XP is calculated and then green thumb is taken into account.