### PR TITLE
Fix: Advanced Config: Mining.BlastMining.DropMultiplier was not being used

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/skills/MiningCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/skills/MiningCommand.java
@@ -45,7 +45,7 @@ public class MiningCommand extends SkillCommand {
             MiningManager miningManager = UserManager.getPlayer(player).getMiningManager();
 
             blastMiningRank = miningManager.getBlastMiningTier();
-            bonusTNTDrops = miningManager.getDropMultiplier();
+            bonusTNTDrops = miningManager.getDropMultiplier(miningManager.getBlastMiningTier());
             oreBonus = percent.format(miningManager.getOreBonus() / 30.0D); // Base received in TNT is 30%
 //            debrisReduction = percent.format(miningManager.getDebrisReduction() / 30.0D); // Base received in TNT is 30%
             blastDamageDecrease = percent.format(miningManager.getBlastDamageModifier() / 100.0D);

--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -166,7 +166,7 @@ public class MiningManager extends SkillManager {
 
         float oreBonus = (float) (getOreBonus() / 100);
         float debrisReduction = (float) (getDebrisReduction() / 100);
-        int dropMultiplier = getDropMultiplier();
+        int dropMultiplier = getDropMultiplier(getBlastMiningTier());
         float debrisYield = yield - debrisReduction;
 
         //Drop "debris" based on skill modifiers


### PR DESCRIPTION
When calculating the bonus drops multiplier for blast mining, mcMMO was using hardcoded values instead of taking values from the advanced.yml configuration under Mining.BlastMining.DropMultiplier. The function `getDropMultiplier()` was defaulting to hardcoded values since no blast mining tier was passed instead of it's overload `getDropMultiplier(int rank)` which reached out to the advanced config to get user-defined multiplier values.

The blast mining tier rank is now supplied, and the base function `getDropMultiplier()` now doesn't seem to be used anywhere, but I'll leave refactoring out of this commit for a maintainer to look at :^)

![2022-07-09_02-51-31_Photoshop_rauM](https://user-images.githubusercontent.com/33894549/178087232-00f678b5-51be-429c-845f-8fcebc02f380.png)