### PR TITLE
remove YAML parsing hacks in favor of native bukkit provided parsing

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
+++ b/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
@@ -61,14 +61,16 @@ public abstract class AutoUpdateConfigLoader extends ConfigLoader {
 
         // Don't need a re-save if we have old keys sticking around?
         // Would be less saving, but less... correct?
-        if (!newKeys.isEmpty() || !oldKeys.isEmpty()) {
+        if (!newKeys.isEmpty() /*|| !oldKeys.isEmpty()*/) {
             needSave = true;
         }
-//
-//        for (String key : oldKeys) {
-//            mcMMO.p.debug("Detected potentially unused key: " + key);
-//            //config.set(key, null);
-//        }
+        if (!oldKeys.isEmpty()) {
+            mcMMO.p.getLogger().info("[yaml-fixer] old key(s) in " +fileName);
+        }
+        for (String key : oldKeys) {
+            mcMMO.p.getLogger().info("[yaml-fixer] old-key:" + key);
+            //config.set(key, null);
+        }
 
         for (String key : newKeys) {
             mcMMO.p.debug("Adding new key: " + key + " = " + internalConfig.get(key));

--- a/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
+++ b/src/main/java/com/gmail/nossr50/config/AutoUpdateConfigLoader.java
@@ -3,13 +3,11 @@ package com.gmail.nossr50.config;
 import com.gmail.nossr50.mcMMO;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.configuration.file.YamlConfigurationOptions;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.*;
-import java.util.HashMap;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Set;
 
 public abstract class AutoUpdateConfigLoader extends ConfigLoader {


### PR DESCRIPTION
fixes #4702
related #4713

only changes are whitespace compared to default config generator (better comment indentation, etc)

it keeps the default 4 indentation, since i dont want to change that

this also prints old config keys that would cause a save before.
