### PR TITLE
Fix dots not being replaced when renaming party

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/party/PartyRenameCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/party/PartyRenameCommand.java
@@ -25,7 +25,7 @@ public class PartyRenameCommand implements CommandExecutor {
             Party playerParty = mcMMOPlayer.getParty();
 
             String oldPartyName = playerParty.getName();
-            String newPartyName = args[1];
+            String newPartyName = args[1].replace(".", "");
 
             // This is to prevent party leaders from spamming other players with the rename message
             if (oldPartyName.equalsIgnoreCase(newPartyName)) {


### PR DESCRIPTION
Fixes dots not being replaced when the /party rename command is used, which can cause the party saving logic to put the party in a [wrong section](https://user-images.githubusercontent.com/50800980/227016301-bd5ea484-3c70-4d2f-81ba-0cfbba8596e3.png). Also sort of related to #4881, but different enough that I thought I'd open a seperate PR.

Dots are already replaced when creating a party:
https://github.com/mcMMO-Dev/mcMMO/blob/162c605dacb52ddd2fae6797ffd7cbd9cb4bb84e/src/main/java/com/gmail/nossr50/party/PartyManager.java#L391-L394