### PR TITLE
Fix subskill chat click bug

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/text/TextComponentFactory.java
+++ b/src/main/java/com/gmail/nossr50/util/text/TextComponentFactory.java
@@ -286,7 +286,7 @@ public class TextComponentFactory {
             else
                 textComponent = Component.text().content(LocaleLoader.getString("JSON.Hover.SkillName", skillName));
 
-            textComponent.clickEvent(ClickEvent.runCommand("/mmoinfo " + subSkillType.getNiceNameNoSpaces(subSkillType)));
+            textComponent.clickEvent(ClickEvent.runCommand("/mmoinfo " + subSkillType.toString()));
 
         } else {
             textComponent = Component.text().content(LocaleLoader.getString("JSON.Hover.Mystery",


### PR DESCRIPTION
When viewing skill info. The subskill click listener doesn't work. I fixed it by simply not allowing the plugin to reformat the subskill id. The function getNiceNameNoSpaces(...) doesn't produce a name that will be found by /mmoinfo