### PR TITLE
Add option to not send FakePlayerAnimationEvent for combat skills

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
@@ -642,6 +642,7 @@ public class AdvancedConfig extends AutoUpdateConfigLoader {
     public double getImpactDurabilityDamageMultiplier() { return config.getDouble("Skills.Axes.ArmorImpact.DamagePerRank", 6.5D); }
 
     public double getSkullSplitterModifier() { return config.getDouble("Skills.Axes.SkullSplitter.DamageModifier", 2.0D); }
+    public boolean getSkullSplitterFakeArmSwing() { return config.getBoolean("Skills.Axes.SkullSplitter.FakeArmSwing", true); }
 
     /* EXCAVATION */
     //Nothing to configure, everything is already configurable in config.yml
@@ -735,6 +736,7 @@ public class AdvancedConfig extends AutoUpdateConfigLoader {
 
     public double getSerratedStrikesModifier() { return config.getDouble("Skills.Swords.SerratedStrikes.DamageModifier", 4.0D); }
     public int getSerratedStrikesTicks() { return config.getInt("Skills.Swords.SerratedStrikes.RuptureTicks", 5); }
+    public boolean getSerratedStrikesFakeArmSwing() { return config.getBoolean("Skills.Swords.SerratedStrikes.FakeArmSwing", true); }
 
     /* TAMING */
     public double getGoreModifier() { return config.getDouble("Skills.Taming.Gore.Modifier", 2.0D); }

--- a/src/main/java/com/gmail/nossr50/skills/axes/Axes.java
+++ b/src/main/java/com/gmail/nossr50/skills/axes/Axes.java
@@ -21,6 +21,7 @@ public class Axes {
     public static double greaterImpactKnockbackMultiplier = mcMMO.p.getAdvancedConfig().getGreaterImpactModifier();
 
     public static double skullSplitterModifier = mcMMO.p.getAdvancedConfig().getSkullSplitterModifier();
+    public static boolean skullSplitterFakeArmSwing = mcMMO.p.getAdvancedConfig().getSkullSplitterFakeArmSwing();
 
     protected static boolean hasArmor(LivingEntity target) {
         if(target == null || !target.isValid() || target.getEquipment() == null)

--- a/src/main/java/com/gmail/nossr50/skills/axes/AxesManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/axes/AxesManager.java
@@ -168,6 +168,6 @@ public class AxesManager extends SkillManager {
      * @param damage The amount of damage initially dealt by the event
      */
     public void skullSplitterCheck(@NotNull LivingEntity target, double damage, Map<DamageModifier, Double> modifiers) {
-        CombatUtils.applyAbilityAoE(getPlayer(), target, damage / Axes.skullSplitterModifier, modifiers, skill);
+        CombatUtils.applyAbilityAoE(getPlayer(), target, damage / Axes.skullSplitterModifier, modifiers, skill, Axes.skullSplitterFakeArmSwing);
     }
 }

--- a/src/main/java/com/gmail/nossr50/skills/swords/Swords.java
+++ b/src/main/java/com/gmail/nossr50/skills/swords/Swords.java
@@ -6,4 +6,6 @@ public class Swords {
     public static double  counterAttackModifier      = mcMMO.p.getAdvancedConfig().getCounterModifier();
 
     public static double serratedStrikesModifier   = mcMMO.p.getAdvancedConfig().getSerratedStrikesModifier();
+
+    public static boolean serratedStrikesFakeArmSwing = mcMMO.p.getAdvancedConfig().getSerratedStrikesFakeArmSwing();
 }

--- a/src/main/java/com/gmail/nossr50/skills/swords/SwordsManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/swords/SwordsManager.java
@@ -162,6 +162,6 @@ public class SwordsManager extends SkillManager {
      * @param damage The amount of damage initially dealt by the event
      */
     public void serratedStrikes(@NotNull LivingEntity target, double damage, Map<DamageModifier, Double> modifiers) {
-        CombatUtils.applyAbilityAoE(getPlayer(), target, damage / Swords.serratedStrikesModifier, modifiers, skill);
+        CombatUtils.applyAbilityAoE(getPlayer(), target, damage / Swords.serratedStrikesModifier, modifiers, skill, Swords.serratedStrikesFakeArmSwing);
     }
 }

--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -688,7 +688,7 @@ public final class CombatUtils {
      * @param damage The initial damage amount
      * @param type The type of skill being used
      */
-    public static void applyAbilityAoE(@NotNull Player attacker, @NotNull LivingEntity target, double damage, Map<DamageModifier, Double> modifiers, @NotNull PrimarySkillType type) {
+    public static void applyAbilityAoE(@NotNull Player attacker, @NotNull LivingEntity target, double damage, Map<DamageModifier, Double> modifiers, @NotNull PrimarySkillType type, boolean shouldArmSwing) {
         int numberOfTargets = getTier(attacker.getInventory().getItemInMainHand()); // The higher the weapon tier, the more targets you hit
         double damageAmount = Math.max(damage, 1);
 
@@ -702,7 +702,9 @@ public final class CombatUtils {
             }
 
             LivingEntity livingEntity = (LivingEntity) entity;
-            EventUtils.callFakeArmSwingEvent(attacker);
+            if (shouldArmSwing) {
+                EventUtils.callFakeArmSwingEvent(attacker);
+            }
 
             switch (type) {
                 case SWORDS:

--- a/src/main/resources/advanced.yml
+++ b/src/main/resources/advanced.yml
@@ -200,6 +200,8 @@ Skills:
         SkullSplitter:
             # DamageModifier: Damage will get divided by this modifier
             DamageModifier: 2.0
+            # Determines if a fake player animation event is called
+            FakeArmSwing: true
     #
     #  Settings for Fishing
     ###
@@ -498,6 +500,8 @@ Skills:
             # BleedTicks: This determines how long the bleeding effect of SerratedStrikes lasts
             DamageModifier: 4.0
             BleedTicks: 5
+            # Determines if a fake player animation event is called
+            FakeArmSwing: true
     #
     #  Settings for Taming
     ###


### PR DESCRIPTION
The `FakePlayerAnimationEvent` can cause some compatibility issues with other plugins.