### PR TITLE
Added nether bricks to mining

### DIFF
--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -189,6 +189,7 @@ Experience:
         Diamond_Ore: 750
         Emerald_Ore: 1000
         End_Bricks: 200
+        Nether_Brick: 50
         Ender_Stone: 150
         Glowstone: 30
         Gold_Ore: 350


### PR DESCRIPTION
As per https://github.com/mcMMO-Dev/mcMMO/issues/3426

Red nether brick does not need to be added because it does not generate naturally.