### PR TITLE
Fixed NoClassDefFoundError caused by latest Adventure-platform snapshot.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,27 +219,27 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.5.1</version>
+            <version>4.7.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.5.1</version>
+            <version>4.7.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-nbt</artifactId>
-            <version>4.5.1</version>
+            <version>4.7.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-key</artifactId>
-            <version>4.5.1</version>
+            <version>4.7.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson-legacy-impl</artifactId>
-            <version>4.5.1</version>
+            <version>4.7.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>


### PR DESCRIPTION
When compiling the current state of mcMMO, the resulting jar causes a `NoClassDefFoundError` due to a class not being found which was recently added to [KyoriPowered/adventure](https://github.com/KyoriPowered/adventure) (https://github.com/KyoriPowered/adventure/pull/302).

However... since [KyoriPowered/adventure-platform](https://github.com/KyoriPowered/adventure-platform) uses a `-SNAPSHOT` versioning system, the platform module was updated to build against `4.7.0`, we are building against `adventure-platform` `4.0.0-SNAPSHOT` but only against Adventure `4.5.1`. So our shaded `adventure-platform` portion could not find the classes it was looking for, resulting in the following error.

To fix it, we just need to bump adventure to `4.7.0` once more and we can compile and use mcMMO like before.
```
java.lang.NoClassDefFoundError: com/gmail/nossr50/mcmmo/kyori/adventure/text/flattener/ComponentFlattener
[...]
Caused by: java.lang.ClassNotFoundException: com.gmail.nossr50.mcmmo.kyori.adventure.text.flattener.ComponentFlattener
```
(Source: https://gist.github.com/Demon-tk/943e82577ea92bd9270062f97387d703)

**TL;DR Bumped adventure versions to 4.7.0 (latest at this point in time)**