### PR TITLE
Updated kyori adventure-platform dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,12 +279,12 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.0.1</version>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-api</artifactId>
-            <version>4.0.1</version>
+            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>


### PR DESCRIPTION
An attempt to fix #4792 and a version update nonetheless. 

Taken new versions from: https://search.maven.org/search?q=g:net.kyori%20AND%20a:adventure-platform*