### PR TITLE
Various Fixes

### DIFF
--- a/src/main/java/com/gmail/nossr50/datatypes/skills/MaterialType.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/skills/MaterialType.java
@@ -21,7 +21,7 @@ public enum MaterialType {
                 return Material.LEATHER;
 
             case WOOD:
-                return Material.OAK_WOOD;
+                return Material.OAK_PLANKS;
 
             case STONE:
                 return Material.COBBLESTONE;

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -585,7 +585,7 @@ public class EntityListener implements Listener {
                 return;
 
             case COOKIE: /* RESTORES 1/2 HUNGER - RESTORES 2 HUNGER @ 1000 */
-            case MELON: /* RESTORES 1 HUNGER - RESTORES 2 1/2 HUNGER @ 1000 */
+            case MELON_SLICE: /* RESTORES 1 HUNGER - RESTORES 2 1/2 HUNGER @ 1000 */
             case POISONOUS_POTATO: /*
                                     * RESTORES 1 HUNGER - RESTORES 2 1/2 HUNGER
                                     * @ 1000

--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -198,12 +198,15 @@ public class PlayerListener implements Listener {
                     event.setCancelled(fishingManager.exploitPrevention());
                 }
                 return;
-
             case CAUGHT_FISH:
                 //TODO Update to new API once available! Waiting for case CAUGHT_TREASURE:
                 Item fishingCatch = (Item) event.getCaught();
 
-                if (Config.getInstance().getFishingOverrideTreasures() && fishingCatch.getItemStack().getType() != Material.SALMON) {
+                if (Config.getInstance().getFishingOverrideTreasures() &&
+                        fishingCatch.getItemStack().getType() != Material.SALMON &&
+                        fishingCatch.getItemStack().getType() != Material.COD &&
+                        fishingCatch.getItemStack().getType() != Material.TROPICAL_FISH &&
+                        fishingCatch.getItemStack().getType() != Material.PUFFERFISH) {
                     fishingCatch.setItemStack(new ItemStack(Material.SALMON, 1));
                 }
 

--- a/src/main/java/com/gmail/nossr50/skills/herbalism/Herbalism.java
+++ b/src/main/java/com/gmail/nossr50/skills/herbalism/Herbalism.java
@@ -38,7 +38,7 @@ public class Herbalism {
 
             case DIRT :
             case GRASS_PATH :
-                blockState.setType(Material.GRASS);
+                blockState.setType(Material.GRASS_BLOCK);
                 return true;
 
             case COBBLESTONE :
@@ -161,7 +161,7 @@ public class Herbalism {
     protected static boolean convertShroomThumb(BlockState blockState) {
         switch (blockState.getType()) {
             case DIRT :
-            case GRASS :
+            case GRASS_BLOCK:
             case GRASS_PATH :
                 blockState.setType(Material.MYCELIUM);
                 return true;

--- a/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/herbalism/HerbalismManager.java
@@ -13,10 +13,7 @@ import com.gmail.nossr50.runnables.skills.HerbalismBlockUpdaterTask;
 import com.gmail.nossr50.skills.SkillManager;
 import com.gmail.nossr50.util.*;
 import com.gmail.nossr50.util.skills.SkillUtils;
-import org.bukkit.CropState;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.NetherWartsState;
+import org.bukkit.*;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.entity.Player;
@@ -278,7 +275,7 @@ public class HerbalismManager extends SkillManager {
                 seed = Material.WHEAT_SEEDS;
                 break;
 
-            case NETHER_WART_BLOCK:
+            case NETHER_WART:
                 seed = Material.NETHER_WART;
                 break;
 
@@ -317,14 +314,14 @@ public class HerbalismManager extends SkillManager {
         byte greenThumbStage = getGreenThumbStage();
 
         blockState.setMetadata(mcMMO.greenThumbDataKey, new FixedMetadataValue(mcMMO.p, (int) (System.currentTimeMillis() / Misc.TIME_CONVERSION_FACTOR)));
+        Ageable crops = (Ageable) blockState.getBlockData();
 
         switch (blockState.getType()) {
 
             case POTATOES:
             case CARROTS:
-            case BEETROOTS:
             case WHEAT:
-                Ageable crops = (Ageable) blockState.getBlockData();
+                crops = (Ageable) blockState.getBlockData();
 
                 if (greenTerra) {
                     crops.setAge(3);
@@ -332,39 +329,39 @@ public class HerbalismManager extends SkillManager {
                 else {
                     crops.setAge(greenThumbStage);
                 }
+                break;
 
-                return true;
-
-            case NETHER_WART_BLOCK:
-                Ageable warts = (Ageable) blockState.getBlockData();
+            case BEETROOTS:
+            case NETHER_WART:
+                crops = (Ageable) blockState.getBlockData();
 
                 if (greenTerra || greenThumbStage > 2) {
-                    warts.setAge(2);
+                    crops.setAge(2);
                 }
                 else if (greenThumbStage == 2) {
-                    warts.setAge(1);
+                    crops.setAge(1);
                 }
                 else {
-                    warts.setAge(0);
+                    crops.setAge(0);
                 }
-
-                return true;
+               break;
 
             case COCOA:
-                Ageable plant = (Ageable) blockState.getBlockData();
+                crops = (Ageable) blockState.getBlockData();
 
                 if (greenTerra || getGreenThumbStage() > 1) {
-                    plant.setAge(1);
+                    crops.setAge(1);
                 }
                 else {
-                    plant.setAge(0);
+                    crops.setAge(0);
                 }
-
-                return true;
+                break;
 
             default:
                 return false;
         }
+        blockState.setBlockData(crops);
+        return true;
     }
 
     private byte getGreenThumbStage() {

--- a/src/main/java/com/gmail/nossr50/util/ItemUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/ItemUtils.java
@@ -511,7 +511,7 @@ public final class ItemUtils {
     }
 
     public static boolean isSmeltable(ItemStack item) {
-        return item != null && MaterialUtils.isOre(item.getType().createBlockData());
+        return item != null && item.getType().isBlock() && MaterialUtils.isOre(item.getType().createBlockData());
     }
 
     public static boolean isSmelted(ItemStack item) {
@@ -520,7 +520,7 @@ public final class ItemUtils {
         }
 
         for (Recipe recipe : mcMMO.p.getServer().getRecipesFor(item)) {
-            if (recipe instanceof FurnaceRecipe && MaterialUtils.isOre(((FurnaceRecipe) recipe).getInput().getType().createBlockData())) {
+            if (recipe instanceof FurnaceRecipe && ((FurnaceRecipe) recipe).getInput().getType().isBlock() && MaterialUtils.isOre(((FurnaceRecipe) recipe).getInput().getType().createBlockData())) {
                 return true;
             }
         }

--- a/src/main/java/com/gmail/nossr50/util/StringUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/StringUtils.java
@@ -53,7 +53,7 @@ public class StringUtils {
             case BEETROOTS:
             case CARROTS:
             case POTATOES:
-            case NETHER_WART_BLOCK: {
+            case NETHER_WART: {
                 if (data instanceof Ageable) {
                     Ageable ageData = (Ageable) data;
                     if (ageData.getAge() == ageData.getMaximumAge()) {

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -210,7 +210,10 @@ Experience:
         Redstone_Ore: 150
         Sandstone: 30
         Stained_Clay|*: 50
-        Stone|*: 30
+        Stone: 30
+        Granite: 30
+        Andesite: 30
+        Diorite: 30
         Red_Sandstone: 100
         Prismarine: 70
         Purpur_Block: 200

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -168,7 +168,7 @@ Experience:
         Wheat_Ripe: 50
         Dead_Bush: 30
         Lilac: 50
-        Melon_Block: 20
+        Melon: 20
         Nether_Wart_Ripe: 50
         Orange_Tulip: 150
         Oxeye_Daisy: 150
@@ -182,7 +182,7 @@ Experience:
         Rose_Bush: 50
         Fern: 10
         Grass: 10
-        Sugar_Cane_Block: 30
+        Sugar_Cane: 30
         Sunflower: 50
         Tall_Grass: 50
         Large_Fern: 50


### PR DESCRIPTION
**commit dada44e**
ItemUtils
 = added a check in isSmeltable() and isSmelted() to make sure the Materials are blocks

**commit 8c00714**
HerbalismManager
= fixed names of netherwart
= fixed handleBlockState, and slightly altered it
StringUtils
= fixed name of netherwart

**commit f6484d7**
Herbalism
= fixed material name for grass in green terra block conversion
= fixed material name for grass in shroom thumb block conversion
EntityListener
= fixed material name for melon in food level change
experience config
= updated name for melon and sugar cane

**commit c5bedb5**
experience config
= removed Stone|*
= added Stone, Granite, Adesite, Diorite
MaterialTypes
= updated material reference for wood

**commit 9756812**
PlayerListener
= made it so COD, TROPICAL_FISH, and PUFFERFISH are no longer overwritten, so players can now catch these