### PR TITLE
Fixed scoreboard showing vanish players bug

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardWrapper.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardWrapper.java
@@ -20,7 +20,6 @@ import com.gmail.nossr50.util.skills.SkillTools;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardWrapper.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardWrapper.java
@@ -20,6 +20,7 @@ import com.gmail.nossr50.util.skills.SkillTools;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
@@ -632,6 +633,9 @@ public class ScoreboardWrapper {
 
             if (name.equals(playerName)) {
                 name = ChatColor.GOLD + "--You--";
+            }
+            else {
+                name = " " + ChatColor.WHITE + name + " ";
             }
 
             sidebarObjective.getScore(name).setScore(stat.statVal);


### PR DESCRIPTION
This is a bit of a hack to fix the following issue: https://github.com/mcMMO-Dev/mcMMO/issues/4675. It turns out that issue was caused by another plugin (potentially very frequently used) overloading the Scoreboard `getScore` [method](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/scoreboard/Objective.html#getScore(java.lang.String)). This PR only has a single commit which adds an else statement to add a space + a white color code in front of the mctop scoreboard.

I completely understand if you choose to deny this PR as it isn't really an MCMMO issue but I do believe it can help others with the same issue.