### PR TITLE
Fixed fishing exploiting compatibility

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -450,6 +450,9 @@ public class PlayerListener implements Listener {
             case CAUGHT_FISH:
                 if(caught instanceof Item) {
                     if(ExperienceConfig.getInstance().isFishingExploitingPrevented()) {
+
+                        fishingManager.processExploiting(event.getHook().getLocation().toVector());
+                        
                         if (fishingManager.isExploitingFishing(event.getHook().getLocation().toVector())) {
                             player.sendMessage(LocaleLoader.getString("Fishing.ScarcityTip", ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange()));
                             event.setExpToDrop(0);

--- a/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/PlayerListener.java
@@ -452,7 +452,7 @@ public class PlayerListener implements Listener {
                     if(ExperienceConfig.getInstance().isFishingExploitingPrevented()) {
 
                         fishingManager.processExploiting(event.getHook().getLocation().toVector());
-                        
+
                         if (fishingManager.isExploitingFishing(event.getHook().getLocation().toVector())) {
                             player.sendMessage(LocaleLoader.getString("Fishing.ScarcityTip", ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange()));
                             event.setExpToDrop(0);

--- a/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
@@ -125,6 +125,20 @@ public class FishingManager extends SkillManager {
         return hasFished;
     }
 
+    public void processExploiting(Vector centerOfCastVector) {
+        BoundingBox newCastBoundingBox = makeBoundingBox(centerOfCastVector);
+        boolean sameTarget = lastFishingBoundingBox != null && lastFishingBoundingBox.overlaps(newCastBoundingBox);
+
+        if (sameTarget)
+            fishCaughtCounter++;
+        else
+            fishCaughtCounter = 1;
+
+        if (fishCaughtCounter + 1 == ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit()) {
+            getPlayer().sendMessage(LocaleLoader.getString("Fishing.LowResourcesTip", ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange()));
+        }
+    }
+
     public boolean isExploitingFishing(Vector centerOfCastVector) {
 
         /*Block targetBlock = getPlayer().getTargetBlock(BlockUtils.getTransparentBlocks(), 100);
@@ -134,22 +148,10 @@ public class FishingManager extends SkillManager {
         }*/
 
         BoundingBox newCastBoundingBox = makeBoundingBox(centerOfCastVector);
-
         boolean sameTarget = lastFishingBoundingBox != null && lastFishingBoundingBox.overlaps(newCastBoundingBox);
 
-        if(sameTarget)
-            fishCaughtCounter++;
-        else
-            fishCaughtCounter = 1;
-
-        if(fishCaughtCounter + 1 == ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit())
-        {
-            getPlayer().sendMessage(LocaleLoader.getString("Fishing.LowResourcesTip", ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange()));
-        }
-
         //If the new bounding box does not intersect with the old one, then update our bounding box reference
-        if(!sameTarget)
-            lastFishingBoundingBox = newCastBoundingBox;
+        if (!sameTarget) lastFishingBoundingBox = newCastBoundingBox;
 
         return sameTarget && fishCaughtCounter >= ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit();
     }

--- a/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
@@ -51,6 +51,7 @@ public class FishingManager extends SkillManager {
     private long lastWarnedExhaust = 0L;
     private FishHook fishHookReference;
     private BoundingBox lastFishingBoundingBox;
+    private boolean sameTarget;
     private Item fishingCatch;
     private Location hookLocation;
     private int fishCaughtCounter = 1;
@@ -127,12 +128,17 @@ public class FishingManager extends SkillManager {
 
     public void processExploiting(Vector centerOfCastVector) {
         BoundingBox newCastBoundingBox = makeBoundingBox(centerOfCastVector);
-        boolean sameTarget = lastFishingBoundingBox != null && lastFishingBoundingBox.overlaps(newCastBoundingBox);
+        this.sameTarget = lastFishingBoundingBox != null && lastFishingBoundingBox.overlaps(newCastBoundingBox);
 
-        if (sameTarget)
+        if (this.sameTarget) {
             fishCaughtCounter++;
-        else
+        }
+        else {
             fishCaughtCounter = 1;
+        }
+
+        //If the new bounding box does not intersect with the old one, then update our bounding box reference
+        if (!this.sameTarget) lastFishingBoundingBox = newCastBoundingBox;
 
         if (fishCaughtCounter + 1 == ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit()) {
             getPlayer().sendMessage(LocaleLoader.getString("Fishing.LowResourcesTip", ExperienceConfig.getInstance().getFishingExploitingOptionMoveRange()));
@@ -147,13 +153,7 @@ public class FishingManager extends SkillManager {
             return false;
         }*/
 
-        BoundingBox newCastBoundingBox = makeBoundingBox(centerOfCastVector);
-        boolean sameTarget = lastFishingBoundingBox != null && lastFishingBoundingBox.overlaps(newCastBoundingBox);
-
-        //If the new bounding box does not intersect with the old one, then update our bounding box reference
-        if (!sameTarget) lastFishingBoundingBox = newCastBoundingBox;
-
-        return sameTarget && fishCaughtCounter >= ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit();
+        return this.sameTarget && fishCaughtCounter >= ExperienceConfig.getInstance().getFishingExploitingOptionOverFishLimit();
     }
 
     public static BoundingBox makeBoundingBox(Vector centerOfCastVector) {


### PR DESCRIPTION
# Issue

**When other plugins, like `Jobs`, check `isExploitingFishing`, the `fishCaughtCounter` increases more!** 

This causes problems. When there is an even amount of plugins using the method `isExploitingFishing` some plugins will think they are overfishing too early. Furthermore, when the amount of plugins increases the config value `OverFishLimit: 10` will be halved each time. Sometimes you even get multiple `Fishing.LowResourcesTip`.

# Fix
**I have separated the `fishCaughtCounter` increase and `Fishing.LowResourcesTip` messages into a new method.** 

This way plugins will not need to change anything for the fix to be implemented. I then called the process in the listener correctly. This makes sure increasing the counter is intentional.

# Testing
I put the Jobs and new MCMMO jar in a testing server and it seemed to work perfectly. 

# Reason
Before this fix, jobs used to not pay on the `Fishing.LowResourcesTip`. It also halved the `OverFishLimit` amount to 5.