### PR TITLE
Wrong overfishing count when fishing first time

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
@@ -55,7 +55,7 @@ public class FishingManager extends SkillManager {
     private BoundingBox lastFishingBoundingBox;
     private Item fishingCatch;
     private Location hookLocation;
-    private int fishCaughtCounter = 1;
+    private int fishCaughtCounter = 0;
 
     public FishingManager(McMMOPlayer mcMMOPlayer) {
         super(mcMMOPlayer, PrimarySkillType.FISHING);


### PR DESCRIPTION
If you fish in the same spot when you first log into a server, you will only be able to fish 3 times before getting the overfishing message.

A very minor bug, but a very easy fix.