### PR TITLE
Add SKULL to BlockUtil blacklist

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/BlockUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/BlockUtils.java
@@ -104,6 +104,7 @@ public final class BlockUtils {
             case SILVER_SHULKER_BOX :
             case WHITE_SHULKER_BOX :
             case YELLOW_SHULKER_BOX :
+            case SKULL :
                 return false;
 
             default :


### PR DESCRIPTION
Prevents activating skills when right-clicking skulls, a block often used by plugins like Slimefun for custom-textured blocks.