### PR TITLE
Updated bStats dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                         </relocation>
                         <relocation>
                             <pattern>org.bstats</pattern>
-                            <shadedPattern>com.gmail.nossr50.mcmmo.metrics.bstat</shadedPattern>
+                            <shadedPattern>com.gmail.nossr50.mcmmo.metrics.bstats</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.4</version>
+            <version>1.8</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -253,7 +253,7 @@ public class mcMMO extends JavaPlugin {
             Metrics metrics;
 
             if(Config.getInstance().getIsMetricsEnabled()) {
-                metrics = new Metrics(this);
+                metrics = new Metrics(this, 3894);
                 metrics.addCustomChart(new Metrics.SimplePie("version", () -> getDescription().getVersion()));
 
                 if(Config.getInstance().getIsRetroMode())


### PR DESCRIPTION
While building a project against mcMMO, I noticed that it uses a pretty old version of bStats.
So I decided to update this dependency for you.
Especially version 1.7 and 1.8 of bStats-Metrics saw some pretty important changes (sources further below).
Most noteworthy, bStats uses an id-system nowadays and mcMMO still sends its data to the deprecated non-id-compatible url.

Here's the bStats page for mcMMO where I found the id:
https://bstats.org/plugin/bukkit/mcMMO/3894 (ID: 3894)

It is a pretty small change but it's never a bad thing to update stuff and do some chores :)

## Changes
* Updated bStats version to `1.8` (latest at this time)
* Fixed typo in the relocation path (missing 's')
* Added id parameter to the `Metrics` constructor

## Sources
Here are two announcements that Bastian (the developer of bStats) posted on discord in regards to why these two updates are particularly important.
```
I've just released version 1.7 of the Metrics classes. This new version requires you to provide a plugin id when creating the Metrics class. [...]
You can find the ids of your plugins at the https://bstats.org/what-is-my-plugin-id page or by just looking at the url when visiting the bStats page of your plugin (e.g. my plugin SafeTrade https://bstats.org/plugin/bukkit/SafeTrade/4 has the plugin id 4).

It is still not possible to have multiple plugins with the same name, but it will be soon!
```
Source : https://discord.com/channels/260708924481601539/283548939893080064/669176875486281758

```
I've just released version 1.8 of the Metrics classes.
It turns out that a lot of server tend to restart at a fixed time at xx:00. The previous Metrics classes had a fixed 5 minute delay for sending data to bStats. This—combined with the fixed restart times of some servers—causes a significant increase in requests (more than doubled) to bStats at the xx:05 and xx:35 mark. The new Metrics classes introduce a bit of randomness in the delay to evenly distribute the requests.

This update is not important but I would appreciate if you update bStats together with the next version of your plugin. :slight_smile:
```
Source: https://discord.com/channels/260708924481601539/283548939893080064/789836211802996767