### PR TITLE
Feature: Show the name of the party who's chat you're toggling into

### DIFF
--- a/src/main/java/com/gmail/nossr50/chat/ChatManager.java
+++ b/src/main/java/com/gmail/nossr50/chat/ChatManager.java
@@ -127,11 +127,19 @@ public class ChatManager {
     public void setOrToggleChatChannel(@NotNull McMMOPlayer mmoPlayer, @NotNull ChatChannel targetChatChannel) {
         if(targetChatChannel == mmoPlayer.getChatChannel()) {
             //Disabled message
-            mmoPlayer.getPlayer().sendMessage(LocaleLoader.getString("Chat.Channel.Off", StringUtils.getCapitalized(targetChatChannel.toString())));
+            if (ChatConfig.getInstance().useChannelNames(targetChatChannel)) {
+                mmoPlayer.getPlayer().sendMessage(LocaleLoader.getString("Chat.Channel.Off", mmoPlayer.getParty().getName()));
+            } else {
+                mmoPlayer.getPlayer().sendMessage(LocaleLoader.getString("Chat.Channel.Off", StringUtils.getCapitalized(targetChatChannel.toString())));
+            }
             mmoPlayer.setChatMode(ChatChannel.NONE);
         } else {
             mmoPlayer.setChatMode(targetChatChannel);
-            mmoPlayer.getPlayer().sendMessage(LocaleLoader.getString("Chat.Channel.On", StringUtils.getCapitalized(targetChatChannel.toString())));
+            if (ChatConfig.getInstance().useChannelNames(targetChatChannel)) {
+                mmoPlayer.getPlayer().sendMessage(LocaleLoader.getString("Chat.Channel.On", mmoPlayer.getParty().getName()));
+            } else {
+                mmoPlayer.getPlayer().sendMessage(LocaleLoader.getString("Chat.Channel.On", StringUtils.getCapitalized(targetChatChannel.toString())));
+            }
         }
     }
 

--- a/src/main/java/com/gmail/nossr50/config/ChatConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/ChatConfig.java
@@ -49,6 +49,16 @@ public class ChatConfig extends AutoUpdateConfigLoader {
         return config.getBoolean(key, true);
     }
 
+    /**
+     * Whether or not to use the current party name of a players party {@link ChatChannel}
+     * @param chatChannel target chat channel
+     * @return true if party name should be used
+     */
+    public boolean useChannelNames(@NotNull ChatChannel chatChannel){
+        String key = "Chat.Channels." + StringUtils.getCapitalized(chatChannel.toString()) + ".Use_Channel_Names";
+        return config.getBoolean(key, false);
+    }
+
     public boolean isSpyingAutomatic() {
         return config.getBoolean("Chat.Channels.Party.Spies.Automatically_Enable_Spying", false);
     }

--- a/src/main/resources/chat.yml
+++ b/src/main/resources/chat.yml
@@ -8,6 +8,8 @@ Chat:
             Enable: true
             # Whether or not to use the current display name of a player
             Use_Display_Names: true
+            # Whether or not to use the current party name of a players party
+            Use_Channel_Names: false
             Spies:
                 # Whether or not players with the chat spy permission join the server with chat spying toggled on
                 Automatically_Enable_Spying: false


### PR DESCRIPTION
This pr adds the Use_Channel_Names option to the chat.yml config. It's false by default.

When false the behavior remains the same as before and it simply says if you're joining or leaving Party/Admin chat. When true it uses the party name of the user who's toggling their chat channel. If the channel is the Admin chat it defaults to false since Admin doesn't have the Use_Channel_Names option.

(Note: This is a copy of #4340 because I'm not that well versed in git and merged the branch into my master and started working on it more for something else, this time I'll be sure to keep it separate)