### PR TITLE
Two small fixes

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -31,6 +31,7 @@ import com.gmail.nossr50.util.skills.SkillActivationType;
 import com.gmail.nossr50.worldguard.WorldGuardManager;
 import com.gmail.nossr50.worldguard.WorldGuardUtils;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
@@ -53,6 +54,12 @@ import org.jetbrains.annotations.NotNull;
 public class EntityListener implements Listener {
     private final mcMMO pluginRef;
     private final @NotNull AbstractPersistentDataLayer persistentDataLayer;
+
+    /**
+     * We can use this {@link NamespacedKey} for {@link Enchantment} comparisons to
+     * check if a {@link Player} has a {@link Trident} enchanted with "Piercing".
+     */
+    private final NamespacedKey piercingEnchantment = NamespacedKey.minecraft("piercing");
 
     public EntityListener(final mcMMO pluginRef) {
         this.pluginRef = pluginRef;
@@ -161,9 +168,10 @@ public class EntityListener implements Listener {
             projectile.setMetadata(mcMMO.bowForceKey, new FixedMetadataValue(pluginRef, 1.0));
             projectile.setMetadata(mcMMO.arrowDistanceKey, new FixedMetadataValue(pluginRef, projectile.getLocation()));
 
-            for(Enchantment enchantment : player.getInventory().getItemInMainHand().getEnchantments().keySet()) {
-                if(enchantment.getName().equalsIgnoreCase("piercing"))
+            for (Enchantment enchantment : player.getInventory().getItemInMainHand().getEnchantments().keySet()) {
+                if (enchantment.getKey().equals(piercingEnchantment)) {
                     return;
+                }
             }
 
             if (RandomChanceUtil.isActivationSuccessful(SkillActivationType.RANDOM_LINEAR_100_SCALE_WITH_CAP, SubSkillType.ARCHERY_ARROW_RETRIEVAL, player)) {

--- a/src/main/java/com/gmail/nossr50/runnables/skills/BleedTimerTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/skills/BleedTimerTask.java
@@ -69,9 +69,11 @@ public class BleedTimerTask extends BukkitRunnable {
                 }
 
                 //Count Armor
-                for(ItemStack armorPiece : ((Player) target).getInventory().getArmorContents())
-                {
-                    armorCount++;
+                for (ItemStack armorPiece : ((Player) target).getInventory().getArmorContents()) {
+                    //We only want to count slots that contain armor.
+                    if (armorPiece != null) {
+                        armorCount++;
+                    }
                 }
 
             } else {


### PR DESCRIPTION
## 1. Fixed `armorCount`
`#getArmorContents()` will always return an array of length 4, individual items are nullable though, so the snippet below will always result in `armorCount` being equal to four. As it should only count the actually equipped armorpieces though, this behaviour was corrected to include a null-check.

```java
for(ItemStack armorPiece : ((Player) target).getInventory().getArmorContents())
{
    armorCount++;
}
```

## 2. Piercing Enchantment
Enchantment names are deprecated since a while, as they are not only inconsistently named but may also not be guaranteed to remain unique in future versions.
That's why comparisons should rather use a NamespacedKey instead.
I changed a small bit in `EntityListener` for that, to look for a `minecraft:piercing` enchantment instead.