### PR TITLE
Added Maven workflow to validate pull requests and commits

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,40 @@
+# This workflow automatically tests new commits and pull requests as they come in.
+# Note that this does not upload any artifacts, you will need to compile mcMMO manually
+# if you wish to create the actual jar.
+name: Compile and test
+
+on:
+  # We run our tests whenever the pom or a source file was touched.
+  # There is no need to run Maven when only the changelog was touched.
+  push:
+    paths:
+    - 'src/**'
+    - 'pom.xml'
+
+  # Whenever someone submits a new pull request which modified the pom or a source file,
+  # we want to ensure it compiles successfully and that all tests will pass.
+  pull_request:
+    paths:
+    - 'src/**'
+    - 'pom.xml'
+
+jobs:
+  compile:
+    name: Maven compiler
+    runs-on: ubuntu-latest
+    steps:
+
+    # 1. Check out the current working tree
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # 2. Setup Java 1.8 JDK
+    - name: Java 1.8 setup
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-package: jdk
+        java-version: 1.8
+
+    # 3. Build via Maven 
+    - name: Build via Maven
+      run: mvn clean verify -B --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,6 +46,6 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
-    # 3. Build via Maven 
+    # 4. Build via Maven 
     - name: Build via Maven
       run: mvn verify -B --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,10 +6,13 @@ name: Compile and test
 on:
   # We run our tests whenever the pom or a source file was touched.
   # There is no need to run Maven when only the changelog was touched.
+  # We may also want to re-run this workflow when the workflow file itself
+  # was updated too.
   push:
     paths:
     - 'src/**'
     - 'pom.xml'
+    - '.github/workflows/maven.yml'
 
   # Whenever someone submits a new pull request which modified the pom or a source file,
   # we want to ensure it compiles successfully and that all tests will pass.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,6 +38,14 @@ jobs:
         java-package: jdk
         java-version: 1.8
 
+    # 3. Setup local Maven package cache to speed up building
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
     # 3. Build via Maven 
     - name: Build via Maven
-      run: mvn clean verify -B --file pom.xml
+      run: mvn verify -B --file pom.xml


### PR DESCRIPTION
As discussed on discord - I am making a pull request to add a GH Actions workflow which will automatically compile and test commits and pull requests.

I made sure to thoroughly document everything and outline which step does what.
The action only runs where necessary, if you prefer to have it only run on pull requests, the push section can just be removed from the workflow.

This also utilises the `actions/cache` action which will use the local .m2 Maven cache to speed up building.
For mcMMO this resulted in 2m7s of compile time vs. 3m30s.

The action will flag any pull request in case the proposed changes won't compile successfully or fail any of the unit tests.
It may speed up pull requests review in the future as broken changes can be easily spotted.
This also does not upload/distribute the resulting jar.