### PR TITLE
Add Multiple Custom Boost Options in Experience.yml

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -12,14 +12,17 @@ import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 public class ExperienceConfig extends AutoUpdateConfigLoader {
     private static ExperienceConfig instance;
-
+    
     private ExperienceConfig() {
         super("experience.yml");
         validate();
@@ -144,7 +147,6 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     /*
      * FORMULA SETTINGS
      */
-
     /* EXPLOIT TOGGLES */
     public boolean isSnowExploitPrevented() { return config.getBoolean("ExploitFix.SnowGolemExcavation", true); }
     public boolean isEndermanEndermiteFarmingPrevented() { return config.getBoolean("ExploitFix.EndermanEndermiteFarms", true); }
@@ -188,7 +190,15 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     public double getFormulaSkillModifier(PrimarySkillType skill) { return config.getDouble("Experience_Formula.Modifier." + StringUtils.getCapitalized(skill.toString())); }
 
     /* Custom XP perk */
-    public double getCustomXpPerkBoost() { return config.getDouble("Experience_Formula.Custom_XP_Perk.Boost", 1.25); }
+    public double getCustomXpPerkBoost() { 
+    	
+    	for(String RankName : ExperienceConfig.getInstance().getListofCustomPerks()) {
+    		return config.getDouble("Experience_Formula.Custom_XP_Perk."+RankName, 1.25);    		
+    	}
+		return 1;
+    }
+    
+    public Set<String> getListofCustomPerks() {return config.getConfigurationSection("Experience_Formula.Custom_XP_Perk").getKeys(false);}
 
     /* Diminished Returns */
     public float getDiminishedReturnsCap() { return (float) config.getDouble("Dimished_Returns.Guaranteed_Minimum_Percentage", 0.05D); }

--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -199,11 +199,9 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     	for(String RankName : getListofCustomPerks()) {
     		if(permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
     	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH))) {
-    			System.out.println(RankName);
     			return RankName;
     		}
     	}
-    	System.out.println(false);
 		return null;
     	 
     }

--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -1,24 +1,25 @@
 package com.gmail.nossr50.config.experience;
 
-import com.gmail.nossr50.config.AutoUpdateConfigLoader;
-import com.gmail.nossr50.datatypes.experience.FormulaType;
-import com.gmail.nossr50.datatypes.skills.MaterialType;
-import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
-import com.gmail.nossr50.datatypes.skills.alchemy.PotionStage;
-import com.gmail.nossr50.util.text.StringUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.EntityType;
+import org.bukkit.permissions.Permissible;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import com.gmail.nossr50.config.AutoUpdateConfigLoader;
+import com.gmail.nossr50.datatypes.experience.FormulaType;
+import com.gmail.nossr50.datatypes.skills.MaterialType;
+import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
+import com.gmail.nossr50.datatypes.skills.alchemy.PotionStage;
+import com.gmail.nossr50.util.text.StringUtils;
 
 public class ExperienceConfig extends AutoUpdateConfigLoader {
     private static ExperienceConfig instance;
@@ -190,15 +191,21 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     public double getFormulaSkillModifier(PrimarySkillType skill) { return config.getDouble("Experience_Formula.Modifier." + StringUtils.getCapitalized(skill.toString())); }
 
     /* Custom XP perk */
-    public double getCustomXpPerkBoost() { 
-    	
-    	for(String RankName : ExperienceConfig.getInstance().getListofCustomPerks()) {
-    		return config.getDouble("Experience_Formula.Custom_XP_Perk."+RankName, 1.25);    		
-    	}
-		return 1;
-    }
+    public double getCustomXpPerkBoost(String RankName) {return config.getDouble("Experience_Formula.Custom_XP_Perk."+RankName, 1.25);}
     
     public Set<String> getListofCustomPerks() {return config.getConfigurationSection("Experience_Formula.Custom_XP_Perk").getKeys(false);}
+    
+    public String getRankName(Permissible permissible, PrimarySkillType skill) {
+    	for(String RankName : getListofCustomPerks()) {
+    		if(permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
+    	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH))) {
+    			return RankName;
+    		}
+    	}
+		return null;
+    	 
+    }
+    
 
     /* Diminished Returns */
     public float getDiminishedReturnsCap() { return (float) config.getDouble("Dimished_Returns.Guaranteed_Minimum_Percentage", 0.05D); }
@@ -397,4 +404,6 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     }
 
     public boolean preventStoneLavaFarming() { return config.getBoolean("ExploitFix.LavaStoneAndCobbleFarming", true);}
+
+	
 }

--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -199,9 +199,11 @@ public class ExperienceConfig extends AutoUpdateConfigLoader {
     	for(String RankName : getListofCustomPerks()) {
     		if(permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
     	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH))) {
+    			System.out.println(RankName);
     			return RankName;
     		}
     	}
+    	System.out.println(false);
 		return null;
     	 
     }

--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -141,7 +141,7 @@ public final class Permissions {
     }
 
     public static boolean customXpBoost(Permissible permissible, PrimarySkillType skill) {
-    	
+    	System.out.println(ExperienceConfig.getInstance().getListofCustomPerks());
     	for(String RankName : ExperienceConfig.getInstance().getListofCustomPerks()) {
     		return permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
     	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH));    		

--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -141,7 +141,6 @@ public final class Permissions {
     }
 
     public static boolean customXpBoost(Permissible permissible, PrimarySkillType skill) {
-    	System.out.println(ExperienceConfig.getInstance().getListofCustomPerks());
     	for(String RankName : ExperienceConfig.getInstance().getListofCustomPerks()) {
     		if(permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
     	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH))) {

--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -1,6 +1,7 @@
 package com.gmail.nossr50.util;
 
 import com.gmail.nossr50.commands.party.PartySubcommandType;
+import com.gmail.nossr50.config.experience.ExperienceConfig;
 import com.gmail.nossr50.datatypes.skills.ItemType;
 import com.gmail.nossr50.datatypes.skills.MaterialType;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
@@ -140,8 +141,12 @@ public final class Permissions {
     }
 
     public static boolean customXpBoost(Permissible permissible, PrimarySkillType skill) {
-        return permissible.hasPermission("mcmmo.perks.xp.customboost.all")
-            || permissible.hasPermission("mcmmo.perks.xp.customboost." + skill.toString().toLowerCase(Locale.ENGLISH));
+    	
+    	for(String RankName : ExperienceConfig.getInstance().getListofCustomPerks()) {
+    		return permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
+    	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH));    		
+    	}
+		return false;
     }
 
 

--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -143,8 +143,12 @@ public final class Permissions {
     public static boolean customXpBoost(Permissible permissible, PrimarySkillType skill) {
     	System.out.println(ExperienceConfig.getInstance().getListofCustomPerks());
     	for(String RankName : ExperienceConfig.getInstance().getListofCustomPerks()) {
-    		return permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
-    	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH));    		
+    		if(permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
+    	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH))) {
+    			return permissible.hasPermission("mcmmo.perks.xp.customboost." + RankName + ".all")
+        	            || permissible.hasPermission("mcmmo.perks.xp.customboost."+ RankName + "."+ skill.toString().toLowerCase(Locale.ENGLISH));    
+    		}
+    				
     	}
 		return false;
     }

--- a/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
@@ -56,8 +56,9 @@ public final class PerksUtils {
             if(UserManager.getPlayer(player) != null && UserManager.getPlayer(player).isDebugMode()) {
                 player.sendMessage(ChatColor.GOLD + "[DEBUG] " + ChatColor.DARK_GRAY + "XP Perk Multiplier IS CUSTOM! ");
             }
-
-             modifier = ExperienceConfig.getInstance().getCustomXpPerkBoost();
+            String RankName = ExperienceConfig.getInstance().getRankName(player, skill);
+            
+            modifier = ExperienceConfig.getInstance().getCustomXpPerkBoost(RankName);
         }
         else if (Permissions.quadrupleXp(player, skill)) {
             modifier = 4;

--- a/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
@@ -57,8 +57,10 @@ public final class PerksUtils {
                 player.sendMessage(ChatColor.GOLD + "[DEBUG] " + ChatColor.DARK_GRAY + "XP Perk Multiplier IS CUSTOM! ");
             }
             String RankName = ExperienceConfig.getInstance().getRankName(player, skill);
+            System.out.println(RankName+"test");
             
             modifier = ExperienceConfig.getInstance().getCustomXpPerkBoost(RankName);
+            System.out.println(modifier);
         }
         else if (Permissions.quadrupleXp(player, skill)) {
             modifier = 4;

--- a/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
@@ -57,10 +57,8 @@ public final class PerksUtils {
                 player.sendMessage(ChatColor.GOLD + "[DEBUG] " + ChatColor.DARK_GRAY + "XP Perk Multiplier IS CUSTOM! ");
             }
             String RankName = ExperienceConfig.getInstance().getRankName(player, skill);
-            System.out.println(RankName+"test");
             
             modifier = ExperienceConfig.getInstance().getCustomXpPerkBoost(RankName);
-            System.out.println(modifier);
         }
         else if (Permissions.quadrupleXp(player, skill)) {
             modifier = 4;

--- a/src/main/resources/experience.yml
+++ b/src/main/resources/experience.yml
@@ -171,10 +171,11 @@ Experience_Formula:
         Fishing: 1.0
         Alchemy: 1.0
 
-    # XP earned by players with the permission mcmmo.perks.xp.customboost.<skillname> will get multiplied
+    # XP earned by players with the permission mcmmo.perks.xp.customboost.rank1.<skillname> will get multiplied
     # with 1.25 by default, resulting in a 25% XP boost
     Custom_XP_Perk:
-        Boost: 1.25
+        Rank1: 1.25
+        Rank2: 1.3
 
 #
 # Settings for Diminished Returns


### PR DESCRIPTION
Replaced single custom boost with configurable multiple options. This can be added by adding the name of the rank and double to the configuration in the required spot.