### PR TITLE
Switch to new sk89q repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,8 +226,8 @@
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
         <repository>
-            <id>sk89q-repo</id>
-            <url>https://maven.sk89q.com/repo/</url>
+            <id>enginehub-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository> <!-- for development builds -->
             <id>sonatype-oss</id>


### PR DESCRIPTION
Seems like https://maven.sk89q.com/repo/ is down for good, causing projects which depend on mcMMO to fail build with "Cannot resolve com.sk89q.worldedit.worldedit-libs:core:7.2.0-SNAPSHOT"