### PR TITLE
Added some missing blocks to Herbalism/Mining

### DIFF
--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -338,6 +338,10 @@ Experience_Values:
         Lily_Pad: 100
         White_Tulip: 150
         Dandelion: 100
+        Bamboo: 10
+        Cornflower: 150
+        Lily_of_the_valley: 150
+        Wither_rose: 500
     Mining:
         Tube_Coral_Block: 75
         Brain_Coral_Block: 80
@@ -383,8 +387,15 @@ Experience_Values:
         Granite: 30
         Andesite: 30
         Diorite: 30
+        Stone_Bricks: 50
+        Cracked_Stone_Bricks: 50
+        Mossy_Stone_Bricks: 50
+        Chiseled_Stone_Bricks: 50
         Red_Sandstone: 100
         Prismarine: 70
+        Prismarine_Bricks: 70
+        Dark_Prismarine: 70
+        Sea_Lantern: 70
         Purpur_Block: 200
         Purpur_Pillar: 250
         Purpur_Slab: 150
@@ -482,4 +493,5 @@ Experience_Values:
             Pillager: 2.0
             Ravager: 4.0
             Trader_Llama: 1.0
+            Wandering_trader: 1.0
 


### PR DESCRIPTION
Added some missing entries to herbalism mining and one to combat.
Reasoning for each xp below:

bamboo - 10 Cant grow nearly as tall as kelp, but still higher then sugarcane
cornflower - 150 same as the other 1 high tall flowers (excluding poppy, dandelion and allium)
lily_of_the_valley - 150 same as the other 1 high tall flowers (excluding poppy, dandelion and allium)
wither_rose - 500. Quite hard to harvest. You need a wither to kill a mob and have the block not get destroyed by the wither blast. If the block where to get destroyed the flower just drops instead and you dont get any xp.

The whole stone brick family get the same xp as nether brick, 50
stone_bricks
cracked_stone_bricks
mossy_stone_bricks
chiseled_stone_bricks

The rest of the prismarine family continue with the same xp as their main block, 70
prismarine_bricks
dark_prismarine
sea_lantern

wandering_trader  - 1.0 same as normal villagers