### PR TITLE
Updated dependencies (also fixes #4404)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
                             <include>commons-logging:commons-logging</include>
                             <include>org.apache.tomcat:tomcat-jdbc</include>
                             <include>org.apache.tomcat:tomcat-juli</include>
+                            <include>org.bstats:bstats-base</include>
                             <include>org.bstats:bstats-bukkit</include>
                             <include>net.kyori:adventure-api</include>
                             <include>net.kyori:adventure-text-serializer-gson</include>
@@ -208,27 +209,27 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.4.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.4.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-nbt</artifactId>
-            <version>4.4.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-key</artifactId>
-            <version>4.4.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson-legacy-impl</artifactId>
-            <version>4.4.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
@@ -253,13 +254,13 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.8</version>
+            <version>2.2.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -307,7 +308,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.4.6</version>
+            <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -55,6 +55,7 @@ import com.gmail.nossr50.worldguard.WorldGuardManager;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.shatteredlands.shatt.backup.ZipLibrary;
 import org.bstats.bukkit.Metrics;
+import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
@@ -258,12 +259,12 @@ public class mcMMO extends JavaPlugin {
 
             if(Config.getInstance().getIsMetricsEnabled()) {
                 metrics = new Metrics(this, 3894);
-                metrics.addCustomChart(new Metrics.SimplePie("version", () -> getDescription().getVersion()));
+                metrics.addCustomChart(new SimplePie("version", () -> getDescription().getVersion()));
 
                 if(Config.getInstance().getIsRetroMode())
-                    metrics.addCustomChart(new Metrics.SimplePie("leveling_system", () -> "Retro"));
+                    metrics.addCustomChart(new SimplePie("leveling_system", () -> "Retro"));
                 else
-                    metrics.addCustomChart(new Metrics.SimplePie("leveling_system", () -> "Standard"));
+                    metrics.addCustomChart(new SimplePie("leveling_system", () -> "Standard"));
             }
         }
         catch (Throwable t) {


### PR DESCRIPTION
This pull request resolves #4404 by updating to KyoriPowered/Adventure v4.5.1, see KyoriPowered/Adventure#266.
I also went ahead and updated other dependencies too:
* Spigot-API to MC 1.16.5
* Mockito to v3.8.0

Additionally, bStats was also bumped to v2.2.1, as bStats is now split into a base component and an implementation component, bStats-base is now shaded along with it to prevent the usual relocation errors.
The `SimplePie` import was adjusted as well, since it is now its own class.