### PR TITLE
Adding crossbows, shields, elytra, and tridents to default repair.vanilla.yml and fixing minor typo.

### DIFF
--- a/src/main/resources/repair.vanilla.yml
+++ b/src/main/resources/repair.vanilla.yml
@@ -45,6 +45,14 @@ Repairables:
     # Wooden repairables
     ###
     # Tools
+    SHIELD:
+        MinimumLevel: 0
+        XpMultiplier: .25
+        ItemType: OTHER
+        ItemMaterialCategory: WOOD
+        RepairMaterial: OAK_PLANKS
+        MinimumQuantity: 6
+        MaximumDurability: 336
     WOODEN_SWORD:
         MinimumLevel: 0
         XpMultiplier: .25
@@ -183,7 +191,7 @@ Repairables:
         XpMultiplier: 6
 
     #
-    # Diamond repairables
+    # Netherite repairables
     ###
     # Tools
     NETHERITE_SWORD:
@@ -243,3 +251,30 @@ Repairables:
     CARROT_ON_A_STICK:
         MinimumLevel: 0
         XpMultiplier: .5
+    CROSSBOW:
+        MinimumLevel: 0
+        XpMultiplier: .5
+        ItemType: TOOL
+        ItemMaterialCategory: STRING
+        RepairMaterial: STRING
+        MinimumQuantity: 3
+        MaximumDurability: 326
+    #
+    # Other
+    ###
+    ELYTRA:
+        MinimumLevel: 0
+        XpMultiplier: 3
+        ItemType: OTHER
+        ItemMaterialCategory: OTHER
+        RepairMaterial: PHANTOM_MEMBRANE
+        MinimumQuantity: 8
+        MaximumDurability: 432
+    TRIDENT:
+        MinimumLevel: 0
+        XpMultiplier: 3
+        ItemType: TOOL
+        ItemMaterialCategory: OTHER
+        RepairMaterial: PRISMARINE_CRYSTALS
+        MinimumQuantity: 16
+        MaximumDurability: 250

--- a/src/main/resources/repair.vanilla.yml
+++ b/src/main/resources/repair.vanilla.yml
@@ -259,6 +259,14 @@ Repairables:
         RepairMaterial: STRING
         MinimumQuantity: 3
         MaximumDurability: 326
+    WARPED_FUNGUS_ON_A_STICK:
+        MinimumLevel: 0
+        XpMultiplier: .5
+        ItemType: TOOL
+        ItemMaterialCategory: STRING
+        RepairMaterial: STRING
+        MinimumQuantity: 3
+        MaximumDurability: 100
     #
     # Other
     ###


### PR DESCRIPTION
Changed comment over netherite items to say "Netherite repairables" instead of "Diamond repairables"

Added Crossbow to string repairables
Added Shield to wood repairables, with oak planks as material
Added Elytra and Trident to Other repairables, using phantom membrane and prismarine crystals respectively.