### PR TITLE
Bump adventure to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,27 +238,27 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-nbt</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-key</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson-legacy-impl</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>


### PR DESCRIPTION
As discovered by @CheesyTheArtist on discord (https://discord.com/channels/526933440214597677/526933440214597685/852892710040764466)

Adventure requires an update in order to work with the latest `adventure-platform` snapshot.
Luckily the Unit Test introduced in #4446 caught this and warned us 😄 

```
[ERROR] Errors:
[ERROR]   TextUtilsTest.testColorizeText:27 » NoClassDefFound net/kyori/adventure/util/S...
```