### PR TITLE
Added a Unit Test for mc version detection

### DIFF
--- a/src/test/java/com/gmail/nossr50/util/platform/MinecraftGameVersionTest.java
+++ b/src/test/java/com/gmail/nossr50/util/platform/MinecraftGameVersionTest.java
@@ -1,6 +1,5 @@
 package com.gmail.nossr50.util.platform;
 
-
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -21,23 +20,23 @@ class MinecraftGameVersionTest {
 
     @Test
     void testAtLeast() {
-        //TODO: Remove redundant tests
+        // TODO: Remove redundant tests
         MinecraftGameVersion oneEightEight = new MinecraftGameVersion(1, 8, 8);
         MinecraftGameVersion oneSixteenFive = new MinecraftGameVersion(1, 16, 5);
         MinecraftGameVersion oneTwo = new MinecraftGameVersion(1, 2);
 
-        //1.8.8
+        // 1.8.8
         assertTrue(oneEightEight.isAtLeast(1, 8, 7));
         assertFalse(oneEightEight.isAtLeast(1, 9, 0));
 
-        //1.16.5
+        // 1.16.5
         assertTrue(oneSixteenFive.isAtLeast(1, 15, 2));
         assertFalse(oneSixteenFive.isAtLeast(1, 17, 0));
 
-        //1.2
+        // 1.2
         assertTrue(oneTwo.isAtLeast(1, 2, 0));
 
-        //Test major version number
+        // Test major version number
         MinecraftGameVersion majorVersionTest = new MinecraftGameVersion(2, 0, 0);
 
         assertFalse(majorVersionTest.isAtLeast(3, 0, 0));
@@ -47,8 +46,7 @@ class MinecraftGameVersionTest {
         assertTrue(majorVersionTest.isAtLeast(2, 0, 0));
         assertTrue(majorVersionTest.isAtLeast(1, 0, 0));
 
-
-        //Test minor version number
+        // Test minor version number
         MinecraftGameVersion minorVersionTest = new MinecraftGameVersion(0, 3, 0);
 
         assertFalse(minorVersionTest.isAtLeast(0, 4, 0));
@@ -60,7 +58,7 @@ class MinecraftGameVersionTest {
         assertTrue(minorVersionTest.isAtLeast(0, 2, 1));
         assertTrue(minorVersionTest.isAtLeast(0, 3, 0));
 
-        //Test patch version number
+        // Test patch version number
 
         MinecraftGameVersion patchVersionTest = new MinecraftGameVersion(0, 0, 5);
 
@@ -75,33 +73,32 @@ class MinecraftGameVersionTest {
         assertTrue(patchVersionTest.isAtLeast(0, 0, 4));
         assertTrue(patchVersionTest.isAtLeast(0, 0, 5));
     }
-    
+
     @MethodSource("getGameVersions")
     @ParameterizedTest(name = "Verify that \"{0}\" is recognized as {1}.{2}.{3}")
     void testVersionDetection(String gameVersion, int major, int minor, int patch) {
         /*
-         *  The platform manager checks for the type of server software,
-         *  we will just simulate some "Spigot" version here, so that the test can
-         *  continue successfully.
+         * The platform manager checks for the type of server software,
+         * we will just simulate some "Spigot" version here, so that the test can
+         * continue successfully.
          */
-        String serverSoftwareVersion = "git-Spigot-12345-abcdef (MC: 1.17)";
-        
+        String serverSoftwareVersion = "git-Spigot-12345-abcdef (MC: " + major + '.' + minor + '.' + patch + ')';
+
         // Set up a mock plugin for logging.
         mcMMO plugin = Mockito.mock(mcMMO.class);
         Mockito.when(plugin.getName()).thenReturn("mcMMO");
         Mockito.when(plugin.getLogger()).thenReturn(Logger.getLogger("mcMMO"));
         mcMMO.p = plugin;
-        
-        try (MockedStatic<Bukkit> bukkit = Mockito.mockStatic(Bukkit.class)) {
-            bukkit.when(() -> Bukkit.getVersion()).thenReturn(serverSoftwareVersion);
 
-            // Inject our own Bukkit version
+        try (MockedStatic<Bukkit> bukkit = Mockito.mockStatic(Bukkit.class)) {
+            // Inject our own Bukkit versions
+            bukkit.when(() -> Bukkit.getVersion()).thenReturn(serverSoftwareVersion);
             bukkit.when(() -> Bukkit.getBukkitVersion()).thenReturn(gameVersion);
-            
+
             PlatformManager manager = new PlatformManager();
             Platform platform = manager.getPlatform();
             MinecraftGameVersion minecraftVersion = platform.getGameVersion();
-            
+
             assertEquals(major, minecraftVersion.getMajorVersion().asInt());
             assertEquals(minor, minecraftVersion.getMinorVersion().asInt());
             assertEquals(patch, minecraftVersion.getPatchVersion().asInt());
@@ -109,7 +106,7 @@ class MinecraftGameVersionTest {
             mcMMO.p = null;
         }
     }
-    
+
     private static @NotNull Stream<Arguments> getGameVersions() {
         /*
          * These samples were taken directly from the historical
@@ -130,5 +127,5 @@ class MinecraftGameVersionTest {
             Arguments.of("1.17-R0.1-SNAPSHOT", 1, 17, 0)
         );
     }
-    
+
 }

--- a/src/test/java/com/gmail/nossr50/util/platform/MinecraftGameVersionTest.java
+++ b/src/test/java/com/gmail/nossr50/util/platform/MinecraftGameVersionTest.java
@@ -1,13 +1,26 @@
 package com.gmail.nossr50.util.platform;
 
+
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.gmail.nossr50.mcMMO;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class MinecraftGameVersionTest {
 
     @Test
-    public void testAtLeast() {
+    void testAtLeast() {
         //TODO: Remove redundant tests
         MinecraftGameVersion oneEightEight = new MinecraftGameVersion(1, 8, 8);
         MinecraftGameVersion oneSixteenFive = new MinecraftGameVersion(1, 16, 5);
@@ -62,4 +75,60 @@ class MinecraftGameVersionTest {
         assertTrue(patchVersionTest.isAtLeast(0, 0, 4));
         assertTrue(patchVersionTest.isAtLeast(0, 0, 5));
     }
+    
+    @MethodSource("getGameVersions")
+    @ParameterizedTest(name = "Verify that \"{0}\" is recognized as {1}.{2}.{3}")
+    void testVersionDetection(String gameVersion, int major, int minor, int patch) {
+        /*
+         *  The platform manager checks for the type of server software,
+         *  we will just simulate some "Spigot" version here, so that the test can
+         *  continue successfully.
+         */
+        String serverSoftwareVersion = "git-Spigot-12345-abcdef (MC: 1.17)";
+        
+        // Set up a mock plugin for logging.
+        mcMMO plugin = Mockito.mock(mcMMO.class);
+        Mockito.when(plugin.getName()).thenReturn("mcMMO");
+        Mockito.when(plugin.getLogger()).thenReturn(Logger.getLogger("mcMMO"));
+        mcMMO.p = plugin;
+        
+        try (MockedStatic<Bukkit> bukkit = Mockito.mockStatic(Bukkit.class)) {
+            bukkit.when(() -> Bukkit.getVersion()).thenReturn(serverSoftwareVersion);
+
+            // Inject our own Bukkit version
+            bukkit.when(() -> Bukkit.getBukkitVersion()).thenReturn(gameVersion);
+            
+            PlatformManager manager = new PlatformManager();
+            Platform platform = manager.getPlatform();
+            MinecraftGameVersion minecraftVersion = platform.getGameVersion();
+            
+            assertEquals(major, minecraftVersion.getMajorVersion().asInt());
+            assertEquals(minor, minecraftVersion.getMinorVersion().asInt());
+            assertEquals(patch, minecraftVersion.getPatchVersion().asInt());
+        } finally {
+            mcMMO.p = null;
+        }
+    }
+    
+    private static @NotNull Stream<Arguments> getGameVersions() {
+        /*
+         * These samples were taken directly from the historical
+         * data of CraftBukkit's pom.xml file:
+         * https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/pom.xml
+         * 
+         * We should be safe to assume that forks follow these conventions and do not mess
+         * with this version number (Spigot, Paper and Tuinity do at least).
+         */
+        return Stream.of(
+            Arguments.of("1.13.2-R0.1-SNAPSHOT", 1, 13, 2),
+            Arguments.of("1.13-R0.2-SNAPSHOT", 1, 13, 0),
+            Arguments.of("1.13.2-R0.1-SNAPSHOT", 1, 13, 2),
+            Arguments.of("1.13-pre7-R0.1-SNAPSHOT", 1, 13, 0),
+            Arguments.of("1.14-pre5-SNAPSHOT", 1, 14, 0),
+            Arguments.of("1.15-R0.1-SNAPSHOT", 1, 15, 0),
+            Arguments.of("1.16.5-R0.1-SNAPSHOT", 1, 16, 5),
+            Arguments.of("1.17-R0.1-SNAPSHOT", 1, 17, 0)
+        );
+    }
+    
 }


### PR DESCRIPTION
## 🧭 Premise
This PR adds an automated parameterized unit test to verify that the Minecraft version is detected correctly.

This test is directly inspired by @stepech's pull request #4555 and should not be merged until that one is.
**As with the current setup of mcMMO, the tests will fail, see issue #4554**.

I think this is a behaviour that should definitely be unit-tested though to protect against future issues like #4554.
The test can also easily be expanded. Though I am not sure what the desired scenario should be for invalid server versions.
Right now it just results in an exception I think, I can also add a test for that if you want, I'd just like to know confirmation that this is the desired behaviour that should happen for when a server version is invalid.

The test itself is pretty simple, it injects a custom platform version string into `Bukkit.getBukkitVersion()`, instantiates a new `PlatformManager` and then compares the determined `MinecraftGameVersion` to the expected result.

These samples were taken directly from the historical data of CraftBukkit's pom.xml file:
https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/pom.xml
and with the help of @stepech's samples provided in #4555.

Until I checked the history for CB's pom, I also completely forgotten the time when CraftBukkit had `-pre` versions o.O

### 📊 Coverage
While this test seems trivial, it actually has quite a lot of good implications for test coverage.
This single test alone, provides the following additional coverage:

| 📔  Class | 📈  Coverage |
| :-------------------- | :-----: |
| `CompatibilityManager.java` | 67,5% |
| `PlatformManager.java` | 83,0% |
| `PlatformBuilder.java` | 90,0% |
| `BukkitPlatform.java` | 60,0% |
| `MinecraftGameVersion.java` | 52,9% |
