### PR TITLE
Fix adminchat returning too early if send by the console

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/chat/ChatCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/chat/ChatCommand.java
@@ -55,11 +55,10 @@ public abstract class ChatCommand implements TabExecutor {
                 return true;
 
             case 1:
-                if (!CommandUtils.hasPlayerDataKey(sender)) {
-                    return true;
-                }
-
                 if (CommandUtils.shouldEnableToggle(args[0])) {
+                    if (!CommandUtils.hasPlayerDataKey(sender)) {
+                        return true;
+                    }
                     if (CommandUtils.noConsoleUsage(sender)) {
                         return true;
                     }
@@ -69,6 +68,9 @@ public abstract class ChatCommand implements TabExecutor {
                 }
 
                 if (CommandUtils.shouldDisableToggle(args[0])) {
+                    if (!CommandUtils.hasPlayerDataKey(sender)) {
+                        return true;
+                    }
                     if (CommandUtils.noConsoleUsage(sender)) {
                         return true;
                     }

--- a/src/main/java/com/gmail/nossr50/commands/chat/ChatCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/chat/ChatCommand.java
@@ -56,10 +56,10 @@ public abstract class ChatCommand implements TabExecutor {
 
             case 1:
                 if (CommandUtils.shouldEnableToggle(args[0])) {
-                    if (!CommandUtils.hasPlayerDataKey(sender)) {
+                    if (CommandUtils.noConsoleUsage(sender)) {
                         return true;
                     }
-                    if (CommandUtils.noConsoleUsage(sender)) {
+                    if (!CommandUtils.hasPlayerDataKey(sender)) {
                         return true;
                     }
 
@@ -68,10 +68,10 @@ public abstract class ChatCommand implements TabExecutor {
                 }
 
                 if (CommandUtils.shouldDisableToggle(args[0])) {
-                    if (!CommandUtils.hasPlayerDataKey(sender)) {
+                    if (CommandUtils.noConsoleUsage(sender)) {
                         return true;
                     }
-                    if (CommandUtils.noConsoleUsage(sender)) {
+                    if (!CommandUtils.hasPlayerDataKey(sender)) {
                         return true;
                     }
 


### PR DESCRIPTION
Fixes #3883 

"hasPlayerDataKey" was returning false too early if the console send only one argument. Putting it after each of the on/off argument checks and after the consoleUsage checks fixes this and properly either tells the concosole that it can't use the on/off arguments or sends the first argument as a chat message like it's supposed to.

Tested on a 1.13.2 spigot server.