### PR TITLE
"EndermanEndermiteFarms" does not work.

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -81,7 +81,7 @@ public class EntityListener implements Listener {
         //Prevent entities from giving XP if they target endermite
         if(event.getTarget() instanceof Endermite)
         {
-            if(event.getEntity().hasMetadata(mcMMO.entityMetadataKey))
+            if(!event.getEntity().hasMetadata(mcMMO.entityMetadataKey))
                 event.getEntity().setMetadata(mcMMO.entityMetadataKey, mcMMO.metadataValue);
         }
     }


### PR DESCRIPTION
This error causes the "ExploitFix.EndermanEndermiteFarms" option in ExperienceConfig to not work.