### PR TITLE
Add spectral arrows to archery check

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -357,7 +357,7 @@ public final class CombatUtils {
                 }
             }
         }
-        else if (entityType == EntityType.ARROW) {
+        else if (entityType == EntityType.ARROW || entityType == EntityType.SPECTRAL_ARROW) {
             Arrow arrow = (Arrow) damager;
             ProjectileSource projectileSource = arrow.getShooter();
 


### PR DESCRIPTION
Seems that Bukkit uses EntityType.ARROW for arrows and potion-
tipped arrows, but EntityType.SPECTRAL_ARROW is a special case.

Fixes #3825

(n.b. submitter has not worked in Java for ~9 years and doesn't have a test environment, but this has been annoying for a while and seemed trivial to fix)