### PR TITLE
Added MMODebug permission

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/admin/PlayerDebugCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/admin/PlayerDebugCommand.java
@@ -1,6 +1,7 @@
 package com.gmail.nossr50.commands.admin;
 
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
+import com.gmail.nossr50.util.Permissions;
 import com.gmail.nossr50.util.player.NotificationManager;
 import com.gmail.nossr50.util.player.UserManager;
 import org.bukkit.command.Command;
@@ -14,9 +15,15 @@ public class PlayerDebugCommand implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         if(sender instanceof Player) {
+            if (!Permissions.mmodebug(sender)) {
+                sender.sendMessage(command.getPermissionMessage());
+                return true;
+            }
+
             McMMOPlayer mcMMOPlayer = UserManager.getPlayer((Player) sender);
             mcMMOPlayer.toggleDebugMode(); //Toggle debug mode
             NotificationManager.sendPlayerInformationChatOnlyPrefixed(mcMMOPlayer.getPlayer(), "Commands.Mmodebug.Toggle", String.valueOf(mcMMOPlayer.isDebugMode()));
+
             return true;
         } else {
             return false;

--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -43,6 +43,7 @@ public final class Permissions {
      * COMMANDS
      */
 
+    public static boolean mmodebug(Permissible permissible) { return permissible.hasPermission("mcmmo.commands.mmodebug"); }
     public static boolean mmoinfo(Permissible permissible) { return permissible.hasPermission("mcmmo.commands.mmoinfo"); }
     public static boolean addlevels(Permissible permissible) { return permissible.hasPermission("mcmmo.commands.addlevels"); }
     public static boolean addlevelsOthers(Permissible permissible) { return permissible.hasPermission("mcmmo.commands.addlevels.others"); }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -30,6 +30,7 @@ commands:
     mmodebug:
         aliases: [mcmmodebugmode]
         description: Toggles a debug mode which will print useful information to chat
+        permission: mcmmo.commands.mmodebug
     mmoinfo:
         aliases: [mcinfo]
         description: Info pages for mcMMO
@@ -796,6 +797,7 @@ permissions:
     mcmmo.commands.defaults:
         description: Implies all default mcmmo.commands permissions.
         children:
+            mcmmo.commands.mmodebug: true
             mcmmo.commands.mmoinfo: true
             mcmmo.commands.acrobatics: true
             mcmmo.commands.alchemy: true


### PR DESCRIPTION
- Added the `mcmmo.commands.mmodebug` for the command `/mmodebug`

Seems to default to true on my test server. Therefor, it provides an option for admins to disable it.