### PR TITLE
Fix alchemy not working with latest changes

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/alchemy/AlchemyPotionBrewer.java
+++ b/src/main/java/com/gmail/nossr50/skills/alchemy/AlchemyPotionBrewer.java
@@ -129,7 +129,7 @@ public final class AlchemyPotionBrewer {
             inputList.add(input);
 
             if (output != null) {
-                outputList.set(i, output.toItemStack(item.getAmount()).clone());
+                outputList.add(output.toItemStack(item.getAmount()).clone());
             }
         }
 


### PR DESCRIPTION
This PR modifies the `AlchemyPotionBrewer.finishBrewing` method to add the output item to the output list instead of setting the item to the index (which errors and causes an `IndexOutOfBoundsException` as the list doesn't have the index to set). This fixes #4653 and works properly on my testing server.