### PR TITLE
Fix Maven build failure

### DIFF
--- a/src/main/java/com/gmail/nossr50/events/fake/FakePlayerAnimationEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/fake/FakePlayerAnimationEvent.java
@@ -2,12 +2,13 @@ package com.gmail.nossr50.events.fake;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerAnimationEvent;
+import org.bukkit.event.player.PlayerAnimationType;
 
 /**
  * Called when handling extra drops to avoid issues with NoCheat.
  */
 public class FakePlayerAnimationEvent extends PlayerAnimationEvent implements FakeEvent {
-    public FakePlayerAnimationEvent(Player player) {
-        super(player);
+    public FakePlayerAnimationEvent(Player player, PlayerAnimationType playerAnimationType) {
+        super(player, playerAnimationType);
     }
 }

--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -841,7 +841,7 @@ public class PlayerListener implements Listener {
 
                 HerbalismManager herbalismManager = mcMMOPlayer.getHerbalismManager();
 
-                FakePlayerAnimationEvent fakeSwing = new FakePlayerAnimationEvent(event.getPlayer()); //PlayerAnimationEvent compat
+                FakePlayerAnimationEvent fakeSwing = new FakePlayerAnimationEvent(event.getPlayer(), PlayerAnimationType.ARM_SWING); //PlayerAnimationEvent compat
                 if(!event.isCancelled() || event.useInteractedBlock() != Event.Result.DENY) {
                     //TODO: Is this code to set false from bone meal even needed? I'll have to double check later.
                     if (heldItem.getType() == Material.BONE_MEAL) {

--- a/src/main/java/com/gmail/nossr50/util/EventUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/EventUtils.java
@@ -44,6 +44,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerAnimationType;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
@@ -225,7 +226,7 @@ public final class EventUtils {
     }
 
     public static FakePlayerAnimationEvent callFakeArmSwingEvent(Player player) {
-        FakePlayerAnimationEvent event = new FakePlayerAnimationEvent(player);
+        FakePlayerAnimationEvent event = new FakePlayerAnimationEvent(player, PlayerAnimationType.ARM_SWING);
         mcMMO.p.getServer().getPluginManager().callEvent(event);
 
         return event;


### PR DESCRIPTION
This fixes the Maven build failure. It also appears to get rid of some console errors I was experiencing (i.e., `[Thu 12:14:00 ERROR Minecraft] Could not pass event PlayerInteractEvent to mcMMO v2.1.213-SNAPSHOT`) while running the mod on a 1.19 server