### PR TITLE
Fixed #4438 and also normalized some stuff

### DIFF
--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -52,7 +52,6 @@ import com.gmail.nossr50.util.skills.RankUtils;
 import com.gmail.nossr50.util.skills.SmeltingTracker;
 import com.gmail.nossr50.util.upgrade.UpgradeManager;
 import com.gmail.nossr50.worldguard.WorldGuardManager;
-import com.google.common.base.Charsets;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.shatteredlands.shatt.backup.ZipLibrary;
 import org.bstats.bukkit.Metrics;
@@ -62,11 +61,14 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -124,24 +126,24 @@ public class mcMMO extends JavaPlugin {
     private static boolean isRetroModeEnabled;
 
     /* Metadata Values */
-    public final static String REPLANT_META_KEY = "mcMMO: Recently Replanted";
+    public static final String REPLANT_META_KEY      = "mcMMO: Recently Replanted";
     public static final String FISH_HOOK_REF_METAKEY = "mcMMO: Fish Hook Tracker";
-    public static final String DODGE_TRACKER        = "mcMMO: Dodge Tracker";
+    public static final String DODGE_TRACKER         = "mcMMO: Dodge Tracker";
     public static final String CUSTOM_DAMAGE_METAKEY = "mcMMO: Custom Damage";
-    public final static String travelingBlock      = "mcMMO: Traveling Block";
-    public final static String blockMetadataKey    = "mcMMO: Piston Tracking";
-    public final static String tntMetadataKey      = "mcMMO: Tracked TNT";
-    public final static String customNameKey       = "mcMMO: Custom Name";
-    public final static String customVisibleKey    = "mcMMO: Name Visibility";
-    public final static String droppedItemKey      = "mcMMO: Tracked Item";
-    public final static String infiniteArrowKey    = "mcMMO: Infinite Arrow";
-    public final static String trackedArrow        = "mcMMO: Tracked Arrow";
-    public final static String bowForceKey         = "mcMMO: Bow Force";
-    public final static String arrowDistanceKey    = "mcMMO: Arrow Distance";
-    public final static String BONUS_DROPS_METAKEY = "mcMMO: Double Drops";
-    public final static String disarmedItemKey     = "mcMMO: Disarmed Item";
-    public final static String playerDataKey       = "mcMMO: Player Data";
-    public final static String databaseCommandKey  = "mcMMO: Processing Database Command";
+    public static final String travelingBlock        = "mcMMO: Traveling Block";
+    public static final String blockMetadataKey      = "mcMMO: Piston Tracking";
+    public static final String tntMetadataKey        = "mcMMO: Tracked TNT";
+    public static final String customNameKey         = "mcMMO: Custom Name";
+    public static final String customVisibleKey      = "mcMMO: Name Visibility";
+    public static final String droppedItemKey        = "mcMMO: Tracked Item";
+    public static final String infiniteArrowKey      = "mcMMO: Infinite Arrow";
+    public static final String trackedArrow          = "mcMMO: Tracked Arrow";
+    public static final String bowForceKey           = "mcMMO: Bow Force";
+    public static final String arrowDistanceKey      = "mcMMO: Arrow Distance";
+    public static final String BONUS_DROPS_METAKEY   = "mcMMO: Double Drops";
+    public static final String disarmedItemKey       = "mcMMO: Disarmed Item";
+    public static final String playerDataKey         = "mcMMO: Player Data";
+    public static final String databaseCommandKey    = "mcMMO: Processing Database Command";
 
     public static FixedMetadataValue metadataValue;
 
@@ -158,7 +160,9 @@ public class mcMMO extends JavaPlugin {
             //Platform Manager
             platformManager = new PlatformManager();
 
+            //Filter out any debug messages (if debug/verbose logging is not enabled)
             getLogger().setFilter(new LogFilter(this));
+
             metadataValue = new FixedMetadataValue(this, true);
 
             PluginManager pluginManager = getServer().getPluginManager();
@@ -273,6 +277,9 @@ public class mcMMO extends JavaPlugin {
             }
 
             getServer().getPluginManager().disablePlugin(this);
+
+            //Fixes #4438 - Don't initialize things if we are going to disable mcMMO anyway
+            return;
         }
 
         //Init player level values
@@ -284,6 +291,7 @@ public class mcMMO extends JavaPlugin {
         //Init smelting tracker
         smeltingTracker = new SmeltingTracker();
 
+        //Set up Adventure's audiences
         audiences = BukkitAudiences.create(this);
 
         transientMetadataTools = new TransientMetadataTools(this);
@@ -347,8 +355,9 @@ public class mcMMO extends JavaPlugin {
             holidayManager.saveAnniversaryFiles();
             placeStore.closeAll();
         }
-
-        catch (Exception e) { e.printStackTrace(); }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
 
         if (Config.getInstance().getBackupsEnabled()) {
             // Remove other tasks BEFORE starting the Backup, or we just cancel it straight away.
@@ -358,14 +367,12 @@ public class mcMMO extends JavaPlugin {
             catch (IOException e) {
                 getLogger().severe(e.toString());
             }
+            catch(NoClassDefFoundError e) {
+                getLogger().severe("Backup class not found!");
+                getLogger().info("Please do not replace the mcMMO jar while the server is running."); 
+            }
             catch (Throwable e) {
-                if (e instanceof NoClassDefFoundError) {
-                    getLogger().severe("Backup class not found!");
-                    getLogger().info("Please do not replace the mcMMO jar while the server is running.");
-                }
-                else {
-                    getLogger().severe(e.toString());
-                }
+                getLogger().severe(e.toString());
             }
         }
 
@@ -682,9 +689,9 @@ public class mcMMO extends JavaPlugin {
         }
     }
 
-    public InputStreamReader getResourceAsReader(String fileName) {
+    public @Nullable InputStreamReader getResourceAsReader(@NotNull String fileName) {
         InputStream in = getResource(fileName);
-        return in == null ? null : new InputStreamReader(in, Charsets.UTF_8);
+        return in == null ? null : new InputStreamReader(in, StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
This pull request fixes #4438 by aborting the enabling process if we are going to disable the plugin anyway.
I also replaced Google Common's Charsets reference with Java's `StandardCharsets` since there is not really any reason as to why we should rely on Google Commons here when Java provides a native value too.
I also went ahead and normalized the `static final` vs. `final static` order on some of these fields to make it more consistent and split a catch-block which contained an if-statement into two dedicated catch-blocks.