### PR TITLE
fix memory leak

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -395,6 +395,10 @@ public class EntityListener implements Listener {
             entity.setCustomNameVisible(entity.getMetadata(mcMMO.customVisibleKey).get(0).asBoolean());
             entity.removeMetadata(mcMMO.customVisibleKey, plugin);
         }
+
+        if (entity.hasMetadata(mcMMO.entityMetadataKey)) {
+            entity.removeMetadata(mcMMO.entityMetadataKey, plugin);
+        }
     }
 
     /**


### PR DESCRIPTION
on servers with lots of spawner farms this metadata won't get GC'd unless removed, line 436 its added but never removed as far as I can tell