### PR TITLE
Herbalism compatibility with PlayerAnimationEvent

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -29,6 +29,8 @@ import com.gmail.nossr50.util.sounds.SoundManager;
 import com.gmail.nossr50.util.sounds.SoundType;
 import com.gmail.nossr50.worldguard.WorldGuardManager;
 import com.gmail.nossr50.worldguard.WorldGuardUtils;
+import com.gmail.nossr50.events.fake.FakePlayerAnimationEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -656,16 +656,17 @@ public class PlayerListener implements Listener {
                     }
                 }
 
+                FakePlayerAnimationEvent fakeSwing = new FakePlayerAnimationEvent(event.getPlayer()); //PlayerAnimationEvent compat        
                 if (herbalismManager.canGreenThumbBlock(blockState)) {
+                    Bukkit.getPluginManager().callEvent(fakeSwing);
                     player.getInventory().setItemInMainHand(new ItemStack(Material.WHEAT_SEEDS, heldItem.getAmount() - 1));
-
                     if (herbalismManager.processGreenThumbBlocks(blockState) && EventUtils.simulateBlockBreak(block, player, false)) {
                         blockState.update(true);
                     }
                 }
-
                 /* SHROOM THUMB CHECK */
                 else if (herbalismManager.canUseShroomThumb(blockState)) {
+                    Bukkit.getPluginManager().callEvent(fakeSwing);
                     event.setCancelled(true);
                     if (herbalismManager.processShroomThumb(blockState) && EventUtils.simulateBlockBreak(block, player, false)) {
                         blockState.update(true);


### PR DESCRIPTION
This change in theory should make McMMO herbalism compatible with plugins that utilise PlayerAnimationEvent. The main reason that I want to add this is to fix `no swing` false positives in `AAC` (though didn't get to test this). 

I would appreciate if someone could test this PR and verify that its working without any issues. (I am busy for the next few days so I haven't been able to test it. In theory it looks like it should work. I could have checked if the event `isCancelled()` however, this doesn't seem necessary quite yet. Though, if it is needed I can add it 👍 

Please don't merge this unless it's confirmed completely working. I will find some time to test it out within the next few days.