### PR TITLE
Bug fix for italian locale

### DIFF
--- a/src/main/resources/locale/locale_it.properties
+++ b/src/main/resources/locale/locale_it.properties
@@ -39,7 +39,7 @@ Archery.Effect.3=Disorienta i nemici e infligge {0} Danni
 Archery.Effect.4=Recupero Frecce
 Archery.Effect.5=Probabilit\u00E0 di recuperare frecce dai cadaveri
 Archery.Listener=Tiro con l'Arco:
-Archery.SkillName=Tiro con l'Arco
+Archery.SkillName=Arco
 Archery.Skillup=[[YELLOW]]L'abilit\u00E0 Tiro con l'Arco \u00E8 aumentata di {0}. Totale ({1})
 
 #AXES


### PR DESCRIPTION
Fixed the command "/mctop Tiro con l'Arco" that with spaces was not recognized (/mctop archery is not usable if the English locale is not selected).
Now is "/mctop Arco".

That should fix also "/Tiro con l'Arco".