### PR TITLE
Added option to disallow using enchanted materials to repair items.

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
@@ -680,7 +680,7 @@ public class AdvancedConfig extends AutoUpdateConfigLoader {
     /* REPAIR */
     public double getRepairMasteryMaxBonus() { return config.getDouble("Skills.Repair.RepairMastery.MaxBonusPercentage", 200.0D); }
     public int getRepairMasteryMaxLevel() { return config.getInt("Skills.Repair.RepairMastery.MaxBonusLevel", 100); }
-    public boolean getAllowEnchantedRepairMaterials() { return config.getBoolean("Skills.Repair.Items.AllowEnchantedRepairMaterials", false); }
+    public boolean getAllowEnchantedRepairMaterials() { return config.getBoolean("Skills.Repair.Use_Enchanted_Materials", false); }
 
     public boolean getArcaneForgingEnchantLossEnabled() { return config.getBoolean("Skills.Repair.ArcaneForging.May_Lose_Enchants", true); }
     public double getArcaneForgingKeepEnchantsChance(int rank) { return config.getDouble("Skills.Repair.ArcaneForging.Keep_Enchants_Chance.Rank_" + rank); }

--- a/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
@@ -680,6 +680,7 @@ public class AdvancedConfig extends AutoUpdateConfigLoader {
     /* REPAIR */
     public double getRepairMasteryMaxBonus() { return config.getDouble("Skills.Repair.RepairMastery.MaxBonusPercentage", 200.0D); }
     public int getRepairMasteryMaxLevel() { return config.getInt("Skills.Repair.RepairMastery.MaxBonusLevel", 100); }
+    public boolean getAllowEnchantedRepairMaterials() { return config.getBoolean("Skills.Repair.Items.AllowEnchantedRepairMaterials", false); }
 
     public boolean getArcaneForgingEnchantLossEnabled() { return config.getBoolean("Skills.Repair.ArcaneForging.May_Lose_Enchants", true); }
     public double getArcaneForgingKeepEnchantsChance(int rank) { return config.getDouble("Skills.Repair.ArcaneForging.Keep_Enchants_Chance.Rank_" + rank); }

--- a/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
@@ -28,8 +28,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
@@ -28,11 +28,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -141,14 +138,15 @@ public class RepairManager extends SkillManager {
             // See if our proposed item is even enchanted in the first place.
             if (toRemove.getEnchantments().size() > 0) {
 
-                // Lots of array sorting to gather a possible list of items not including the enchanted item.
-                List<ItemStack> possibleMaterials = Arrays.stream(inventory.getContents())
+                // Lots of array sorting to find a potential non-enchanted candidate item.
+                Optional<ItemStack> possibleMaterial = Arrays.stream(inventory.getContents())
                         .filter(Objects::nonNull)
                         .filter(p -> p.getType() == repairMaterial)
-                        .filter(p -> p.getEnchantments().size() == 0).toList();
+                        .filter(p -> p.getEnchantments().isEmpty())
+                        .findFirst();
 
                 // Fail out with "you need material" if we don't find a suitable alternative.
-                if (possibleMaterials.size() == 0) {
+                if (possibleMaterial.isEmpty()) {
                     String prettyName = repairable.getRepairMaterialPrettyName() == null ? StringUtils.getPrettyItemString(repairMaterial) : repairable.getRepairMaterialPrettyName();
 
                     String materialsNeeded = "";
@@ -157,8 +155,8 @@ public class RepairManager extends SkillManager {
                     return;
                 }
 
-                // If there is at least one item in the array, use the first one.
-                toRemove = possibleMaterials.get(0).clone();
+                // Update our toRemove item to our suggested possible material.
+                toRemove = possibleMaterial.get().clone();
             }
         }
         

--- a/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
@@ -28,8 +28,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 public class RepairManager extends SkillManager {
     private boolean placedAnvil;
@@ -128,6 +133,34 @@ public class RepairManager extends SkillManager {
 
         // toRemove should be refreshed before the event call.
         toRemove = inventory.getItem(inventory.first(repairMaterial)).clone();
+
+        // Check if we allow enchanted materials to be used to repair objects.
+        // (Servers may provide enchanted items that don't follow their intended use)
+        if (!mcMMO.p.getAdvancedConfig().getAllowEnchantedRepairMaterials()) {
+
+            // See if our proposed item is even enchanted in the first place.
+            if (toRemove.getEnchantments().size() > 0) {
+
+                // Lots of array sorting to gather a possible list of items not including the enchanted item.
+                List<ItemStack> possibleMaterials = Arrays.stream(inventory.getContents())
+                        .filter(Objects::nonNull)
+                        .filter(p -> p.getType() == repairMaterial)
+                        .filter(p -> p.getEnchantments().size() == 0).toList();
+
+                // Fail out with "you need material" if we don't find a suitable alternative.
+                if (possibleMaterials.size() == 0) {
+                    String prettyName = repairable.getRepairMaterialPrettyName() == null ? StringUtils.getPrettyItemString(repairMaterial) : repairable.getRepairMaterialPrettyName();
+
+                    String materialsNeeded = "";
+
+                    NotificationManager.sendPlayerInformation(player, NotificationType.SUBSKILL_MESSAGE_FAILED, "Skills.NeedMore.Extra", prettyName, materialsNeeded);
+                    return;
+                }
+
+                // If there is at least one item in the array, use the first one.
+                toRemove = possibleMaterials.get(0).clone();
+            }
+        }
         
         // Call event
         if (EventUtils.callRepairCheckEvent(player, (short) (startDurability - newDurability), toRemove, item).isCancelled()) {


### PR DESCRIPTION
Due to an issue where special use items created by other plugins were being used to repair tools, I created this option to allow server owners to disable using enchanted items to repair tools.

Note, this does not disable repairing enchanted _tools_, just using enchanted _materials_ to repair tools.
 
Since to my knowledge you can not (through vanilla survival means) enchant materials (i.e. iron ingots) used to repair tools, having this disabled should not affect normal gameplay.

Here is what I have done in each affected file:
AdvancedConfig  - Added getAllowEnchantedRepairMaterials to config, enable it if you'd like to mimic the original behavior
RepairManager  - Added functionality to (if enabled) disallow enchanted materials to be used to repair tools, and find potentially non-enchanted repair materials (if they exist in the player's inventory)

Feel free to let me know if there is anything you would like changed and I will be happy to do so. 😃 