### PR TITLE
Disable parsing comments to prevent duplicate comments

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
+++ b/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
@@ -48,6 +48,12 @@ public abstract class AutoUpdateConfigLoader extends ConfigLoader {
         super.loadFile();
         FileConfiguration internalConfig = YamlConfiguration.loadConfiguration(mcMMO.p.getResourceAsReader(fileName));
 
+        try {
+            internalConfig.options().parseComments(false);
+            config.options().parseComments(false);
+        }
+        catch (NoSuchMethodError ignored) {}
+
         Set<String> configKeys = config.getKeys(true);
         Set<String> internalConfigKeys = internalConfig.getKeys(true);
 


### PR DESCRIPTION
This apparently also removes all duplicate comments that were added.

So far tests:

* 1 - Works
* 0 - Not works

Would love more testers, though, since I can't reproduce this issue.

Fixes #4702 