### PR TITLE
Fix bug where players could know staff are invis

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
@@ -74,7 +74,7 @@ public class InspectCommand implements TabExecutor {
                 if (!isVanished && CommandUtils.tooFar(sender, target, Permissions.inspectFar(sender))) {
                     return true;
                 }
-                
+
                 if (mcMMO.p.getGeneralConfig().getScoreboardsEnabled()
                         && sender instanceof Player
                         && mcMMO.p.getGeneralConfig().getInspectUseBoard()) {

--- a/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
@@ -74,7 +74,7 @@ public class InspectCommand implements TabExecutor {
                 if (!isVanished && CommandUtils.tooFar(sender, target, Permissions.inspectFar(sender))) {
                     return true;
                 }
-
+                
                 if (mcMMO.p.getGeneralConfig().getScoreboardsEnabled()
                         && sender instanceof Player
                         && mcMMO.p.getGeneralConfig().getInspectUseBoard()) {
@@ -85,11 +85,19 @@ public class InspectCommand implements TabExecutor {
                     }
                 }
 
-                sender.sendMessage(LocaleLoader.getString("Inspect.Stats", target.getName()));
+                if (isVanished) {
+                    sender.sendMessage(LocaleLoader.getString("Inspect.OfflineStats", playerName));
+                } else {
+                    sender.sendMessage(LocaleLoader.getString("Inspect.Stats", target.getName()));
+                }
+
                 CommandUtils.printGatheringSkills(target, sender);
                 CommandUtils.printCombatSkills(target, sender);
                 CommandUtils.printMiscSkills(target, sender);
-                sender.sendMessage(LocaleLoader.getString("Commands.PowerLevel", mcMMOPlayer.getPowerLevel()));
+
+                if (!isVanished) {
+                    sender.sendMessage(LocaleLoader.getString("Commands.PowerLevel", mcMMOPlayer.getPowerLevel()));
+                }
             }
 
             return true;


### PR DESCRIPTION
When inspecting a staff member that is invisible to you, the displayed message is different from when inspecting an actual offline player; the power level is shown and the heading other message does not mention the player is offline whereas the offline message specified the player is offline.