### PR TITLE
Fix missing return in notify command

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/McnotifyCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/McnotifyCommand.java
@@ -24,8 +24,10 @@ public class McnotifyCommand implements TabExecutor {
             McMMOPlayer mcMMOPlayer = UserManager.getPlayer((Player) sender);
 
             //Not Loaded yet
-            if (mcMMOPlayer == null)
+            if (mcMMOPlayer == null) {
                 sender.sendMessage(LocaleLoader.getString("Profile.PendingLoad"));
+                return true;
+            }
 
             sender.sendMessage(LocaleLoader.getString("Commands.Notifications." + (mcMMOPlayer.useChatNotifications() ? "Off" : "On")));
             mcMMOPlayer.toggleChatNotifications();


### PR DESCRIPTION
Fixes an exception when a player with no loaded data runs /notify.