### PR TITLE
Small optimizations

### DIFF
--- a/src/main/java/com/gmail/nossr50/datatypes/player/McMMOPlayer.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/player/McMMOPlayer.java
@@ -65,11 +65,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -83,7 +82,7 @@ public class McMMOPlayer implements Identified {
     private final Player        player;
     private final PlayerProfile profile;
 
-    private final Map<PrimarySkillType, SkillManager> skillManagers = new HashMap<>();
+    private final Map<PrimarySkillType, SkillManager> skillManagers = new EnumMap<>(PrimarySkillType.class);
     private final ExperienceBarManager experienceBarManager;
 
     private Party   party;
@@ -102,10 +101,10 @@ public class McMMOPlayer implements Identified {
 
     private ChatChannel chatChannel;
 
-    private final Map<SuperAbilityType, Boolean> abilityMode     = new HashMap<>();
-    private final Map<SuperAbilityType, Boolean> abilityInformed = new HashMap<>();
+    private final Map<SuperAbilityType, Boolean> abilityMode     = new EnumMap<>(SuperAbilityType.class);
+    private final Map<SuperAbilityType, Boolean> abilityInformed = new EnumMap<>(SuperAbilityType.class);
 
-    private final Map<ToolType, Boolean> toolMode = new HashMap<>();
+    private final Map<ToolType, Boolean> toolMode = new EnumMap<>(ToolType.class);
 
     private int recentlyHurt;
     private int respawnATS;
@@ -1021,7 +1020,7 @@ public class McMMOPlayer implements Identified {
                 String.valueOf(calculateTimeRemaining(superAbilityType)));
     }
 
-    public boolean isAbilityOnCooldown(SuperAbilityType ability) {
+    public boolean isAbilityOnCooldown(@NotNull SuperAbilityType ability) {
         return !getAbilityMode(ability) && calculateTimeRemaining(ability) > 0;
     }
 
@@ -1040,43 +1039,43 @@ public class McMMOPlayer implements Identified {
     /*
      * These functions are wrapped from PlayerProfile so that we don't always have to store it alongside the McMMOPlayer object.
      */
-    public int getSkillLevel(PrimarySkillType skill) {
+    public int getSkillLevel(@NotNull PrimarySkillType skill) {
         return profile.getSkillLevel(skill);
     }
 
-    public float getSkillXpLevelRaw(PrimarySkillType skill) {
+    public float getSkillXpLevelRaw(@NotNull PrimarySkillType skill) {
         return profile.getSkillXpLevelRaw(skill);
     }
 
-    public int getSkillXpLevel(PrimarySkillType skill) {
+    public int getSkillXpLevel(@NotNull PrimarySkillType skill) {
         return profile.getSkillXpLevel(skill);
     }
 
-    public void setSkillXpLevel(PrimarySkillType skill, float xpLevel) {
+    public void setSkillXpLevel(@NotNull PrimarySkillType skill, float xpLevel) {
         profile.setSkillXpLevel(skill, xpLevel);
     }
 
-    public int getXpToLevel(PrimarySkillType skill) {
+    public int getXpToLevel(@NotNull PrimarySkillType skill) {
         return profile.getXpToLevel(skill);
     }
 
-    public void removeXp(PrimarySkillType skill, int xp) {
+    public void removeXp(@NotNull PrimarySkillType skill, int xp) {
         profile.removeXp(skill, xp);
     }
 
-    public void modifySkill(PrimarySkillType skill, int level) {
+    public void modifySkill(@NotNull PrimarySkillType skill, int level) {
         profile.modifySkill(skill, level);
     }
 
-    public void addLevels(PrimarySkillType skill, int levels) {
+    public void addLevels(@NotNull PrimarySkillType skill, int levels) {
         profile.addLevels(skill, levels);
     }
 
-    public void addXp(PrimarySkillType skill, float xp) {
+    public void addXp(@NotNull PrimarySkillType skill, float xp) {
         profile.addXp(skill, xp);
     }
 
-    public void setAbilityDATS(SuperAbilityType ability, long DATS) {
+    public void setAbilityDATS(@NotNull SuperAbilityType ability, long DATS) {
         profile.setAbilityDATS(ability, DATS);
     }
 
@@ -1141,7 +1140,7 @@ public class McMMOPlayer implements Identified {
      * @return this players identity
      */
     @Override
-    public @NonNull Identity identity() {
+    public @NotNull Identity identity() {
         return identity;
     }
 

--- a/src/main/java/com/gmail/nossr50/datatypes/player/PlayerProfile.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/player/PlayerProfile.java
@@ -14,7 +14,7 @@ import com.gmail.nossr50.skills.child.FamilyTree;
 import com.gmail.nossr50.util.player.UserManager;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -32,14 +32,14 @@ public class PlayerProfile {
     private int saveAttempts = 0;
 
     /* Skill Data */
-    private final Map<PrimarySkillType, Integer>   skills     = new HashMap<>();   // Skill & Level
-    private final Map<PrimarySkillType, Float>     skillsXp   = new HashMap<>();     // Skill & XP
-    private final Map<SuperAbilityType, Integer> abilityDATS = new HashMap<>(); // Ability & Cooldown
-    private final Map<UniqueDataType, Integer> uniquePlayerData = new HashMap<>(); //Misc data that doesn't fit into other categories (chimaera wing, etc..)
+    private final Map<PrimarySkillType, Integer> skills           = new EnumMap<>(PrimarySkillType.class);   // Skill & Level
+    private final Map<PrimarySkillType, Float>   skillsXp         = new EnumMap<>(PrimarySkillType.class);     // Skill & XP
+    private final Map<SuperAbilityType, Integer> abilityDATS      = new EnumMap<>(SuperAbilityType.class); // Ability & Cooldown
+    private final Map<UniqueDataType, Integer>   uniquePlayerData = new EnumMap<>(UniqueDataType.class); //Misc data that doesn't fit into other categories (chimaera wing, etc..)
 
     // Store previous XP gains for diminished returns
     private final DelayQueue<SkillXpGain> gainedSkillsXp = new DelayQueue<>();
-    private final HashMap<PrimarySkillType, Float> rollingSkillsXp = new HashMap<>();
+    private final Map<PrimarySkillType, Float> rollingSkillsXp = new EnumMap<>(PrimarySkillType.class);
 
     @Deprecated
     public PlayerProfile(String playerName) {


### PR DESCRIPTION
## Optimized Permission checks
So I wrote a quick method which logs all mcmmo permission checks.

These lookups should be quick and it is quite common for these to be fired very frequently.
However some small-scale optimizations can not hurt, as it may make things run smoother in the long run.

Particularly `McMMOPlayer#hasReachedPowerLevelCap()` is responsible for these many lookups since it loops through all primary skill types and fires a permissions lookup for each.
There isn't really a way around it, however `McMMOPlayer#hasReachedLevelCap()` (which checks for a specific Primary Skill Type) invokes  `McMMOPlayer#hasReachedPowerLevelCap()` too, resulting in the above seen 6 lookups per primary skill type.

This code portion for example may be optimized.
```java
//Check if they've reached the power level cap just now
if (hasReachedPowerLevelCap()) {
    NotificationManager...
} else if (hasReachedLevelCap(primarySkillType)) {
    NotificationManager...
}

```
Since we are inside of an `else if` block here, it means that `McMMOPlayer#hasReachedPowerLevelCap` must have returned false.
Therefore, we can save ourselves this further computation without breaking anything.
This PR proposes a small optimization to reduce permission lookup calls which can stack up quite a lot depending on what other plugins are at play.

| Before | After |
| ------- | ----- |
|![Before](https://cdn.discordapp.com/attachments/829093748453146665/829316762759462912/unknown.png)|![After](https://cdn.discordapp.com/attachments/829093748453146665/829321676361695283/unknown.png)|
| 98 lookups (max) | 85 lookups (max) |
| 72 lookups (min) | 59 lookups (min) |

These numbers are not 100% accurate or representative, as the amount of lookups depends a lot on internal logic.

## Enum Maps
I also switched out a few HashMaps for EnumMaps as their keys were enums.
EnumMaps are optimized for enums specifically and since the underlying data structure for them is an Array, it saves a bit on memory. They are also slightly quicker to compute than a regular `HashMap` in some instances, though the computation time will often be roughly the same.
Still, a decent way to optimize the code a bit further.

*I also added some missing annotations too :eyes:*