### PR TITLE
Sanitize ability buffs when using Item Frames

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -990,16 +990,23 @@ public class PlayerListener implements Listener {
         if (event.getRightClicked() instanceof ItemFrame) {
             ItemFrame frame = (ItemFrame) event.getRightClicked();
 
-            // Check if an item can even be placed
-            if (frame.isFixed() || !frame.getItem().getType().isAir()) {
+            // Check for existing items (ignore rotations)
+            if (frame.getItem().getType() != Material.AIR) {
                 return;
             }
 
             // Get the item the Player is about to place
-            ItemStack item = event.getPlayer().getInventory().getItem(event.getHand());
-            
+            ItemStack itemInHand;
+
+            if (event.getHand() == EquipmentSlot.OFF_HAND) {
+                itemInHand = event.getPlayer().getInventory().getItemInOffHand();
+            }
+            else {
+                itemInHand = event.getPlayer().getInventory().getItemInMainHand();
+            }
+
             // and remove any skill ability buffs!
-            SkillUtils.removeAbilityBuff(item);
+            SkillUtils.removeAbilityBuff(itemInHand);
         }
     }
 

--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -973,6 +973,36 @@ public class PlayerListener implements Listener {
             }
         }
     }
+
+    /**
+     * When a {@link Player} attempts to place an {@link ItemStack}
+     * into an {@link ItemFrame}, we want to make sure to remove any
+     * Ability buffs from that item.
+     * 
+     * @param event The {@link PlayerInteractEntityEvent} to handle
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        /*
+         *  We can check for an instance instead of EntityType here, so we are
+         *  ready for the infamous "Glow Item Frame" in 1.17 too!
+         */
+        if (event.getRightClicked() instanceof ItemFrame) {
+            ItemFrame frame = (ItemFrame) event.getRightClicked();
+
+            // Check if an item can even be placed
+            if (frame.isFixed() || !frame.getItem().getType().isAir()) {
+                return;
+            }
+
+            // Get the item the Player is about to place
+            ItemStack item = event.getPlayer().getInventory().getItem(event.getHand());
+            
+            // and remove any skill ability buffs!
+            SkillUtils.removeAbilityBuff(item);
+        }
+    }
+
 //
 //    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 //    public void onPlayerStatisticIncrementEvent(PlayerStatisticIncrementEvent event) {


### PR DESCRIPTION
## Exposition
So someone has reported an exploit to us that involved Item Frames and utilities from other plugins.
However when looking into this, I quickly came to the conclusion that this should probably be patched on mcMMO's end to prevent future exploits with other plugins.

*For more info on the underlying issue, see https://github.com/Slimefun/Slimefun4/issues/2930*

## The fix
I saw that mcMMO does a pretty rigorous job of sanitizing the ability buff (enchantments) from items on multiple occasions (i.e. inventory opening, clicking on items and more).
However the core issue which lead to this exploit was the fact that placing an item into an Item Frame does not trigger such a cleanup. 
This is what this PR addresses, it is a small change but a significant one in terms of patching loopholes like these.

The event triggers on the `HIGH` priority and ignores previously cancelled events.
Feel free to suggest a different priority though if you think it should have rather been handled on `NORMAL` or something else.

## Testing results
I did test this before and after and can confirm that it has been patched successfully.
Furthermore, this is also compatible with MC 1.13 - 1.16 and ignores item rotations. It should only trigger when an item is actively placed into the item frame and the event has not been cancelled.