### PR TITLE
Updated plugin.yml to include command permissions

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,107 +22,153 @@ commands:
     xprate:
         aliases: [mcxprate]
         description: Modify the xp rate or start an event
+        permission: mcmmo.commands.xprate
     mcmmo:
         description: Shows a brief mod description
+        permission mcmmo.commands.mcmmo
     mctop:
         description: Show mcMMO leader boards
+        permission mcmmo.commands.mctop
     mcrank:
         description: Show mcMMO ranking for a player
+        permission mcmmo.commands.mcrank
     addxp:
         description: Add mcMMO XP to a user
+        permission: mcmmo.commands.addxp
     addlevels:
         description: Add mcMMO levels to a user
+        permission: mcmmo.commands.addlevels
     mcability:
         description: Toggle whether or not abilities get readied on right click
+        permission: mcmmo.commands.mcability
     mcrefresh:
         description: Refresh all cooldowns for mcMMO
+        permission: mcmmo.commands.mcrefresh
     mccooldown:
         description: Show the cooldowns on all your mcMMO abilities
         aliases: [mccooldowns]
+        permission: mcmmo.commands.mccooldown
     mcgod:
         description: Toggle mcMMO god-mode on/off
+        permission: mcmmo.commands.mcgod
     mcimport:
         description: Import mod config files
+        permission: mcmmo.commands.mcimport
     mcstats:
         aliases: [stats]
         description: Shows your mcMMO stats and xp
+        permission mcmmo.commands.mcstats
     mcremove:
         description: Remove a user from the database
+        permission: mcmmo.commands.mcremove
     mmoedit:
         description: Edit the mcMMO skill values for a user
+        permission: mcmmo.commands.mmoedit
     ptp:
         description: Teleport to a party member
+        permission: mcmmo.commands.ptp
     party:
         description: Create/join a party
+        permission: mcmmo.commands.party
     inspect:
         description: View detailed mcMMO info on another player
+        permission: mcmmo.commands.inspect
     mmoshowdb:
         description: Show the name of the current database type (for later use with /mmoupdate)
+        permission: mcmmo.commands.mmoshowdb
     mcconvert:
         description: Convert between different database and formula types
+        permission: mcmmo.commands.mcconvert
     partychat:
         aliases: [pc, p]
         description: Toggle Party chat or send party chat messages
+        permission: mcmmo.chat.partychat
     skillreset:
         description: Reset the level of one or all of your skills
+        permission: mcmmo.commands.skillreset
     excavation:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.excavation
     herbalism:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.herbalism
     mining:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.mining
     woodcutting:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.woodcutting
     axes:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.axes
     archery:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.archery
     swords:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.swords
     taming:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.taming
     unarmed:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.unarmed
     acrobatics:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.acrobatics
     repair:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.repair
     fishing:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.fishing
     smelting:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.smelting
     alchemy:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.alchemy
     salvage:
         description: Detailed mcMMO skill info
+        permission: mcmmo.commands.salvage
     adminchat:
         aliases: [ac, a]
         description: Toggle Admin chat or send admin chat messages
+        permission: mcmmo.chat.adminchat
     mcpurge:
         description: Purge users with 0 powerlevel and/or who haven't connected in several months from the server DB.
+        permission: mcmmo.commands.mcpurge
     hardcore:
         aliases: [mchardcore]
         description: Modify the mcMMO hardcore percentage or toggle hardcore mode on/off
+        permission: mcmmo.commands.hardcore
     vampirism:
         aliases: [mcvampirism]
         description: Modify the mcMMO vampirism percentage or toggle vampirism mode on/off
+        permission: mcmmo.commands.vampirism
     mcnotify:
         aliases: [notify]
         description: Toggle mcMMO abilities chat display notifications on/off
+        permission: mcmmo.commands.mcnotify
     mobhealth:
         aliases: [mcmobhealth]
         description: Change the style of the mob healthbar
+        permission: mcmmo.commands.mobhealth
     mhd:
         description: Sets all players mob health settings to default
+        permission: mcmmo.commands.mhd
     mcscoreboard:
         aliases: [mcsb]
         description: Manage your mcMMO Scoreboard
+        permission: mcmmo.commands.mcscoreboard
     kraken:
         aliases: [mckraken]
         description: Unleash the kraken!
+        permission: mcmmo.commands.kraken
     mcfools:
         aliases: [macho, jumping, throwing, wrecking, crafting, walking, swimming, falling, climbing, flying, diving, piggy]
         description: Deploy jokes
+        permission: mcmmo.commands.mcfools
 permissions:
     mcmmo.*:
         default: false


### PR DESCRIPTION
This will stop people from seeing the commands in tabcomplete for 1.13.2 if they dont have the permission for it. Should fix #3625.