### PR TITLE
Feature: asynchronous chunkmeta handling

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -128,7 +128,7 @@ public class BlockListener implements Listener {
 
         for (Block b : event.getBlocks()) {
             movedBlock = b.getRelative(direction);
-            mcMMO.getPlaceStore().setTrue(movedBlock);
+            mcMMO.getPlaceStore().setTrueAsync(movedBlock);
         }
     }
 
@@ -150,11 +150,11 @@ public class BlockListener implements Listener {
         // Get opposite direction so we get correct block
         BlockFace direction = event.getDirection();
         Block movedBlock = event.getBlock().getRelative(direction);
-        mcMMO.getPlaceStore().setTrue(movedBlock);
+        mcMMO.getPlaceStore().setTrueAsync(movedBlock);
 
         for (Block block : event.getBlocks()) {
             movedBlock = block.getRelative(direction);
-            mcMMO.getPlaceStore().setTrue(movedBlock);
+            mcMMO.getPlaceStore().setTrueAsync(movedBlock);
         }
     }
 
@@ -174,7 +174,7 @@ public class BlockListener implements Listener {
 
         if(ExperienceConfig.getInstance().isSnowExploitPrevented() && BlockUtils.shouldBeWatched(blockState))
         {
-            mcMMO.getPlaceStore().setTrue(blockState.getBlock());
+            mcMMO.getPlaceStore().setTrueAsync(blockState.getBlock());
         }
     }
 
@@ -190,7 +190,7 @@ public class BlockListener implements Listener {
             if(event.getNewState().getType() != Material.OBSIDIAN
                     && ExperienceConfig.getInstance().doesBlockGiveSkillXP(PrimarySkillType.MINING, event.getNewState().getBlockData()))
             {
-                mcMMO.getPlaceStore().setTrue(event.getNewState());
+                mcMMO.getPlaceStore().setTrueAsync(event.getNewState());
             }
         }
     }
@@ -206,7 +206,7 @@ public class BlockListener implements Listener {
 
         /* Check if the blocks placed should be monitored so they do not give out XP in the future */
 //      if (!Tag.LOGS.isTagged(event.getBlockReplacedState().getType()) || !Tag.LOGS.isTagged(event.getBlockPlaced().getType()))
-        mcMMO.getPlaceStore().setTrue(blockState);
+        mcMMO.getPlaceStore().setTrueAsync(blockState);
 
         /* WORLD BLACKLIST CHECK */
         if(WorldBlacklist.isWorldBlacklisted(event.getBlock().getWorld())) {
@@ -244,7 +244,7 @@ public class BlockListener implements Listener {
             BlockState blockState = replacedBlockState.getBlock().getState();
 
             /* Check if the blocks placed should be monitored so they do not give out XP in the future */
-            mcMMO.getPlaceStore().setTrue(blockState);
+            mcMMO.getPlaceStore().setTrueAsync(blockState);
         }
 
         /* WORLD BLACKLIST CHECK */
@@ -272,7 +272,7 @@ public class BlockListener implements Listener {
 //            return;
 //        }
 
-        mcMMO.getPlaceStore().setFalse(blockState);
+        mcMMO.getPlaceStore().setFalseAsync(blockState);
     }
 
     /**
@@ -320,7 +320,7 @@ public class BlockListener implements Listener {
         //Check if profile is loaded
         if(mcMMOPlayer == null) {
             /* Remove metadata from placed watched blocks */
-            mcMMO.getPlaceStore().setFalse(blockState);
+            mcMMO.getPlaceStore().setFalseAsync(blockState);
             return;
         }
 
@@ -377,7 +377,7 @@ public class BlockListener implements Listener {
         }
 
         /* Remove metadata from placed watched blocks */
-        mcMMO.getPlaceStore().setFalse(blockState);
+        mcMMO.getPlaceStore().setFalseAsync(blockState);
     }
 
     /**

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -199,20 +199,24 @@ public class EntityListener implements Listener {
         if (entity instanceof FallingBlock || entity instanceof Enderman) {
             boolean isTracked = entity.hasMetadata(mcMMO.travelingBlock);
 
-            if (mcMMO.getPlaceStore().isTrue(block) && !isTracked) {
-                mcMMO.getPlaceStore().setFalse(block);
+            mcMMO.getPlaceStore().isTrueAsync(block).thenAccept(isTrue -> {
+                if (isTrue && !isTracked) {
+                    mcMMO.getPlaceStore().setFalseAsync(block);
 
-                entity.setMetadata(mcMMO.travelingBlock, mcMMO.metadataValue);
-            }
-            else if (isTracked) {
-                mcMMO.getPlaceStore().setTrue(block);
-            }
+                    entity.setMetadata(mcMMO.travelingBlock, mcMMO.metadataValue);
+                }
+                else if (isTracked) {
+                    mcMMO.getPlaceStore().setTrueAsync(block);
+                }
+            });
         } else if ((block.getType() == Material.REDSTONE_ORE)) {
         }
         else {
-            if (mcMMO.getPlaceStore().isTrue(block)) {
-                mcMMO.getPlaceStore().setFalse(block);
-            }
+            mcMMO.getPlaceStore().isTrueAsync(block).thenAccept(isTrue -> {
+                if (isTrue) {
+                    mcMMO.getPlaceStore().setTrueAsync(block);
+                }
+            });
         }
     }
 

--- a/src/main/java/com/gmail/nossr50/listeners/WorldListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/WorldListener.java
@@ -91,6 +91,6 @@ public class WorldListener implements Listener {
 
         Chunk chunk = event.getChunk();
 
-        mcMMO.getPlaceStore().chunkUnloaded(chunk.getX(), chunk.getZ(), event.getWorld());
+        mcMMO.getPlaceStore().chunkUnloadedAsync(chunk.getX(), chunk.getZ(), event.getWorld());
     }
 }

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/ChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/ChunkManager.java
@@ -6,15 +6,22 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 public interface ChunkManager {
     void closeAll();
 
     ChunkStore readChunkStore(World world, int x, int z) throws IOException;
 
+    CompletableFuture<ChunkStore> readChunkStoreAsync(World world, int x, int z);
+
     void writeChunkStore(World world, int x, int z, ChunkStore data);
 
+    CompletableFuture<Void> writeChunkStoreAsync(World world, int x, int z, ChunkStore data);
+
     void closeChunkStore(World world, int x, int z);
+
+    CompletableFuture<Void> closeChunkStoreAsync(World world, int x, int z);
 
     /**
      * Loads a specific chunklet
@@ -26,6 +33,8 @@ public interface ChunkManager {
      */
     void loadChunklet(int cx, int cy, int cz, World world);
 
+    CompletableFuture<Void> loadChunkletAsync(int cx, int cy, int cz, World world);
+
     /**
      * Unload a specific chunklet
      *
@@ -36,6 +45,8 @@ public interface ChunkManager {
      */
     void unloadChunklet(int cx, int cy, int cz, World world);
 
+    CompletableFuture<Void> unloadChunkletAsync(int cx, int cy, int cz, World world);
+
     /**
      * Load a given Chunk's Chunklet data
      *
@@ -44,6 +55,8 @@ public interface ChunkManager {
      * @param world World that the Chunk is in
      */
     void loadChunk(int cx, int cz, World world, Entity[] entities);
+
+    CompletableFuture<Void> loadChunkAsync(int cx, int cz, World world, Entity[] entities);
 
     /**
      * Unload a given Chunk's Chunklet data
@@ -54,6 +67,8 @@ public interface ChunkManager {
      */
     void unloadChunk(int cx, int cz, World world);
 
+    CompletableFuture<Void> unloadChunkAsync(int cx, int cz, World world);
+
     /**
      * Saves a given Chunk's Chunklet data
      *
@@ -62,6 +77,8 @@ public interface ChunkManager {
      * @param world World that the Chunk is in
      */
     void saveChunk(int cx, int cz, World world);
+
+    CompletableFuture<Void> saveChunkAsync(int cx, int cz, World world);
 
     boolean isChunkLoaded(int cx, int cz, World world);
 
@@ -74,6 +91,8 @@ public interface ChunkManager {
      */
     void chunkLoaded(int cx, int cz, World world);
 
+    CompletableFuture<Void> chunkLoadedAsync(int cx, int cz, World world);
+
     /**
      * Informs the ChunkletManager a chunk is unloaded
      *
@@ -82,6 +101,8 @@ public interface ChunkManager {
      * @param world World that the chunk was unloaded in
      */
     void chunkUnloaded(int cx, int cz, World world);
+
+    CompletableFuture<Void> chunkUnloadedAsync(int cx, int cz, World world);
 
     /**
      * Save all ChunkletStores related to the given world

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/ChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/ChunkManager.java
@@ -146,6 +146,8 @@ public interface ChunkManager {
      */
     boolean isTrue(int x, int y, int z, World world);
 
+    CompletableFuture<Boolean> isTrueAsync(int x, int y, int z, World world);
+
     /**
      * Check to see if a given block location is set to true
      *
@@ -154,6 +156,8 @@ public interface ChunkManager {
      */
     boolean isTrue(Block block);
 
+    CompletableFuture<Boolean> isTrueAsync(Block block);
+
     /**
      * Check to see if a given BlockState location is set to true
      *
@@ -161,6 +165,8 @@ public interface ChunkManager {
      * @return true if the given BlockState location is set to true, false if otherwise
      */
     boolean isTrue(BlockState blockState);
+
+    CompletableFuture<Boolean> isTrueAsync(BlockState blockState);
 
     /**
      * Set a given location to true, should create stores as necessary if the location does not exist
@@ -172,6 +178,8 @@ public interface ChunkManager {
      */
     void setTrue(int x, int y, int z, World world);
 
+    CompletableFuture<Void> setTrueAsync(int x, int y, int z, World world);
+
     /**
      * Set a given block location to true, should create stores as necessary if the location does not exist
      *
@@ -179,12 +187,16 @@ public interface ChunkManager {
      */
     void setTrue(Block block);
 
+    CompletableFuture<Void> setTrueAsync(Block block);
+
     /**
      * Set a given BlockState location to true, should create stores as necessary if the location does not exist
      *
      * @param blockState BlockState location to set
      */
     void setTrue(BlockState blockState);
+
+    CompletableFuture<Void> setTrueAsync(BlockState blockState);
 
     /**
      * Set a given location to false, should not create stores if one does not exist for the given location
@@ -196,6 +208,8 @@ public interface ChunkManager {
      */
     void setFalse(int x, int y, int z, World world);
 
+    CompletableFuture<Void> setFalseAsync(int x, int y, int z, World world);
+
     /**
      * Set a given block location to false, should not create stores if one does not exist for the given location
      *
@@ -203,12 +217,16 @@ public interface ChunkManager {
      */
     void setFalse(Block block);
 
+    CompletableFuture<Void> setFalseAsync(Block block);
+
     /**
      * Set a given BlockState location to false, should not create stores if one does not exist for the given location
      *
      * @param blockState BlockState location to set
      */
     void setFalse(BlockState blockState);
+
+    CompletableFuture<Void> setFalseAsync(BlockState blockState);
 
     /**
      * Delete any ChunkletStores that are empty

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/HashChunkManager.java
@@ -325,7 +325,7 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized boolean isTrue(int x, int y, int z, World world) {
+    public boolean isTrue(int x, int y, int z, World world) {
         if (world == null) {
             return false;
         }
@@ -351,7 +351,12 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized boolean isTrue(Block block) {
+    public CompletableFuture<Boolean> isTrueAsync(int x, int y, int z, World world) {
+        return lockManager.supplyAsyncWithLock(getBlockKey(world, x, y, z), () -> isTrue(x, y, z, world));
+    }
+
+    @Override
+    public boolean isTrue(Block block) {
         if (block == null) {
             return false;
         }
@@ -360,7 +365,12 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized boolean isTrue(BlockState blockState) {
+    public CompletableFuture<Boolean> isTrueAsync(Block block) {
+        return lockManager.supplyAsyncWithLock(getBlockKey(block), () -> isTrue(block));
+    }
+
+    @Override
+    public boolean isTrue(BlockState blockState) {
         if (blockState == null) {
             return false;
         }
@@ -369,7 +379,12 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized void setTrue(int x, int y, int z, World world) {
+    public CompletableFuture<Boolean> isTrueAsync(BlockState blockState) {
+        return lockManager.supplyAsyncWithLock(getBlockKey(blockState), () -> isTrue(blockState));
+    }
+
+    @Override
+    public void setTrue(int x, int y, int z, World world) {
         if (world == null) {
             return;
         }
@@ -397,12 +412,22 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized void setTrue(Block block) {
+    public CompletableFuture<Void> setTrueAsync(int x, int y, int z, World world) {
+        return lockManager.runAsyncWithLock(getBlockKey(world, x, y, z), () -> setTrue(x, y, z, world));
+    }
+
+    @Override
+    public void setTrue(Block block) {
         if (block == null) {
             return;
         }
 
         setTrue(block.getX(), block.getY(), block.getZ(), block.getWorld());
+    }
+
+    @Override
+    public CompletableFuture<Void> setTrueAsync(Block block) {
+        return lockManager.runAsyncWithLock(getBlockKey(block), () -> setTrue(block));
     }
 
     @Override
@@ -415,7 +440,12 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized void setFalse(int x, int y, int z, World world) {
+    public CompletableFuture<Void> setTrueAsync(BlockState blockState) {
+        return lockManager.runAsyncWithLock(getBlockKey(blockState), () -> setTrue(blockState));
+    }
+
+    @Override
+    public void setFalse(int x, int y, int z, World world) {
         if (world == null) {
             return;
         }
@@ -442,7 +472,12 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized void setFalse(Block block) {
+    public CompletableFuture<Void> setFalseAsync(int x, int y, int z, World world) {
+        return lockManager.runAsyncWithLock(getBlockKey(world, x, y, z), () -> setFalse(x, y, z, world));
+    }
+
+    @Override
+    public void setFalse(Block block) {
         if (block == null) {
             return;
         }
@@ -451,12 +486,22 @@ public class HashChunkManager implements ChunkManager {
     }
 
     @Override
-    public synchronized void setFalse(BlockState blockState) {
+    public CompletableFuture<Void> setFalseAsync(Block block) {
+        return lockManager.runAsyncWithLock(getBlockKey(block), () -> setFalse(block));
+    }
+
+    @Override
+    public void setFalse(BlockState blockState) {
         if (blockState == null) {
             return;
         }
 
         setFalse(blockState.getX(), blockState.getY(), blockState.getZ(), blockState.getWorld());
+    }
+
+    @Override
+    public CompletableFuture<Void> setFalseAsync(BlockState blockState) {
+        return lockManager.runAsyncWithLock(getBlockKey(blockState), () -> setFalse(blockState));
     }
 
     @Override
@@ -509,5 +554,18 @@ public class HashChunkManager implements ChunkManager {
     public static String getChunkKey(World world, int cx, int cz) {
         if (world == null) return UUID.randomUUID().toString();
         return world.getName() + "," + cx + "," + cz;
+    }
+
+    public static String getBlockKey(World world, int x, int y, int z) {
+        if (world == null) return UUID.randomUUID().toString();
+        return world.getName() + "," + x + "," + y + "," + z;
+    }
+
+    public static String getBlockKey(Block block) {
+        return getBlockKey(block.getWorld(), block.getX(), block.getY(), block.getZ());
+    }
+
+    public static String getBlockKey(BlockState state) {
+        return getBlockKey(state.getWorld(), state.getX(), state.getY(), state.getZ());
     }
 }

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/LockManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/LockManager.java
@@ -1,0 +1,34 @@
+package com.gmail.nossr50.util.blockmeta.chunkmeta;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+public class LockManager {
+
+    private final Map<String, Object> keyLocks = new ConcurrentHashMap<>();
+
+    private Object newLock(String key) {
+        return keyLocks.computeIfAbsent(key, k -> new Object());
+    }
+
+    public CompletableFuture<Void> runAsyncWithLock(String key, Runnable runnable) {
+        return CompletableFuture.runAsync(() -> {
+            synchronized (newLock(key)) {
+                runnable.run();
+                keyLocks.remove(key);
+            }
+        });
+    }
+
+    public <U> CompletableFuture<U> supplyAsyncWithLock(String key, Supplier<U> supplier) {
+        return CompletableFuture.supplyAsync(() -> {
+            synchronized (newLock(key)) {
+                U obj = supplier.get();
+                keyLocks.remove(key);
+                return obj;
+            }
+        });
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/NullChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/NullChunkManager.java
@@ -121,8 +121,18 @@ public class NullChunkManager implements ChunkManager {
     }
 
     @Override
+    public CompletableFuture<Boolean> isTrueAsync(int x, int y, int z, World world) {
+        return CompletableFuture.completedFuture(false);
+    }
+
+    @Override
     public boolean isTrue(Block block) {
         return false;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isTrueAsync(Block block) {
+        return CompletableFuture.completedFuture(false);
     }
 
     @Override
@@ -131,22 +141,57 @@ public class NullChunkManager implements ChunkManager {
     }
 
     @Override
+    public CompletableFuture<Boolean> isTrueAsync(BlockState blockState) {
+        return CompletableFuture.completedFuture(false);
+    }
+
+    @Override
     public void setTrue(int x, int y, int z, World world) {}
+
+    @Override
+    public CompletableFuture<Void> setTrueAsync(int x, int y, int z, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void setTrue(Block block) {}
 
     @Override
+    public CompletableFuture<Void> setTrueAsync(Block block) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void setTrue(BlockState blockState) {}
+
+    @Override
+    public CompletableFuture<Void> setTrueAsync(BlockState blockState) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void setFalse(int x, int y, int z, World world) {}
 
     @Override
+    public CompletableFuture<Void> setFalseAsync(int x, int y, int z, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void setFalse(Block block) {}
 
     @Override
+    public CompletableFuture<Void> setFalseAsync(Block block) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void setFalse(BlockState blockState) {}
+
+    @Override
+    public CompletableFuture<Void> setFalseAsync(BlockState blockState) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void cleanUp() {}

--- a/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/NullChunkManager.java
+++ b/src/main/java/com/gmail/nossr50/util/blockmeta/chunkmeta/NullChunkManager.java
@@ -6,6 +6,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 public class NullChunkManager implements ChunkManager {
 
@@ -18,25 +19,65 @@ public class NullChunkManager implements ChunkManager {
     }
 
     @Override
+    public CompletableFuture<ChunkStore> readChunkStoreAsync(World world, int x, int z) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void writeChunkStore(World world, int x, int z, ChunkStore data) {}
+
+    @Override
+    public CompletableFuture<Void> writeChunkStoreAsync(World world, int x, int z, ChunkStore data) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void closeChunkStore(World world, int x, int z) {}
 
     @Override
+    public CompletableFuture<Void> closeChunkStoreAsync(World world, int x, int z) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void loadChunklet(int cx, int cy, int cz, World world) {}
+
+    @Override
+    public CompletableFuture<Void> loadChunkletAsync(int cx, int cy, int cz, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void unloadChunklet(int cx, int cy, int cz, World world) {}
 
     @Override
+    public CompletableFuture<Void> unloadChunkletAsync(int cx, int cy, int cz, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void loadChunk(int cx, int cz, World world, Entity[] entities) {}
+
+    @Override
+    public CompletableFuture<Void> loadChunkAsync(int cx, int cz, World world, Entity[] entities) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void unloadChunk(int cx, int cz, World world) {}
 
     @Override
+    public CompletableFuture<Void> unloadChunkAsync(int cx, int cz, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void saveChunk(int cx, int cz, World world) {}
+
+    @Override
+    public CompletableFuture<Void> saveChunkAsync(int cx, int cz, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public boolean isChunkLoaded(int cx, int cz, World world) {
@@ -47,7 +88,17 @@ public class NullChunkManager implements ChunkManager {
     public void chunkLoaded(int cx, int cz, World world) {}
 
     @Override
+    public CompletableFuture<Void> chunkLoadedAsync(int cx, int cz, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public void chunkUnloaded(int cx, int cz, World world) {}
+
+    @Override
+    public CompletableFuture<Void> chunkUnloadedAsync(int cx, int cz, World world) {
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void saveWorld(World world) {}


### PR DESCRIPTION
This PR aims to solve the synchronous writes mcMMO does when chunk meta needs to be written to the disk. Consistency between loads/unloads are guarded by `LockManager`, which ensures only one worker thread can access a chunk/block at a time.