### PR TITLE
Add '.all' to all existing perk xp multipliers

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -135,7 +135,7 @@ public final class Permissions {
     
     public static boolean doubleXp(Permissible permissible, PrimarySkillType skill) { 
         return permissible.hasPermission("mcmmo.perks.xp.double.all")
-            || return permissible.hasPermission("mcmmo.perks.xp.double." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+            || permissible.hasPermission("mcmmo.perks.xp.double." + skill.toString().toLowerCase(Locale.ENGLISH)); 
     }
     
     public static boolean oneAndOneHalfXp(Permissible permissible, PrimarySkillType skill) { 

--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -118,16 +118,39 @@ public final class Permissions {
     public static boolean lucky(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.lucky." + skill.toString().toLowerCase(Locale.ENGLISH)); }
 
     /* XP PERKS */
-    public static boolean quadrupleXp(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.xp.quadruple." + skill.toString().toLowerCase(Locale.ENGLISH)); }
-    public static boolean tripleXp(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.xp.triple." + skill.toString().toLowerCase(Locale.ENGLISH)); }
-    public static boolean doubleAndOneHalfXp(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.xp.150percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); }
-    public static boolean doubleXp(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.xp.double." + skill.toString().toLowerCase(Locale.ENGLISH)); }
-    public static boolean oneAndOneHalfXp(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.xp.50percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); }
-    public static boolean oneAndOneTenthXp(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.xp.10percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); }
+    public static boolean quadrupleXp(Permissible permissible, PrimarySkillType skill) { 
+        return permissible.hasPermission("mcmmo.perks.xp.quadruple.all")
+            || permissible.hasPermission("mcmmo.perks.xp.quadruple." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+    }
+    
+    public static boolean tripleXp(Permissible permissible, PrimarySkillType skill) { 
+        return permissible.hasPermission("mcmmo.perks.xp.triple.all")
+            || permissible.hasPermission("mcmmo.perks.xp.triple." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+    }
+    
+    public static boolean doubleAndOneHalfXp(Permissible permissible, PrimarySkillType skill) { 
+        return permissible.hasPermission("mcmmo.perks.xp.150percentboost.all")
+            || permissible.hasPermission("mcmmo.perks.xp.150percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+    }
+    
+    public static boolean doubleXp(Permissible permissible, PrimarySkillType skill) { 
+        return permissible.hasPermission("mcmmo.perks.xp.double.all")
+            || return permissible.hasPermission("mcmmo.perks.xp.double." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+    }
+    
+    public static boolean oneAndOneHalfXp(Permissible permissible, PrimarySkillType skill) { 
+        return permissible.hasPermission("mcmmo.perks.xp.50percentboost.all")
+            || permissible.hasPermission("mcmmo.perks.xp.50percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+    }
+    
+    public static boolean oneAndOneTenthXp(Permissible permissible, PrimarySkillType skill) { 
+        return permissible.hasPermission("mcmmo.perks.xp.10percentboost.all")
+            || permissible.hasPermission("mcmmo.perks.xp.10percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+    }
 
     public static boolean customXpBoost(Permissible permissible, PrimarySkillType skill) {
         return permissible.hasPermission("mcmmo.perks.xp.customboost.all")
-            ||permissible.hasPermission("mcmmo.perks.xp.customboost." + skill.toString().toLowerCase(Locale.ENGLISH));
+            || permissible.hasPermission("mcmmo.perks.xp.customboost." + skill.toString().toLowerCase(Locale.ENGLISH));
     }
 
 


### PR DESCRIPTION
Added '.all' usage for all existing perk xp mulipliers to enable use of mcmmo.perks.xp.<xpboost>.all

**Note** 
I believe I did this right but if not criticism/comments would be very much appreciated and accepted