### PR TITLE
Propose: Add an option for Exploiting Fishing.

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -155,8 +155,8 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     public boolean isNPCInteractionPrevented() { return config.getBoolean("ExploitFix.PreventPluginNPCInteraction", true); }
 
     public boolean isFishingExploitingPrevented() { return config.getBoolean("ExploitFix.Fishing", true); }
-    public int getFishingExploitingOptionMoveRange() { return config.getInt("FishExploitOption.MoveRange", 3); }
-    public int getFishingExploitingOptionOverFishLimit() { return config.getInt("FishExploitOption.OverFishLimit", 10); }
+    public int getFishingExploitingOptionMoveRange() { return config.getInt("Fishing_ExploitFix_Options.MoveRange", 3); }
+    public int getFishingExploitingOptionOverFishLimit() { return config.getInt("Fishing_ExploitFix_Options.OverFishLimit", 10); }
 
     public boolean isAcrobaticsExploitingPrevented() { return config.getBoolean("ExploitFix.Acrobatics", true); }
     public boolean isTreeFellerXPReduced() { return config.getBoolean("ExploitFix.TreeFellerReducedXP", true); }

--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -155,6 +155,9 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     public boolean isNPCInteractionPrevented() { return config.getBoolean("ExploitFix.PreventPluginNPCInteraction", true); }
 
     public boolean isFishingExploitingPrevented() { return config.getBoolean("ExploitFix.Fishing", true); }
+    public int getFishingExploitingOptionMoveRange() { return config.getInt("FishExploitOption.MoveRange", 3); }
+    public int getFishingExploitingOptionOverFishLimit() { return config.getInt("FishExploitOption.OverFishLimit", 10); }
+
     public boolean isAcrobaticsExploitingPrevented() { return config.getBoolean("ExploitFix.Acrobatics", true); }
     public boolean isTreeFellerXPReduced() { return config.getBoolean("ExploitFix.TreeFellerReducedXP", true); }
 

--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -449,7 +449,7 @@ public class PlayerListener implements Listener {
                 if(caught instanceof Item) {
                     if(ExperienceConfig.getInstance().isFishingExploitingPrevented()) {
                         if (fishingManager.isExploitingFishing(event.getHook().getLocation().toVector())) {
-                            player.sendMessage(LocaleLoader.getString("Fishing.ScarcityTip", 3));
+                            player.sendMessage(LocaleLoader.getString("Fishing.ScarcityTip", ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange()));
                             event.setExpToDrop(0);
                             Item caughtItem = (Item) caught;
                             caughtItem.remove();
@@ -886,7 +886,7 @@ public class PlayerListener implements Listener {
                 if(player.getInventory().getItemInOffHand().getType() != Material.AIR && !player.isInsideVehicle() && !player.isSneaking()) {
                     break;
                 }
-                
+
                 /* ACTIVATION CHECKS */
                 if (mcMMO.p.getGeneralConfig().getAbilitiesEnabled()) {
                     mcMMOPlayer.processAbilityActivation(PrimarySkillType.AXES);
@@ -1005,7 +1005,7 @@ public class PlayerListener implements Listener {
      * When a {@link Player} attempts to place an {@link ItemStack}
      * into an {@link ItemFrame}, we want to make sure to remove any
      * Ability buffs from that item.
-     * 
+     *
      * @param event The {@link PlayerInteractEntityEvent} to handle
      */
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
@@ -43,7 +43,6 @@ import java.util.*;
 
 public class FishingManager extends SkillManager {
     public static final int FISHING_ROD_CAST_CD_MILLISECONDS = 100;
-    public static final int OVERFISH_LIMIT = 10;
     private final long FISHING_COOLDOWN_SECONDS = 1000L;
 
     private long fishingRodCastTimestamp = 0L;
@@ -143,20 +142,21 @@ public class FishingManager extends SkillManager {
         else
             fishCaughtCounter = 1;
 
-        if(fishCaughtCounter + 1 == OVERFISH_LIMIT)
+        if(fishCaughtCounter + 1 == ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit())
         {
-            getPlayer().sendMessage(LocaleLoader.getString("Fishing.LowResourcesTip", 3));
+            getPlayer().sendMessage(LocaleLoader.getString("Fishing.LowResourcesTip", ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange()));
         }
 
         //If the new bounding box does not intersect with the old one, then update our bounding box reference
         if(!sameTarget)
             lastFishingBoundingBox = newCastBoundingBox;
 
-        return sameTarget && fishCaughtCounter >= OVERFISH_LIMIT;
+        return sameTarget && fishCaughtCounter >= ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit();
     }
 
     public static BoundingBox makeBoundingBox(Vector centerOfCastVector) {
-        return BoundingBox.of(centerOfCastVector, 1, 1, 1);
+        int exploitingRange = ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange();
+        return BoundingBox.of(centerOfCastVector, exploitingRange / 2, 1, exploitingRange / 2);
     }
 
     public void setFishingTarget() {

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -39,7 +39,7 @@ ExploitFix:
     # mcMMO normally doesn't process attacks against an Entity if it is an NPC from another plugin
     # Of course, mcMMO doesn't know for sure whether or not something is an NPC, it checks a few known things, see our source code to see how
     PreventPluginNPCInteraction: true
-FishExploitOption:
+Fishing_ExploitFix_Options:
     MoveRange: 3
     OverFishLimit: 10
 Experience_Bars:

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -39,6 +39,9 @@ ExploitFix:
     # mcMMO normally doesn't process attacks against an Entity if it is an NPC from another plugin
     # Of course, mcMMO doesn't know for sure whether or not something is an NPC, it checks a few known things, see our source code to see how
     PreventPluginNPCInteraction: true
+FishExploitOption:
+    MoveRange: 3
+    OverFishLimit: 10
 Experience_Bars:
     # Turn this to false if you wanna disable XP bars
     Enable: true


### PR DESCRIPTION
## :octocat: Description

When I installed mcMMO, it was very inconvenient that I could not fish more than 10 times in the same place to prevent exploits.
However, if this option is turned off, it is possible to gain an unfairly large amount of experience through fishing exploits.

So I wanted to loosen this restriction, but I couldn't find that option anywhere, so I decided to add it.

At one point, someone playing on my server automatically turned around 90 degrees using mouse macros and such, which anti-exploit measures could not prevent.

So I think that being able to specify the distance you have to move will make the anti-exploit better.

Thank you in advance for your consideration.

I love mcMMO.

## 🔑  Changes

1. The number of times before a warning is displayed can now be specified by the user.
2. The distance that must be traveled can now be specified by the user.

## To Reviewers

Since I don't speak English very well, you may feel uncomfortable with the method names and so on. So if you have any suggestions, please let me know.

## Testing

- [x] Manual Testing
- [x] Build & Package

