### PR TITLE
feat: Make power level display for offline players

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
@@ -47,21 +47,28 @@ public class InspectCommand implements TabExecutor {
 
                 sender.sendMessage(LocaleLoader.getString("Inspect.OfflineStats", playerName));
 
+                // Sum power level
+                int powerLevel = 0;
+
                 sender.sendMessage(LocaleLoader.getString("Stats.Header.Gathering"));
                 for (PrimarySkillType skill : mcMMO.p.getSkillTools().GATHERING_SKILLS) {
                     sender.sendMessage(CommandUtils.displaySkill(profile, skill));
+                    powerLevel += profile.getSkillLevel(skill);
                 }
 
                 sender.sendMessage(LocaleLoader.getString("Stats.Header.Combat"));
                 for (PrimarySkillType skill : mcMMO.p.getSkillTools().COMBAT_SKILLS) {
                     sender.sendMessage(CommandUtils.displaySkill(profile, skill));
+                    powerLevel += profile.getSkillLevel(skill);
                 }
 
                 sender.sendMessage(LocaleLoader.getString("Stats.Header.Misc"));
                 for (PrimarySkillType skill : mcMMO.p.getSkillTools().MISC_SKILLS) {
                     sender.sendMessage(CommandUtils.displaySkill(profile, skill));
+                    powerLevel += profile.getSkillLevel(skill);
                 }
 
+                sender.sendMessage(LocaleLoader.getString("Commands.PowerLevel", powerLevel));
             } else {
                 Player target = mcMMOPlayer.getPlayer();
                 boolean isVanished = false;
@@ -95,9 +102,7 @@ public class InspectCommand implements TabExecutor {
                 CommandUtils.printCombatSkills(target, sender);
                 CommandUtils.printMiscSkills(target, sender);
 
-                if (!isVanished) {
-                    sender.sendMessage(LocaleLoader.getString("Commands.PowerLevel", mcMMOPlayer.getPowerLevel()));
-                }
+                sender.sendMessage(LocaleLoader.getString("Commands.PowerLevel", mcMMOPlayer.getPowerLevel()));
             }
 
             return true;


### PR DESCRIPTION
Fixes #4599. Also related to #4399, #4833. See comment here for better explanation: https://github.com/mcMMO-Dev/mcMMO/issues/4599#issuecomment-1411442863

Bigger underlying issue is that we cannot check which skills are accessible to offline players. I think making this change makes sense with this context. 