### PR TITLE
Some patches

### DIFF
--- a/src/main/java/com/gmail/nossr50/database/FlatFileDatabaseManager.java
+++ b/src/main/java/com/gmail/nossr50/database/FlatFileDatabaseManager.java
@@ -493,6 +493,8 @@ public final class FlatFileDatabaseManager implements DatabaseManager {
             skills.put(skill, getPlayerRank(playerName, playerStatHash.get(skill)));
         }
 
+        skills.put(null, getPlayerRank(playerName, powerLevels));
+
         return skills;
     }
 

--- a/src/main/java/com/gmail/nossr50/database/FlatFileDatabaseManager.java
+++ b/src/main/java/com/gmail/nossr50/database/FlatFileDatabaseManager.java
@@ -493,8 +493,6 @@ public final class FlatFileDatabaseManager implements DatabaseManager {
             skills.put(skill, getPlayerRank(playerName, playerStatHash.get(skill)));
         }
 
-        skills.put(null, getPlayerRank(playerName, powerLevels));
-
         return skills;
     }
 

--- a/src/main/java/com/gmail/nossr50/datatypes/player/McMMOPlayer.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/player/McMMOPlayer.java
@@ -941,6 +941,10 @@ public class McMMOPlayer implements Identified {
         //Sounds
         SoundManager.worldSendSound(player.getWorld(), player.getLocation(), SoundType.ABILITY_ACTIVATED_GENERIC);
 
+        //If the current item is still buffed somehow, remove it to prevent enchantments from stacking.
+        if (superAbilityType == SuperAbilityType.SUPER_BREAKER || superAbilityType == SuperAbilityType.GIGA_DRILL_BREAKER)
+            SkillUtils.removeAbilityBuff(player.getInventory().getItemInMainHand());
+
         // Enable the ability
         profile.setAbilityDATS(superAbilityType, System.currentTimeMillis() + (ticks * Misc.TIME_CONVERSION_FACTOR));
         setAbilityMode(superAbilityType, true);

--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -157,8 +157,10 @@ public class MiningManager extends SkillManager {
     //TODO: Rewrite this garbage
     //TODO: Rewrite this garbage
     public void blastMiningDropProcessing(float yield, EntityExplodeEvent event) {
-        //Strip out only stuff that gives mining XP
+        if (yield == 0)
+            return;
 
+        //Strip out only stuff that gives mining XP
         List<BlockState> ores = new ArrayList<>();
 
         List<BlockState> notOres = new ArrayList<>();

--- a/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
@@ -107,6 +107,11 @@ public class WoodcuttingManager extends SkillManager {
             treeFellerReachedThreshold = false;
 
             NotificationManager.sendPlayerInformation(player, NotificationType.SUBSKILL_MESSAGE_FAILED, "Woodcutting.Skills.TreeFeller.Threshold");
+
+            //Tree feller won't be activated for this block, award normal xp.
+            processWoodcuttingBlockXP(blockState);
+            processHarvestLumber(blockState);
+
             return;
         }
 
@@ -282,7 +287,7 @@ public class WoodcuttingManager extends SkillManager {
             Block block = blockState.getBlock();
 
             if (!EventUtils.simulateBlockBreak(block, player, true)) {
-                break; // TODO: Shouldn't we use continue instead?
+                continue;
             }
 
             /*


### PR DESCRIPTION
This PR adresses the following bugs:
- Fixed blocks being dropped from blast mining even if yield was set to 0.
- Tree feller not working entirely if one fake block break event is cancelled. (Closes #4189)
- Fixes no woodcutting xp being rewarded if a tree is too big while using tree feller.

Added a removeAbilityBuff as a just-in-case when activating super breaker or giga drill breaker, in the unlikely event that the tool is still somehow buffed with the higher efficiency level.