### PR TITLE
Fix child skills counting towards power level in /inspect for offline players

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/player/InspectCommand.java
@@ -9,6 +9,7 @@ import com.gmail.nossr50.util.Permissions;
 import com.gmail.nossr50.util.commands.CommandUtils;
 import com.gmail.nossr50.util.player.UserManager;
 import com.gmail.nossr50.util.scoreboards.ScoreboardManager;
+import com.gmail.nossr50.util.skills.SkillTools;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -47,26 +48,25 @@ public class InspectCommand implements TabExecutor {
 
                 sender.sendMessage(LocaleLoader.getString("Inspect.OfflineStats", playerName));
 
-                // Sum power level
-                int powerLevel = 0;
-
                 sender.sendMessage(LocaleLoader.getString("Stats.Header.Gathering"));
                 for (PrimarySkillType skill : mcMMO.p.getSkillTools().GATHERING_SKILLS) {
                     sender.sendMessage(CommandUtils.displaySkill(profile, skill));
-                    powerLevel += profile.getSkillLevel(skill);
                 }
 
                 sender.sendMessage(LocaleLoader.getString("Stats.Header.Combat"));
                 for (PrimarySkillType skill : mcMMO.p.getSkillTools().COMBAT_SKILLS) {
                     sender.sendMessage(CommandUtils.displaySkill(profile, skill));
-                    powerLevel += profile.getSkillLevel(skill);
                 }
 
                 sender.sendMessage(LocaleLoader.getString("Stats.Header.Misc"));
                 for (PrimarySkillType skill : mcMMO.p.getSkillTools().MISC_SKILLS) {
                     sender.sendMessage(CommandUtils.displaySkill(profile, skill));
-                    powerLevel += profile.getSkillLevel(skill);
                 }
+
+                // Sum power level
+                int powerLevel = 0;
+                for (PrimarySkillType skill : SkillTools.NON_CHILD_SKILLS)
+                    powerLevel += profile.getSkillLevel(skill);
 
                 sender.sendMessage(LocaleLoader.getString("Commands.PowerLevel", powerLevel));
             } else {


### PR DESCRIPTION
Fixes the power level in /inspect for offline players showing higher than their actual power level due to salvage and smelting being counted towards it. It will now iterate over SkillTools#NON_CHILD_SKILLS to calculate the power level similar to what McMMOPlayer#getPowerLevel does.

Originally reported in [EarthMC/Issue-Tracker/issues/1670](https://github.com/EarthMC/Issue-Tracker/issues/1670) which also contains some screenshots of the issue.