### PR TITLE
Fix extra 0 in level for gunpowder in retro mode

### DIFF
--- a/src/main/resources/treasures.yml
+++ b/src/main/resources/treasures.yml
@@ -16,7 +16,7 @@ Excavation:
         Drop_Chance: 10.0
         Level_Requirement:
             Standard_Mode: 10
-            Retro_Mode: 1000
+            Retro_Mode: 100
         Drops_From: [Gravel]
     BONE:
         Amount: 1


### PR DESCRIPTION
Looks like an extra 0 slipped in!

Fixes #4532