### PR TITLE
Fix for impact armor damage formula

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/axes/AxesManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/axes/AxesManager.java
@@ -120,7 +120,7 @@ public class AxesManager extends SkillManager {
         for (ItemStack armor : target.getEquipment().getArmorContents()) {
             if (armor != null && ItemUtils.isArmor(armor)) {
                 if (RandomChanceUtil.isActivationSuccessful(SkillActivationType.RANDOM_STATIC_CHANCE, SubSkillType.AXES_ARMOR_IMPACT, getPlayer())) {
-                    SkillUtils.handleDurabilityChange(armor, durabilityDamage, 1);
+                    SkillUtils.handleArmorDurabilityChange(armor, durabilityDamage, 1);
                 }
             }
         }

--- a/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
@@ -239,7 +239,7 @@ public final class SkillUtils {
     }
 
     /**
-     * Modify the durability of an ItemStack.
+     * Modify the durability of an ItemStack, using Tools specific formula for unbreaking enchant damage reduction
      *
      * @param itemStack The ItemStack which durability should be modified
      * @param durabilityModifier the amount to modify the durability by
@@ -253,6 +253,36 @@ public final class SkillUtils {
         Material type = itemStack.getType();
         short maxDurability = mcMMO.getRepairableManager().isRepairable(type) ? mcMMO.getRepairableManager().getRepairable(type).getMaximumDurability() : type.getMaxDurability();
         durabilityModifier = (int) Math.min(durabilityModifier / (itemStack.getEnchantmentLevel(Enchantment.DURABILITY) + 1), maxDurability * maxDamageModifier);
+
+        itemStack.setDurability((short) Math.min(itemStack.getDurability() + durabilityModifier, maxDurability));
+    }
+
+    private static boolean isLocalizedSkill(String skillName) {
+        for (PrimarySkillType skill : PrimarySkillType.values()) {
+            if (skillName.equalsIgnoreCase(LocaleLoader.getString(StringUtils.getCapitalized(skill.toString()) + ".SkillName"))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    
+    
+    /**
+     * Modify the durability of an ItemStack, using Armor specific formula for unbreaking enchant damage reduction
+     *
+     * @param itemStack The ItemStack which durability should be modified
+     * @param durabilityModifier the amount to modify the durability by
+     * @param maxDamageModifier the amount to adjust the max damage by
+     */
+    public static void handleArmorDurabilityChange(ItemStack itemStack, double durabilityModifier, double maxDamageModifier) {
+        if(itemStack.getItemMeta() != null && itemStack.getItemMeta().isUnbreakable()) {
+            return;
+        }
+
+        Material type = itemStack.getType();
+        short maxDurability = mcMMO.getRepairableManager().isRepairable(type) ? mcMMO.getRepairableManager().getRepairable(type).getMaximumDurability() : type.getMaxDurability();
+        durabilityModifier = (int) Math.min(durabilityModifier * (0.6 + 0.4/ (itemStack.getEnchantmentLevel(Enchantment.DURABILITY) + 1)), maxDurability * maxDamageModifier);
 
         itemStack.setDurability((short) Math.min(itemStack.getDurability() + durabilityModifier, maxDurability));
     }

--- a/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/SkillUtils.java
@@ -246,7 +246,7 @@ public final class SkillUtils {
      * @param maxDamageModifier the amount to adjust the max damage by
      */
     public static void handleDurabilityChange(ItemStack itemStack, double durabilityModifier, double maxDamageModifier) {
-        if(itemStack.getItemMeta() != null && itemStack.getItemMeta().isUnbreakable()) {
+        if(itemStack.hasItemMeta() && itemStack.getItemMeta().isUnbreakable()) {
             return;
         }
 
@@ -276,7 +276,7 @@ public final class SkillUtils {
      * @param maxDamageModifier the amount to adjust the max damage by
      */
     public static void handleArmorDurabilityChange(ItemStack itemStack, double durabilityModifier, double maxDamageModifier) {
-        if(itemStack.getItemMeta() != null && itemStack.getItemMeta().isUnbreakable()) {
+        if(itemStack.hasItemMeta() && itemStack.getItemMeta().isUnbreakable()) {
             return;
         }
 
@@ -285,16 +285,6 @@ public final class SkillUtils {
         durabilityModifier = (int) Math.min(durabilityModifier * (0.6 + 0.4/ (itemStack.getEnchantmentLevel(Enchantment.DURABILITY) + 1)), maxDurability * maxDamageModifier);
 
         itemStack.setDurability((short) Math.min(itemStack.getDurability() + durabilityModifier, maxDurability));
-    }
-
-    private static boolean isLocalizedSkill(String skillName) {
-        for (PrimarySkillType skill : PrimarySkillType.values()) {
-            if (skillName.equalsIgnoreCase(LocaleLoader.getString(StringUtils.getCapitalized(skill.toString()) + ".SkillName"))) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     @Nullable


### PR DESCRIPTION
As specified on https://minecraft.gamepedia.com/Unbreaking#Usage
Unbreaking enchant uses different formula for durability reduction on tools and armor

Using the wrong formula caused axes impact skill to be almost useless on armors with unbreaking enchant lv 3 and very overpowering armors without unbreaking enchant:
50% armor durability damage reduction on unbreaking enchant lv 1
67% armor durability damage reduction on unbreaking enchant lv 2
75% armor durability damage reduction on unbreaking enchant lv 3

This fix aim to a vanilla behavior for armor durability damage: 
20% armor durability damage reduction on unbreaking enchant lv 1
27% armor durability damage reduction on unbreaking enchant lv 2
30% armor durability damage reduction on unbreaking enchant lv 3