### PR TITLE
Close all the files after unload instead of before

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
@@ -242,7 +242,6 @@ public class HashChunkManager implements ChunkManager {
             return;
         }
 
-        closeAll();
         String worldName = world.getName();
 
         List<String> keys = new ArrayList<String>(store.keySet());
@@ -257,6 +256,7 @@ public class HashChunkManager implements ChunkManager {
                 }
             }
         }
+        closeAll();
     }
 
     @Override


### PR DESCRIPTION
- This ensures that all file handles are closed after a world is
unloaded, since the unloadChunk function calls saveChunk, which
opens files.
- Should resolve issue [#3995](https://github.com/mcMMO-Dev/mcMMO/issues/3995)