### PR TITLE
Add McMMOEntityDamageByRuptureEvent

### DIFF
--- a/src/main/java/com/gmail/nossr50/events/fake/FakeEntityDamageByEntityEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakeEntityDamageByEntityEvent.java
@@ -1,9 +1,9 @@
 package com.gmail.nossr50.events.fake;
 
 import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -13,21 +13,21 @@ import java.util.Map;
  */
 public class FakeEntityDamageByEntityEvent extends EntityDamageByEntityEvent implements FakeEvent {
 
-    public FakeEntityDamageByEntityEvent(Entity damager, Entity damagee, DamageCause cause, final Map<DamageModifier, Double> modifiers) {
+    public FakeEntityDamageByEntityEvent(@NotNull Entity damager, @NotNull Entity damagee, @NotNull DamageCause cause, @NotNull final Map<DamageModifier, Double> modifiers) {
         super(damager, damagee, cause, modifiers, getFunctionModifiers(modifiers));
     }
 
     @Deprecated
-    public FakeEntityDamageByEntityEvent(Entity damager, Entity damagee, DamageCause cause, double damage) {
+    public FakeEntityDamageByEntityEvent(@NotNull Entity damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
         super(damager, damagee, cause, damage);
     }
 
-    public static EnumMap<DamageModifier, Function<? super Double, Double>> getFunctionModifiers(Map<DamageModifier, Double> modifiers) {
+    @NotNull
+    public static EnumMap<DamageModifier, Function<? super Double, Double>> getFunctionModifiers(@NotNull Map<DamageModifier, Double> modifiers) {
         EnumMap<DamageModifier, Function<? super Double, Double>> modifierFunctions = new EnumMap<>(DamageModifier.class);
-        Function<? super Double, Double> ZERO = Functions.constant(-0.0);
 
         for (DamageModifier modifier : modifiers.keySet()) {
-            modifierFunctions.put(modifier, ZERO);
+            modifierFunctions.put(modifier, (o -> -0.0));
         }
 
         return modifierFunctions;

--- a/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRupture.java
+++ b/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRupture.java
@@ -1,0 +1,33 @@
+package com.gmail.nossr50.events.skills.rupture;
+
+import com.gmail.nossr50.datatypes.player.McMMOPlayer;
+import com.gmail.nossr50.events.fake.FakeEntityDamageByEntityEvent;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class McMMOEntityDamageByRupture extends FakeEntityDamageByEntityEvent {
+	public McMMOEntityDamageByRupture(@NotNull Player damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
+		super(damager, damagee, cause, getDamageMap(damage));
+	}
+
+	public McMMOEntityDamageByRupture(@NotNull McMMOPlayer damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
+		this(damager.getPlayer(), damagee, cause, damage);
+	}
+
+	private static Map<EntityDamageEvent.DamageModifier, Double> getDamageMap(double damage) {
+		Map<EntityDamageEvent.DamageModifier, Double> damageMap = new HashMap<>();
+		damageMap.put(EntityDamageEvent.DamageModifier.BASE, damage);
+		return damageMap;
+	}
+
+	@NotNull
+	@Override
+	public Player getDamager() {
+		return (Player) super.getDamager();
+	}
+}

--- a/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRuptureEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRuptureEvent.java
@@ -1,33 +1,23 @@
 package com.gmail.nossr50.events.skills.rupture;
 
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
-import com.gmail.nossr50.events.fake.FakeEntityDamageByEntityEvent;
+import com.google.common.collect.ImmutableMap;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
-import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.EnumMap;
 
-public class McMMOEntityDamageByRuptureEvent extends FakeEntityDamageByEntityEvent {
-	public McMMOEntityDamageByRuptureEvent(@NotNull Player damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
-		super(damager, damagee, cause, getDamageMap(damage));
-	}
+public class McMMOEntityDamageByRuptureEvent extends EntityDamageByEntityEvent {
+	private final McMMOPlayer mcMMODamager;
 
 	public McMMOEntityDamageByRuptureEvent(@NotNull McMMOPlayer damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
-		this(damager.getPlayer(), damagee, cause, damage);
-	}
-
-	private static Map<EntityDamageEvent.DamageModifier, Double> getDamageMap(double damage) {
-		Map<EntityDamageEvent.DamageModifier, Double> damageMap = new HashMap<>();
-		damageMap.put(EntityDamageEvent.DamageModifier.BASE, damage);
-		return damageMap;
+		super(damager.getPlayer(), damagee, cause, new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, damage)), new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, (o -> -0.0))));
+		this.mcMMODamager = damager;
 	}
 
 	@NotNull
-	@Override
-	public Player getDamager() {
-		return (Player) super.getDamager();
+	public McMMOPlayer getMcMMODamager() {
+		return mcMMODamager;
 	}
 }

--- a/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRuptureEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRuptureEvent.java
@@ -10,12 +10,12 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
-public class McMMOEntityDamageByRupture extends FakeEntityDamageByEntityEvent {
-	public McMMOEntityDamageByRupture(@NotNull Player damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
+public class McMMOEntityDamageByRuptureEvent extends FakeEntityDamageByEntityEvent {
+	public McMMOEntityDamageByRuptureEvent(@NotNull Player damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
 		super(damager, damagee, cause, getDamageMap(damage));
 	}
 
-	public McMMOEntityDamageByRupture(@NotNull McMMOPlayer damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
+	public McMMOEntityDamageByRuptureEvent(@NotNull McMMOPlayer damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
 		this(damager.getPlayer(), damagee, cause, damage);
 	}
 

--- a/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRuptureEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/skills/rupture/McMMOEntityDamageByRuptureEvent.java
@@ -11,8 +11,8 @@ import java.util.EnumMap;
 public class McMMOEntityDamageByRuptureEvent extends EntityDamageByEntityEvent {
 	private final McMMOPlayer mcMMODamager;
 
-	public McMMOEntityDamageByRuptureEvent(@NotNull McMMOPlayer damager, @NotNull Entity damagee, @NotNull DamageCause cause, double damage) {
-		super(damager.getPlayer(), damagee, cause, new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, damage)), new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, (o -> -0.0))));
+	public McMMOEntityDamageByRuptureEvent(@NotNull McMMOPlayer damager, @NotNull Entity damagee, double damage) {
+		super(damager.getPlayer(), damagee, DamageCause.CUSTOM, new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, damage)), new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, (o -> -0.0))));
 		this.mcMMODamager = damager;
 	}
 

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -8,6 +8,7 @@ import com.gmail.nossr50.datatypes.skills.subskills.interfaces.InteractType;
 import com.gmail.nossr50.events.fake.FakeEntityDamageByEntityEvent;
 import com.gmail.nossr50.events.fake.FakeEntityDamageEvent;
 import com.gmail.nossr50.events.fake.FakeEntityTameEvent;
+import com.gmail.nossr50.events.skills.rupture.McMMOEntityDamageByRuptureEvent;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.party.PartyManager;
 import com.gmail.nossr50.skills.archery.Archery;
@@ -290,7 +291,7 @@ public class EntityListener implements Listener {
      */
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
-        if (event instanceof FakeEntityDamageByEntityEvent) {
+        if (event instanceof FakeEntityDamageByEntityEvent || event instanceof McMMOEntityDamageByRuptureEvent) {
             return;
         }
 

--- a/src/main/java/com/gmail/nossr50/runnables/skills/RuptureTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/skills/RuptureTask.java
@@ -1,7 +1,7 @@
 package com.gmail.nossr50.runnables.skills;
 
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
-import com.gmail.nossr50.events.skills.rupture.McMMOEntityDamageByRupture;
+import com.gmail.nossr50.events.skills.rupture.McMMOEntityDamageByRuptureEvent;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.skills.ParticleEffectUtils;
 import com.google.common.base.Objects;
@@ -57,7 +57,7 @@ public class RuptureTask extends BukkitRunnable {
                     return;
 
                 //Send a fake damage event
-                McMMOEntityDamageByRupture event = new McMMOEntityDamageByRupture(ruptureSource, targetEntity, EntityDamageEvent.DamageCause.ENTITY_ATTACK, calculateAdjustedTickDamage());
+                McMMOEntityDamageByRuptureEvent event = new McMMOEntityDamageByRuptureEvent(ruptureSource, targetEntity, EntityDamageEvent.DamageCause.ENTITY_ATTACK, calculateAdjustedTickDamage());
                 mcMMO.p.getServer().getPluginManager().callEvent(event);
 
                 //Ensure the event wasn't cancelled and damage is still greater than 0

--- a/src/main/java/com/gmail/nossr50/runnables/skills/RuptureTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/skills/RuptureTask.java
@@ -7,7 +7,6 @@ import com.gmail.nossr50.util.skills.ParticleEffectUtils;
 import com.google.common.base.Objects;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
@@ -54,7 +53,7 @@ public class RuptureTask extends BukkitRunnable {
                     //Ensure victim has health
                     if (healthBeforeRuptureIsApplied > 0.01) {
                         //Send a fake damage event
-                        McMMOEntityDamageByRuptureEvent event = new McMMOEntityDamageByRuptureEvent(ruptureSource, targetEntity, EntityDamageEvent.DamageCause.ENTITY_ATTACK, calculateAdjustedTickDamage());
+                        McMMOEntityDamageByRuptureEvent event = new McMMOEntityDamageByRuptureEvent(ruptureSource, targetEntity, calculateAdjustedTickDamage());
                         mcMMO.p.getServer().getPluginManager().callEvent(event);
 
                         //Ensure the event wasn't cancelled and damage is still greater than 0


### PR DESCRIPTION
Fires a (Fake)EntityDamageByEntityEvent for Rupture/Bleeding and ensures the event hasn't been cancelled and the damage value is positive. Allows other plugins to block the damage, such as players toggling on/off PVP or entering safe zones.