### PR TITLE
FakeEvent checks

### DIFF
--- a/src/main/java/com/gmail/nossr50/events/fake/FakeBlockBreakEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeBlockBreakEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 /**
  * Called when mcMMO breaks a block due to a special ability.
  */
-public class FakeBlockBreakEvent extends BlockBreakEvent {
+public class FakeBlockBreakEvent extends BlockBreakEvent implements FakeEvent {
     public FakeBlockBreakEvent(Block theBlock, Player player) {
         super(theBlock, player);
     }

--- a/src/main/java/com/gmail/nossr50/events/fake/FakeBlockDamageEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeBlockDamageEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack;
 /**
  * Called when mcMMO damages a block due to a special ability.
  */
-public class FakeBlockDamageEvent extends BlockDamageEvent {
+public class FakeBlockDamageEvent extends BlockDamageEvent implements FakeEvent {
     public FakeBlockDamageEvent(Player player, Block block, ItemStack itemInHand, boolean instaBreak) {
         super(player, block, itemInHand, instaBreak);
     }

--- a/src/main/java/com/gmail/nossr50/events/fake/FakeBrewEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeBrewEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.block.Block;
 import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.inventory.BrewerInventory;
 
-public class FakeBrewEvent extends BrewEvent {
+public class FakeBrewEvent extends BrewEvent implements FakeEvent {
     public FakeBrewEvent(Block brewer, BrewerInventory contents, int fuelLevel) {
         super(brewer, contents, fuelLevel);
     }

--- a/src/main/java/com/gmail/nossr50/events/fake/FakeEntityDamageByEntityEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeEntityDamageByEntityEvent.java
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * Called when mcMMO applies damage from an entity due to special abilities.
  */
-public class FakeEntityDamageByEntityEvent extends EntityDamageByEntityEvent {
+public class FakeEntityDamageByEntityEvent extends EntityDamageByEntityEvent implements FakeEvent {
 
     public FakeEntityDamageByEntityEvent(Entity damager, Entity damagee, DamageCause cause, final Map<DamageModifier, Double> modifiers) {
         super(damager, damagee, cause, modifiers, getFunctionModifiers(modifiers));

--- a/src/main/java/com/gmail/nossr50/events/fake/FakeEntityDamageEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeEntityDamageEvent.java
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * Called when mcMMO applies damage due to special abilities.
  */
-public class FakeEntityDamageEvent extends EntityDamageEvent {
+public class FakeEntityDamageEvent extends EntityDamageEvent implements FakeEvent {
 
     public FakeEntityDamageEvent(Entity damagee, DamageCause cause, final Map<DamageModifier, Double> modifiers) {
         super(damagee, cause, modifiers, getFunctionModifiers(modifiers));

--- a/src/main/java/com/gmail/nossr50/events/fake/FakeEntityTameEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeEntityTameEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.entity.EntityTameEvent;
 /**
  * Called when mcMMO tames an animal via Call of the Wild
  */
-public class FakeEntityTameEvent extends EntityTameEvent {
+public class FakeEntityTameEvent extends EntityTameEvent implements FakeEvent {
     public FakeEntityTameEvent(LivingEntity entity, AnimalTamer owner) {
         super(entity, owner);
     }

--- a/src/main/java/com/gmail/nossr50/events/fake/FakeEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeEvent.java
@@ -1,0 +1,11 @@
+package com.gmail.nossr50.events.fake;
+
+import org.bukkit.event.Event;
+
+/**
+ * This interface marks an {@link Event} as "fake".
+ * This is just a handy way of checking if an {@link Event} is fake or not, maybe there
+ * will be methods suitable for this in the future.
+ *
+ */
+public interface FakeEvent {}

--- a/src/main/java/com/gmail/nossr50/events/fake/FakePlayerAnimationEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakePlayerAnimationEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.player.PlayerAnimationEvent;
 /**
  * Called when handling extra drops to avoid issues with NoCheat.
  */
-public class FakePlayerAnimationEvent extends PlayerAnimationEvent {
+public class FakePlayerAnimationEvent extends PlayerAnimationEvent implements FakeEvent {
     public FakePlayerAnimationEvent(Player player) {
         super(player);
     }

--- a/src/main/java/com/gmail/nossr50/events/fake/FakePlayerFishEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakePlayerFishEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerFishEvent;
 
-public class FakePlayerFishEvent extends PlayerFishEvent {
+public class FakePlayerFishEvent extends PlayerFishEvent implements FakeEvent {
     public FakePlayerFishEvent(Player player, Entity entity, FishHook hookEntity, State state) {
         super(player, entity, hookEntity, state);
     }

--- a/src/main/java/com/gmail/nossr50/util/EventUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/EventUtils.java
@@ -44,6 +44,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
 import java.util.HashMap;
@@ -52,10 +53,30 @@ import java.util.Map;
 /**
  * This class is meant to help make event related code less boilerplate
  */
-public class EventUtils {
+public final class EventUtils {
+
+    /**
+     * This is a static utility class, therefore we don't want any instances of
+     * this class. Making the constructor private prevents accidents like that.
+     */
+    private EventUtils() {}
+
     /*
      * Quality of Life methods
      */
+
+    /**
+     * This is a simple check to see if an {@link Event} is fake or not.
+     * {@link FakeEvent FakeEvents} should not be processed like normally and maybe even 
+     * be ignored by other {@link Plugin plugins} completely.
+     * 
+     * @param event The {@link Event} in question
+     * @return Whether this {@link Event} has been faked by mcMMO and should not be processed normally.
+     */
+    public static boolean isFakeEvent(Event event) {
+        return event instanceof FakeEvent;
+    }
+
     /**
      * Checks to see if damage is from natural sources
      * This cannot be used to determine if damage is from vanilla MC, it just checks to see if the damage is from a complex behaviour in mcMMO such as bleed.
@@ -69,6 +90,7 @@ public class EventUtils {
 
     /**
      * This little method is just to make the code more readable
+     * 
      * @param entity target entity
      * @return the associated McMMOPlayer for this entity
      */


### PR DESCRIPTION
This PR adds a small quality of life improvement for developers, the `FakeEvent` interface.
I admit that there is no clear benefit from this other than making code like this:

```java
@EventHandler
public void onDamage(EntityDamageByEntityEvent event) {
  // or just 'ismcMMOEnabled' if you use a variable
  if (plugin.getServer().getPluginManager().isPluginEnabled("mcMMO") && event instanceof FakeEntityDamageByEntityEvent) {
    return;
  }

  // Logic
}
```

a bit cleaner since this is no longer event-specific and can be translated and re-used as a standalone method:

```java
@EventHandler
public void onDamage(EntityDamageByEntityEvent event) {
  if (isFake(event)) {
    return;
  }

  // Logic
}

private boolean isFake(Event event) {
  // or just 'ismcMMOEnabled' if you use a variable
  if (plugin.getServer().getPluginManager().isPluginEnabled("mcMMO") && EventUtils.isFakeEvent(event)) {
    return;
  }
}
```

The benefit of this being a super interface is also that there is lower maintenance than having a bunch of instanceof-checks in the `isFakeEvent` method.
While an empty interface can be a nuisance... there might be a few methods down the line that could see a use in there.

Otherwise I also made the `EventUtils` class final and added a private constructor, since this is a utility class with static methods, we don't wanna instantiate that anyway, so it's best to prevent it this way.
I also saw that mcMMO uses Jetbrains Annotations, however I couldn't see them being used in the other methods of that class, let me know if I should make use of them though nonetheless for this method.