### PR TITLE
Don't call EntityDamageByEntityEvent with null damager

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -8,6 +8,7 @@ import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.datatypes.skills.SubSkillType;
 import com.gmail.nossr50.events.fake.FakeEntityDamageByEntityEvent;
+import com.gmail.nossr50.events.fake.FakeEntityDamageEvent;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.metadata.MobMetaFlagType;
 import com.gmail.nossr50.metadata.MobMetadataService;
@@ -885,8 +886,14 @@ public final class CombatUtils {
         return false;
     }
 
-    public static boolean canDamage(@NotNull Entity attacker, @NotNull Entity target, @NotNull DamageCause damageCause, double damage) {
-        EntityDamageEvent damageEvent = new FakeEntityDamageByEntityEvent(attacker, target, damageCause, damage);
+    public static boolean canDamage(@Nullable Entity attacker, @NotNull Entity target, @NotNull DamageCause damageCause, double damage) {
+        EntityDamageEvent damageEvent;
+        if (attacker != null) {
+            damageEvent = new FakeEntityDamageByEntityEvent(attacker, target, damageCause, damage);
+        } else {
+            damageEvent = new FakeEntityDamageEvent(target, damageCause, damage);
+        }
+
         mcMMO.p.getServer().getPluginManager().callEvent(damageEvent);
 
         return !damageEvent.isCancelled();


### PR DESCRIPTION
Currently, canDamage is called with the nullable argument attacker in the following method:
https://github.com/mcMMO-Dev/mcMMO/blob/a58c6be8a09b29a9c2a338e3dff4d208db7e6135/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java#L572-L582

This causes other plugins to throw NPEs when trying to get info about the damager in the event, since the API states the damager is non-null: 
![image](https://user-images.githubusercontent.com/7284033/217692752-fd4207e4-ca18-4a51-89f4-83df7bbe0747.png)

This PR changes canDamage to call the FakeEntityDamageEvent instead if the attacker is null.

Fixes https://github.com/mcMMO-Dev/mcMMO/issues/4767
