### PR TITLE
Updated Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jrje</version> <!-- At this time Spigot is including 29.0 Guava classes that we are using -->
+            <version>31.1-jre</version> <!-- At this time Spigot is including 29.0 Guava classes that we are using -->
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -246,9 +246,9 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>net.gmcbm.dependencies</groupId>
+            <groupId>co.aikar</groupId>
             <artifactId>acf-bukkit</artifactId> <!-- Don't forget to replace this -->
-            <version>0.5.2</version> <!-- Replace this as well -->
+            <version>0.5.1-SNAPSHOT</version> <!-- Replace this as well -->
         </dependency>
 <!--        adventure-api, adventure-text-serializer-gson, adventure-platform-bukkit-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -246,9 +246,9 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>co.aikar</groupId>
+            <groupId>net.gmcbm.dependencies</groupId>
             <artifactId>acf-bukkit</artifactId> <!-- Don't forget to replace this -->
-            <version>0.5.0-SNAPSHOT</version> <!-- Replace this as well -->
+            <version>0.5.2</version> <!-- Replace this as well -->
         </dependency>
 <!--        adventure-api, adventure-text-serializer-gson, adventure-platform-bukkit-->
         <dependency>
@@ -289,12 +289,12 @@
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.12.0</version>
+            <version>2.0.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>2.2.1</version>
+            <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -306,7 +306,7 @@
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-core</artifactId>
-            <version>7.0.4</version>
+            <version>7.0.7</version>
             <exclusions>
                 <exclusion>
                     <!-- We use jetbrains instead. Excluding this -->
@@ -330,36 +330,36 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0-RC1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.2.0</version>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.2.0</version>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jdbc</artifactId>
-            <version>10.0.14</version>
+            <version>10.1.0-M16</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>22.0.0</version>
+            <version>23.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version> <!-- At this time Spigot is including 29.0 Guava classes that we are using -->
+            <version>31.1-jrje</version> <!-- At this time Spigot is including 29.0 Guava classes that we are using -->
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
List of dependencies updated with links to verify:

- https://github.com/aikar/commands#targeted-platforms--current-version
- https://search.maven.org/artifact/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0-M1/jar
- https://search.maven.org/artifact/org.bstats/bstats-bukkit/3.0.0/jar
- https://maven.enginehub.org/repo/com/sk89q/worldguard/worldguard-core/
- https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter/5.9.0-RC1/jar
- https://search.maven.org/artifact/org.mockito/mockito-core/4.6.1/jar
- https://search.maven.org/artifact/org.mockito/mockito-inline/4.6.1/jar
- https://search.maven.org/artifact/org.apache.tomcat/tomcat-jdbc/10.1.0-M16/jar
- https://search.maven.org/artifact/org.jetbrains/annotations/23.0.0/jar
- https://search.maven.org/artifact/com.google.guava/guava/31.1-jre/bundle