### PR TITLE
Updated plugins to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.0.0-M7</version>
 
                 <configuration>
                     <junitArtifactName>org.junit.jupiter:junit-jupiter</junitArtifactName>
@@ -84,7 +84,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.0.0-M7</version>
 
                 <configuration>
                     <junitArtifactName>org.junit.jupiter:junit-jupiter</junitArtifactName>
@@ -95,12 +95,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>3.0.0-M6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <release>16</release>
                     <compilerArgs>
@@ -130,7 +130,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.1-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <configuration>
                     <artifactSet>
                         <includes>
@@ -205,7 +205,7 @@
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-file</artifactId>
-                <version>2.2</version>
+                <version>3.5.2</version>
             </extension>
         </extensions>
     </build>


### PR DESCRIPTION
This doesn't fix any issues and is mostly a QOL change. I've tested this via self-compiling and it seems to compile and run fine ingame.

Plugins updated:
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-failsafe-plugin
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-release-plugin
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin
- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-shade-plugin
- https://mvnrepository.com/artifact/org.apache.maven.wagon/wagon-file