### PR TITLE
Handle playerdata without bukkit.lastKnownName info

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/commands/CommandUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandUtils.java
@@ -296,6 +296,11 @@ public final class CommandUtils {
 
         for (OfflinePlayer offlinePlayer : mcMMO.p.getServer().getOfflinePlayers()) {
             String playerName = offlinePlayer.getName();
+            
+            if (playerName == null) { //Do null checking here to detect corrupted data before sending it throuogh .equals
+            	System.err.println("[McMMO] Bad player data file with UIID " + offlinePlayer.getUniqueId() );
+            	continue; //Don't let an error here interrupt the loop
+            }
 
             if (partialName.equalsIgnoreCase(playerName)) {
                 // Exact match

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandUtils.java
@@ -298,7 +298,7 @@ public final class CommandUtils {
             String playerName = offlinePlayer.getName();
             
             if (playerName == null) { //Do null checking here to detect corrupted data before sending it throuogh .equals
-            	System.err.println("[McMMO] Bad player data file with UIID " + offlinePlayer.getUniqueId() );
+            	System.err.println("[McMMO] Player data file with UIID " + offlinePlayer.getUniqueId() + " is missing a player name. This may be a legacy file from before bukkit.lastKnownName. This should be okay to ignore.");
             	continue; //Don't let an error here interrupt the loop
             }
 


### PR DESCRIPTION
Fixed a null pointer exception that would occur if the offlinePlayer object did not have a defined string for .getName();