### PR TITLE
Clearer output from /mcmmo

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/McmmoCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/McmmoCommand.java
@@ -12,101 +12,106 @@ import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.util.Permissions;
 
 public class McmmoCommand implements CommandExecutor {
-    @Override
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        switch (args.length) {
-            case 0:
-                if (!Permissions.mcmmoDescription(sender)) {
-                    sender.sendMessage(command.getPermissionMessage());
-                    return true;
-                }
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		if (args.length == 1 && ( args[0].equalsIgnoreCase("?") || args[0].equalsIgnoreCase("help")
+				|| args[0].equalsIgnoreCase("commands"))) {
+			if (!Permissions.mcmmoHelp(sender)) {
+				sender.sendMessage(command.getPermissionMessage());
+				return true;
+			}
 
-                String description = LocaleLoader.getString("mcMMO.Description");
-                String[] mcSplit = description.split(",");
-                sender.sendMessage(mcSplit);
+			sender.sendMessage(LocaleLoader.getString("Commands.mcc.Header"));
+			displayGeneralCommands(sender);
+			displayOtherCommands(sender);
+			displayPartyCommands(sender);
+			return true;
+		} else {
+			if (!Permissions.mcmmoDescription(sender)) {
+				sender.sendMessage(command.getPermissionMessage());
+				return true;
+			}
 
-                if (Config.getInstance().getDonateMessageEnabled()) {
-                    sender.sendMessage(LocaleLoader.getString("MOTD.Donate"));
-                    sender.sendMessage(ChatColor.GOLD + " - " + ChatColor.GREEN + "tft_02@hotmail.com" + ChatColor.GOLD + " Paypal");
-                }
+			String description = LocaleLoader.getString("mcMMO.Description");
+			String[] mcSplit = description.split(",");
+			sender.sendMessage(mcSplit);
 
-                if (Permissions.showversion(sender)) {
-                    sender.sendMessage(LocaleLoader.getString("MOTD.Version", mcMMO.p.getDescription().getVersion()));
-                }
+			if (Config.getInstance().getDonateMessageEnabled()) {
+				sender.sendMessage(LocaleLoader.getString("MOTD.Donate"));
+				sender.sendMessage(
+						ChatColor.GOLD + " - " + ChatColor.GREEN + "tft_02@hotmail.com" + ChatColor.GOLD + " Paypal");
+			}
 
-                mcMMO.getHolidayManager().anniversaryCheck(sender);
-                return true;
+			if (Permissions.showversion(sender)) {
+				sender.sendMessage(LocaleLoader.getString("MOTD.Version", mcMMO.p.getDescription().getVersion()));
+			}
 
-            case 1:
-                if (args[0].equalsIgnoreCase("?") || args[0].equalsIgnoreCase("help") || args[0].equalsIgnoreCase("commands")) {
-                    if (!Permissions.mcmmoHelp(sender)) {
-                        sender.sendMessage(command.getPermissionMessage());
-                        return true;
-                    }
+			mcMMO.getHolidayManager().anniversaryCheck(sender);
+			return true;
+		}
+	}
 
-                    sender.sendMessage(LocaleLoader.getString("Commands.mcc.Header"));
-                    displayGeneralCommands(sender);
-                    displayOtherCommands(sender);
-                    displayPartyCommands(sender);
-                }
-                return true;
+	private void displayGeneralCommands(CommandSender sender) {
+		sender.sendMessage(ChatColor.DARK_AQUA + " /mcstats " + LocaleLoader.getString("Commands.Stats"));
+		sender.sendMessage(ChatColor.DARK_AQUA + " /<skill>" + LocaleLoader.getString("Commands.SkillInfo"));
+		sender.sendMessage(ChatColor.DARK_AQUA + " /mctop " + LocaleLoader.getString("Commands.Leaderboards"));
 
-            default:
-                return false;
-        }
-    }
+		if (Permissions.inspect(sender)) {
+			sender.sendMessage(ChatColor.DARK_AQUA + " /inspect " + LocaleLoader.getString("Commands.Inspect"));
+		}
 
-    private void displayGeneralCommands(CommandSender sender) {
-        sender.sendMessage(ChatColor.DARK_AQUA + " /mcstats " + LocaleLoader.getString("Commands.Stats"));
-        sender.sendMessage(ChatColor.DARK_AQUA + " /<skill>" + LocaleLoader.getString("Commands.SkillInfo"));
-        sender.sendMessage(ChatColor.DARK_AQUA + " /mctop " + LocaleLoader.getString("Commands.Leaderboards"));
+		if (Permissions.mcability(sender)) {
+			sender.sendMessage(ChatColor.DARK_AQUA + " /mcability " + LocaleLoader.getString("Commands.ToggleAbility"));
+		}
+	}
 
-        if (Permissions.inspect(sender)) {
-            sender.sendMessage(ChatColor.DARK_AQUA + " /inspect " + LocaleLoader.getString("Commands.Inspect"));
-        }
+	private void displayOtherCommands(CommandSender sender) {
+		sender.sendMessage(LocaleLoader.getString("Commands.Other"));
 
-        if (Permissions.mcability(sender)) {
-            sender.sendMessage(ChatColor.DARK_AQUA + " /mcability " + LocaleLoader.getString("Commands.ToggleAbility"));
-        }
-    }
+		if (Permissions.skillreset(sender)) {
+			sender.sendMessage(
+					ChatColor.DARK_AQUA + " /skillreset <skill|all> " + LocaleLoader.getString("Commands.Reset"));
+		}
 
-    private void displayOtherCommands(CommandSender sender) {
-        sender.sendMessage(LocaleLoader.getString("Commands.Other"));
+		if (Permissions.mmoedit(sender)) {
+			sender.sendMessage(ChatColor.DARK_AQUA + " /mmoedit " + LocaleLoader.getString("Commands.mmoedit"));
+		}
 
-        if (Permissions.skillreset(sender)) {
-            sender.sendMessage(ChatColor.DARK_AQUA + " /skillreset <skill|all> " + LocaleLoader.getString("Commands.Reset"));
-        }
+		if (Permissions.adminChat(sender)) {
+			sender.sendMessage(ChatColor.DARK_AQUA + " /adminchat " + LocaleLoader.getString("Commands.AdminToggle"));
+		}
 
-        if (Permissions.mmoedit(sender)) {
-            sender.sendMessage(ChatColor.DARK_AQUA + " /mmoedit " + LocaleLoader.getString("Commands.mmoedit"));
-        }
+		if (Permissions.mcgod(sender)) {
+			sender.sendMessage(ChatColor.DARK_AQUA + " /mcgod " + LocaleLoader.getString("Commands.mcgod"));
+		}
+	}
 
-        if (Permissions.adminChat(sender)) {
-            sender.sendMessage(ChatColor.DARK_AQUA + " /adminchat " + LocaleLoader.getString("Commands.AdminToggle"));
-        }
+	private void displayPartyCommands(CommandSender sender) {
+		if (Permissions.party(sender)) {
+			sender.sendMessage(LocaleLoader.getString("Commands.Party.Commands"));
+			sender.sendMessage(
+					ChatColor.DARK_AQUA + " /party create <" + LocaleLoader.getString("Commands.Usage.PartyName") + "> "
+							+ LocaleLoader.getString("Commands.Party1"));
+			sender.sendMessage(ChatColor.DARK_AQUA + " /party join <" + LocaleLoader.getString("Commands.Usage.Player")
+					+ "> " + LocaleLoader.getString("Commands.Party2"));
+			sender.sendMessage(ChatColor.DARK_AQUA + " /party quit " + LocaleLoader.getString("Commands.Party.Quit"));
 
-        if (Permissions.mcgod(sender)) {
-            sender.sendMessage(ChatColor.DARK_AQUA + " /mcgod " + LocaleLoader.getString("Commands.mcgod"));
-        }
-    }
+			if (Permissions.partyChat(sender)) {
+				sender.sendMessage(
+						ChatColor.DARK_AQUA + " /party chat " + LocaleLoader.getString("Commands.Party.Toggle"));
+			}
 
-    private void displayPartyCommands(CommandSender sender) {
-        if (Permissions.party(sender)) {
-            sender.sendMessage(LocaleLoader.getString("Commands.Party.Commands"));
-            sender.sendMessage(ChatColor.DARK_AQUA + " /party create <" + LocaleLoader.getString("Commands.Usage.PartyName") + "> " + LocaleLoader.getString("Commands.Party1"));
-            sender.sendMessage(ChatColor.DARK_AQUA + " /party join <" + LocaleLoader.getString("Commands.Usage.Player") + "> " + LocaleLoader.getString("Commands.Party2"));
-            sender.sendMessage(ChatColor.DARK_AQUA + " /party quit " + LocaleLoader.getString("Commands.Party.Quit"));
+			sender.sendMessage(
+					ChatColor.DARK_AQUA + " /party invite <" + LocaleLoader.getString("Commands.Usage.Player") + "> "
+							+ LocaleLoader.getString("Commands.Party.Invite"));
+			sender.sendMessage(
+					ChatColor.DARK_AQUA + " /party accept " + LocaleLoader.getString("Commands.Party.Accept"));
 
-            if (Permissions.partyChat(sender)) {
-                sender.sendMessage(ChatColor.DARK_AQUA + " /party chat " + LocaleLoader.getString("Commands.Party.Toggle"));
-            }
-
-            sender.sendMessage(ChatColor.DARK_AQUA + " /party invite <" + LocaleLoader.getString("Commands.Usage.Player") + "> " + LocaleLoader.getString("Commands.Party.Invite"));
-            sender.sendMessage(ChatColor.DARK_AQUA + " /party accept " + LocaleLoader.getString("Commands.Party.Accept"));
-
-            if (Permissions.partySubcommand(sender, PartySubcommandType.TELEPORT)) {
-                sender.sendMessage(ChatColor.DARK_AQUA + " /party teleport <" + LocaleLoader.getString("Commands.Usage.Player") + "> " + LocaleLoader.getString("Commands.Party.Teleport"));
-            }
-        }
-    }
+			if (Permissions.partySubcommand(sender, PartySubcommandType.TELEPORT)) {
+				sender.sendMessage(
+						ChatColor.DARK_AQUA + " /party teleport <" + LocaleLoader.getString("Commands.Usage.Player")
+								+ "> " + LocaleLoader.getString("Commands.Party.Teleport"));
+			}
+		}
+	}
 }


### PR DESCRIPTION
Passing an invalid argument to /mcmmo will display the /mcmmo about page instead of giving the command sender no feedback.

Diff note: Simply restructured if statements, did not adjust text.