### PR TITLE
Dupe Fix: Don't add bonus drops for non-natural blocks

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -77,7 +77,7 @@ public class BlockListener implements Listener {
         }
 
         //If there are more than one block in the item list we can't really trust it and will back out of rewarding bonus drops
-        if(blockCount <= 1) {
+        if(blockCount <= 1 && !mcMMO.getPlaceStore().isTrue(event.getBlockState())) { // only process bonus drops for naturally generated blocks
             for(Item item : event.getItems())
             {
                 ItemStack is = new ItemStack(item.getItemStack());


### PR DESCRIPTION
Currently, the double drops sub-skill gives you double drops regardless of if the block is naturally generated or placed by a player. This PR fixes that by doing a check before dropping bonus items to ensure the block was not placed by a player.