### PR TITLE
Fix issue #4105 Fishing shake percentage seems off.

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/random/RandomChanceStatic.java
+++ b/src/main/java/com/gmail/nossr50/util/random/RandomChanceStatic.java
@@ -5,9 +5,9 @@ public class RandomChanceStatic implements RandomChanceExecution {
     private final double probabilityCap;
     private final boolean isLucky;
 
-    public RandomChanceStatic(double xPos, boolean isLucky) {
+    public RandomChanceStatic(double xPos, double probabilityCap, boolean isLucky) {
         this.xPos = xPos;
-        this.probabilityCap = xPos;
+        this.probabilityCap = probabilityCap;
         this.isLucky = isLucky;
     }
 

--- a/src/main/java/com/gmail/nossr50/util/random/RandomChanceUtil.java
+++ b/src/main/java/com/gmail/nossr50/util/random/RandomChanceUtil.java
@@ -282,10 +282,10 @@ public class RandomChanceUtil {
     }
 
     public static String @NotNull [] calculateAbilityDisplayValuesStatic(@NotNull Player player, @NotNull PrimarySkillType primarySkillType, double chance) {
-        RandomChanceStatic rcs = new RandomChanceStatic(chance, false);
+        RandomChanceStatic rcs = new RandomChanceStatic(chance, LINEAR_CURVE_VAR, false);
         double successChance = getRandomChanceExecutionChance(rcs);
 
-        RandomChanceStatic rcs_lucky = new RandomChanceStatic(chance, true);
+        RandomChanceStatic rcs_lucky = new RandomChanceStatic(chance, LINEAR_CURVE_VAR, true);
         double successChance_lucky = getRandomChanceExecutionChance(rcs_lucky);
 
         String[] displayValues = new String[2];


### PR DESCRIPTION
The fishing skill uses `RandomChanceStatic` to calculate the chances. **However, this class has a mistaken definition with probabilityCap = XPos.** After calculation in `getChanceOfSuccess`, the value `probabilityCap` is put into `maxProbability`. Leads to result formula `chance = XPos * (XPos / 100.0D)`.

This explains why the bug gives chance `definition ^ 2 / 100 as a result`.

The fixed code now can work properly.