### PR TITLE
Add McMMOPlayerSalvageCheckEvent

### DIFF
--- a/src/main/java/com/gmail/nossr50/events/skills/salvage/McMMOPlayerSalvageCheckEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/skills/salvage/McMMOPlayerSalvageCheckEvent.java
@@ -1,0 +1,58 @@
+package com.gmail.nossr50.events.skills.salvage;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.inventory.ItemStack;
+
+import com.gmail.nossr50.datatypes.skills.SkillType;
+import com.gmail.nossr50.events.skills.McMMOPlayerSkillEvent;
+
+/**
+ * Called just before a player salvages an item with mcMMO.
+ */
+public class McMMOPlayerSalvageCheckEvent extends McMMOPlayerSkillEvent implements Cancellable {
+    private ItemStack salvageItem;
+    private ItemStack salvageResults;
+    private ItemStack enchantedBook;
+    private boolean cancelled;
+
+    public McMMOPlayerSalvageCheckEvent(Player player, ItemStack salvageItem, ItemStack salvageResults, ItemStack enchantedBook) {
+        super(player, SkillType.SALVAGE);
+        this.salvageItem = salvageItem;
+        this.salvageResults = salvageResults;
+        this.enchantedBook = enchantedBook;
+        this.cancelled = false;
+    }
+
+    /**
+     * @return The item that should get salvaged.
+     */
+    public ItemStack getSalvageItem() {
+        return salvageItem;
+    }
+
+    /**
+     * @return The results that should be dropped after salvaging.
+     */
+    public ItemStack getSalvageResults() {
+        return salvageResults;
+    }
+
+    /**
+     * @return The enchanted book that should drop after salvaging or null if no book should be dropped.
+     */
+    public ItemStack getEnchantedBook() {
+        return enchantedBook;
+    }
+
+    /** Following are required for Cancellable **/
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+}

--- a/src/main/java/com/gmail/nossr50/skills/salvage/SalvageManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/salvage/SalvageManager.java
@@ -20,6 +20,7 @@ import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.skills.SkillManager;
 import com.gmail.nossr50.skills.salvage.Salvage.Tier;
 import com.gmail.nossr50.skills.salvage.salvageables.Salvageable;
+import com.gmail.nossr50.util.EventUtils;
 import com.gmail.nossr50.util.Misc;
 import com.gmail.nossr50.util.Permissions;
 import com.gmail.nossr50.util.StringUtils;
@@ -99,17 +100,25 @@ public class SalvageManager extends SkillManager {
 
         Map<Enchantment, Integer> enchants = item.getEnchantments();
 
+        ItemStack enchantBook = null;
         if (!enchants.isEmpty()) {
-            ItemStack enchantBook = arcaneSalvageCheck(enchants);
-
-            if (enchantBook != null) {
-                Misc.dropItem(location, enchantBook);
-            }
+            enchantBook = arcaneSalvageCheck(enchants);
         }
 
         byte salvageMaterialMetadata = (salvageable.getSalvageMaterialMetadata() != (byte) -1) ? salvageable.getSalvageMaterialMetadata() : 0;
 
-        Misc.dropItems(location, new MaterialData(salvageable.getSalvageMaterial(), salvageMaterialMetadata).toItemStack(salvageableAmount), 1);
+        ItemStack salvageResults = new MaterialData(salvageable.getSalvageMaterial(), salvageMaterialMetadata).toItemStack(salvageableAmount);
+
+        //Call event
+        if (EventUtils.callSalvageCheckEvent(player, item, salvageResults, enchantBook).isCancelled()) {
+            return;
+        }
+
+        if (enchantBook != null) {
+            Misc.dropItem(location, enchantBook);
+        }
+
+        Misc.dropItems(location, salvageResults, 1);
 
         // BWONG BWONG BWONG - CLUNK!
         if (Config.getInstance().getSalvageAnvilUseSoundsEnabled()) {

--- a/src/main/java/com/gmail/nossr50/util/EventUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/EventUtils.java
@@ -40,6 +40,7 @@ import com.gmail.nossr50.events.skills.fishing.McMMOPlayerMagicHunterEvent;
 import com.gmail.nossr50.events.skills.repair.McMMOPlayerRepairCheckEvent;
 import com.gmail.nossr50.events.skills.secondaryabilities.SecondaryAbilityEvent;
 import com.gmail.nossr50.events.skills.unarmed.McMMOPlayerDisarmEvent;
+import com.gmail.nossr50.events.skills.salvage.McMMOPlayerSalvageCheckEvent;
 import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.util.player.UserManager;
 
@@ -275,6 +276,13 @@ public class EventUtils {
 
     public static McMMOPlayerDisarmEvent callDisarmEvent(Player defender) {
         McMMOPlayerDisarmEvent event = new McMMOPlayerDisarmEvent(defender);
+        mcMMO.p.getServer().getPluginManager().callEvent(event);
+
+        return event;
+    }
+
+    public static McMMOPlayerSalvageCheckEvent callSalvageCheckEvent(Player player, ItemStack salvageMaterial, ItemStack salvageResults, ItemStack enchantedBook) {
+        McMMOPlayerSalvageCheckEvent event = new McMMOPlayerSalvageCheckEvent(player, salvageMaterial, salvageResults, enchantedBook);
         mcMMO.p.getServer().getPluginManager().callEvent(event);
 
         return event;


### PR DESCRIPTION
[BetonQuest](https://github.com/Co0sh/BetonQuest) currently has compatibillity issues with mcMMOs salvage skill: 

Players can salvage items from quests which breaks those quests and can also be abused in many ways.

To fix this I need this event which allows me to cancel salvaging of quest items. 