### PR TITLE
Add additional info about horse speed in Beast Lore

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
@@ -27,6 +27,7 @@ import com.gmail.nossr50.util.sounds.SoundManager;
 import com.gmail.nossr50.util.sounds.SoundType;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 
@@ -254,6 +255,12 @@ public class TamingManager extends SkillManager {
         }
 
         message = message.concat(LocaleLoader.getString("Combat.BeastLoreHealth", target.getHealth(), target.getMaxHealth()));
+
+        if (beast instanceof AbstractHorse) {
+            AbstractHorse horse = (AbstractHorse) beast;
+            message = message.concat("\n" + LocaleLoader.getString("Combat.BeastLoreHorseSpeed", horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getValue() * 43));
+        }
+
         player.sendMessage(message);
     }
 

--- a/src/main/resources/locale/locale_en_US.properties
+++ b/src/main/resources/locale/locale_en_US.properties
@@ -555,6 +555,7 @@ Combat.ArrowDeflect=[[WHITE]]**ARROW DEFLECT**
 Combat.BeastLore=[[GREEN]]**BEAST LORE**
 Combat.BeastLoreHealth=[[DARK_AQUA]]Health ([[GREEN]]{0}[[DARK_AQUA]]/{1})
 Combat.BeastLoreOwner=[[DARK_AQUA]]Owner ([[RED]]{0}[[DARK_AQUA]])
+Combat.BeastLoreHorseSpeed=[[DARK_AQUA]]Horse Movement Speed ([[GREEN]]{0} blocks/s[[DARK_AQUA]])
 Combat.Gore=[[GREEN]]**GORED**
 Combat.StruckByGore=**YOU HAVE BEEN GORED**
 Combat.TargetDazed=Target was [[DARK_RED]]Dazed


### PR DESCRIPTION
An additional string containing info about the horse's movement speed (in blocks per second) is now concat'd to the end of the Beast Lore info. Also, added a Combat.BeastLoreHorseSpeed locale string to service this info.

![image](https://user-images.githubusercontent.com/30324210/63456761-44d9ea00-c415-11e9-8026-53c6922e4abe.png)
