### PR TITLE
Make /party kick case insensitive

### DIFF
--- a/src/main/java/com/gmail/nossr50/datatypes/party/Party.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/party/Party.java
@@ -327,7 +327,7 @@ public class Party {
     }
 
     public boolean hasMember(String memberName) {
-        return this.getMembers().containsValue(memberName);
+        return this.getMembers().values().stream().anyMatch(memberName::equalsIgnoreCase);
     }
 
     public boolean hasMember(UUID uuid) {


### PR DESCRIPTION
Makes the /party kick command case insentive by modifying the hasMember method