### PR TITLE
Updated dependencies to fix hovering over subskills for 1.19.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.19.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -330,7 +330,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.0-RC1</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -348,7 +348,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jdbc</artifactId>
-            <version>10.1.0-M16</version>
+            <version>10.1.0-M17</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.19.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.0-RC1</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -348,7 +348,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jdbc</artifactId>
-            <version>10.1.0-M16</version>
+            <version>10.1.0-M17</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -279,17 +279,17 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.1.1</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-api</artifactId>
-            <version>4.1.1</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>2.0.0-M1</version>
+            <version>2.0.0-M2</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>2.0.0-M2</version>
+            <version>2.0.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>
@@ -300,7 +300,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.2-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -330,7 +330,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.0</version>
+            <version>5.9.0-RC1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -348,7 +348,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jdbc</artifactId>
-            <version>10.1.0-M17</version>
+            <version>10.1.0-M16</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Hovering over subskills has broken again with the release of 1.19.2. Updating these dependencies should cause the feature to work again.

Dependencies updated so far:
- https://search.maven.org/artifact/net.kyori/adventure-platform-bukkit/4.1.2/jar
- https://search.maven.org/artifact/net.kyori/adventure-platform-api/4.1.2/jar
- https://hub.spigotmc.org/nexus/content/repositories/snapshots/org/spigotmc/spigot-api/
- https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter/5.9.0/jar
- https://search.maven.org/artifact/org.apache.tomcat/tomcat-jdbc/10.1.0-M17/jar