### PR TITLE
fix issue #4667 Herbalism Issue (Beetroot)

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/skills/HerbalismCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/skills/HerbalismCommand.java
@@ -91,7 +91,7 @@ public class HerbalismCommand extends SkillCommand {
     protected void permissionsCheck(Player player) {
         hasHylianLuck = canUseSubskill(player, SubSkillType.HERBALISM_HYLIAN_LUCK);
         canGreenTerra = Permissions.greenTerra(player);
-        canGreenThumbPlants = RankUtils.hasUnlockedSubskill(player, SubSkillType.HERBALISM_GREEN_THUMB) && (Permissions.greenThumbPlant(player, Material.WHEAT) || Permissions.greenThumbPlant(player, Material.CARROT) || Permissions.greenThumbPlant(player, Material.POTATO) || Permissions.greenThumbPlant(player, Material.BEETROOT) || Permissions.greenThumbPlant(player, Material.NETHER_WART) || Permissions.greenThumbPlant(player, Material.COCOA));
+        canGreenThumbPlants = RankUtils.hasUnlockedSubskill(player, SubSkillType.HERBALISM_GREEN_THUMB) && (Permissions.greenThumbPlant(player, Material.WHEAT) || Permissions.greenThumbPlant(player, Material.CARROT) || Permissions.greenThumbPlant(player, Material.POTATO) || Permissions.greenThumbPlant(player, Material.BEETROOTS) || Permissions.greenThumbPlant(player, Material.NETHER_WART) || Permissions.greenThumbPlant(player, Material.COCOA));
         canGreenThumbBlocks = RankUtils.hasUnlockedSubskill(player, SubSkillType.HERBALISM_GREEN_THUMB) && (Permissions.greenThumbBlock(player, Material.DIRT) || Permissions.greenThumbBlock(player, Material.COBBLESTONE) || Permissions.greenThumbBlock(player, Material.COBBLESTONE_WALL) || Permissions.greenThumbBlock(player, Material.STONE_BRICKS));
         canFarmersDiet = canUseSubskill(player, SubSkillType.HERBALISM_FARMERS_DIET);
         canDoubleDrop = canUseSubskill(player, SubSkillType.HERBALISM_DOUBLE_DROPS) && !mcMMO.p.getGeneralConfig().getDoubleDropsDisabled(skill);

--- a/src/main/java/com/gmail/nossr50/util/ItemUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/ItemUtils.java
@@ -421,6 +421,7 @@ public final class ItemUtils {
             case CHORUS_FLOWER:
             case POTATO:
             case BEETROOT:
+            case BEETROOTS:
             case BEETROOT_SEEDS:
             case NETHER_WART:
             case BROWN_MUSHROOM:


### PR DESCRIPTION
## General Problem

I noticed that in the definition of `Material.class`, there's difference between `BEETROOT` and `BEETROOTS`. `BEETROOT` is the item that a player holds in hand, while `BEETROOTS` is the plant block that grows.

My fix involves these 2 files:

### src/main/java/com/gmail/nossr50/commands/skills/HerbalismCommand.java

According to the `config.yml` and the `plugin.yml`, the Material used in the `Green_Thumb_Replanting_Crops` check should be `BEETROOTS` instead of `BEETROOT`. I fixed the judgment from `BEETROOT` to `BEETROOTS`.

### src/main/java/com/gmail/nossr50/util/ItemUtils.java

Here I fixed issue #4667 Herbalism Issue (Lilypad + Beetroot). The reason why beetroot hasn't given double drops is that the `isHerbalismDrop` checks `BEETROOT` instead of `BEETROOTS`. I added `BEETROOTS` to the list.

Now in my test, the fix works properly.

Hope you make a full recovery from the cold.