### PR TITLE
Fix /party teleport tab complete NPE

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/party/PartyCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/party/PartyCommand.java
@@ -200,15 +200,19 @@ public class PartyCommand implements TabExecutor {
 
                         if (matches.size() == 0) {
                             Player player = (Player) sender;
+                            final McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
 
                             //Not Loaded
-                            if(UserManager.getPlayer(player) == null)
+                            if(mcMMOPlayer == null)
                             {
                                 sender.sendMessage(LocaleLoader.getString("Profile.PendingLoad"));
                                 return ImmutableList.of();
                             }
 
-                            Party party = UserManager.getPlayer(player).getParty();
+                            if (mcMMOPlayer.getParty() == null)
+                                return ImmutableList.of();
+
+                            final Party party = mcMMOPlayer.getParty();
 
                             playerNames = party.getOnlinePlayerNames(player);
                             return StringUtil.copyPartialMatches(args[1], playerNames, new ArrayList<>(playerNames.size()));


### PR DESCRIPTION
Fixes an NPE that occurs when a player without a party tries to tab complete after typing /party teleport.