### PR TITLE
Don't set double drop if result is already a full stack

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
@@ -113,7 +113,7 @@ public class SmeltingManager extends SkillManager {
         applyXpGain(Smelting.getResourceXp(smelting), XPGainReason.PVE, XPGainSource.PASSIVE);
 
         if (Config.getInstance().getDoubleDropsEnabled(PrimarySkillType.SMELTING, result.getType())
-                && isSecondSmeltSuccessful()) {
+                && isSecondSmeltSuccessful() && result.getAmount() < 64) {
             ItemStack newResult = result.clone();
 
             newResult.setAmount(result.getAmount() + 1);


### PR DESCRIPTION
This possibly fixes an incompatibility with IllegalStack.