### PR TITLE
update excavation on experience.yml

### DIFF
--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -131,7 +131,7 @@ Experience:
         Dirt: 40
         Coarse_Dirt: 40
         Podzol: 40
-        Grass: 40
+        Grass_Block: 40
         Gravel: 40
         Mycel: 40
         Sand: 40


### PR DESCRIPTION
In 1.13, the name of the grass block changed from **grass** to **grass_block**. This caused no experience to be given while using a shovel on grass. This change was part of something mojang called the flattening and could possibly be the cause of some other experience related issues. 
https://minecraft.gamepedia.com/1.13/Flattening