### PR TITLE
Small Optimizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
                             <include>net.kyori:adventure-text-serializer-craftbukkit</include>
                             <include>net.kyori:adventure-text-serializer-gson-legacy-impl</include>
                             <include>co.aikar:acf-bukkit</include>
+                            <include>io.papermc:paperlib</include>
                         </includes>
                     </artifactSet>
                     <relocations>
@@ -188,6 +189,10 @@
                         <relocation>
                             <pattern>org.bstats</pattern>
                             <shadedPattern>com.gmail.nossr50.mcmmo.metrics.bstats</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>io.papermc.lib</pattern>
+                            <shadedPattern>com.gmail.nossr50.mcmmo.paperlib</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>
@@ -240,6 +245,10 @@
         <repository>
             <id>sonatype-oss-snapshots1</id>
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <!-- ... -->
         <!-- ... -->
@@ -361,6 +370,11 @@
             <artifactId>guava</artifactId>
             <version>31.1-jre</version> <!-- At this time Spigot is including 29.0 Guava classes that we are using -->
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.8</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/gmail/nossr50/locale/LocaleLoader.java
+++ b/src/main/java/com/gmail/nossr50/locale/LocaleLoader.java
@@ -103,8 +103,7 @@ public final class LocaleLoader {
 
     public static String formatString(String string, Object... messageArguments) {
         if (messageArguments != null) {
-            MessageFormat formatter = new MessageFormat("");
-            formatter.applyPattern(string.replace("'", "''"));
+            MessageFormat formatter = new MessageFormat(string.replace("'", "''"));
             string = formatter.format(messageArguments);
         }
 
@@ -115,8 +114,7 @@ public final class LocaleLoader {
 
     public static @NotNull TextComponent formatComponent(@NotNull String string, Object... messageArguments) {
         if (messageArguments != null) {
-            MessageFormat formatter = new MessageFormat("");
-            formatter.applyPattern(string.replace("'", "''"));
+            MessageFormat formatter = new MessageFormat(string.replace("'", "''"));
             string = formatter.format(messageArguments);
         }
 

--- a/src/main/java/com/gmail/nossr50/metadata/ItemMetadataService.java
+++ b/src/main/java/com/gmail/nossr50/metadata/ItemMetadataService.java
@@ -73,19 +73,15 @@ public class ItemMetadataService {
         ItemMeta itemMeta = itemStack.getItemMeta();
 
         if(itemMeta != null) {
-            //TODO: can be optimized
-            if (itemMeta.hasEnchant(Enchantment.DIG_SPEED)) {
-                itemMeta.removeEnchant(Enchantment.DIG_SPEED);
-            }
-
             if (originalSpeed > 0) {
                 itemMeta.addEnchant(Enchantment.DIG_SPEED, originalSpeed, true);
+            } else {
+                itemMeta.removeEnchant(Enchantment.DIG_SPEED);
             }
 
             PersistentDataContainer dataContainer = itemMeta.getPersistentDataContainer();
             dataContainer.remove(NSK_SUPER_ABILITY_BOOSTED_ITEM); //Remove persistent data
 
-            //TODO: needed?
             itemStack.setItemMeta(itemMeta);
         }
     }

--- a/src/main/java/com/gmail/nossr50/util/experience/ExperienceBarManager.java
+++ b/src/main/java/com/gmail/nossr50/util/experience/ExperienceBarManager.java
@@ -50,24 +50,19 @@ public class ExperienceBarManager {
                 || !ExperienceConfig.getInstance().isExperienceBarEnabled(primarySkillType))
             return;
 
-        //Init Bar
-        if(experienceBars.get(primarySkillType) == null)
-            experienceBars.put(primarySkillType, new ExperienceBarWrapper(primarySkillType, mcMMOPlayer));
-
-        //Get Bar
-        ExperienceBarWrapper experienceBarWrapper = experienceBars.get(primarySkillType);
+        // Init or get the bar
+        ExperienceBarWrapper bar = experienceBars.computeIfAbsent(primarySkillType, k -> new ExperienceBarWrapper(primarySkillType, mcMMOPlayer));
 
         //Update Progress
-        experienceBarWrapper.setProgress(mcMMOPlayer.getProgressInCurrentSkillLevel(primarySkillType));
+        bar.setProgress(mcMMOPlayer.getProgressInCurrentSkillLevel(primarySkillType));
 
         //Show Bar
-        experienceBarWrapper.showExperienceBar();
+        bar.showExperienceBar();
 
         //Setup Hide Bar Task
-        if(experienceBarHideTaskHashMap.get(primarySkillType) != null)
-        {
-            experienceBarHideTaskHashMap.get(primarySkillType).cancel();
-        }
+        ExperienceBarHideTask task = experienceBarHideTaskHashMap.get(primarySkillType);
+        if (task != null)
+            task.cancel();
 
         scheduleHideTask(primarySkillType, plugin);
     }

--- a/src/main/java/com/gmail/nossr50/util/player/UserManager.java
+++ b/src/main/java/com/gmail/nossr50/util/player/UserManager.java
@@ -8,12 +8,14 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.metadata.MetadataValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 public final class UserManager {
 
@@ -137,9 +139,13 @@ public final class UserManager {
      * @return McMMOPlayer object for this player, null if Player has not been loaded
      */
     public static @Nullable McMMOPlayer getPlayer(@Nullable Player player) {
+        if (player == null)
+            return null;
+
+        List<MetadataValue> metadata = player.getMetadata(MetadataConstants.METADATA_KEY_PLAYER_DATA);
         //Avoid Array Index out of bounds
-        if(player != null && player.hasMetadata(MetadataConstants.METADATA_KEY_PLAYER_DATA))
-            return (McMMOPlayer) player.getMetadata(MetadataConstants.METADATA_KEY_PLAYER_DATA).get(0).value();
+        if (!metadata.isEmpty())
+            return (McMMOPlayer) metadata.get(0).value();
         else
             return null;
     }

--- a/src/main/java/com/gmail/nossr50/util/skills/SmeltingTracker.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/SmeltingTracker.java
@@ -4,6 +4,7 @@ import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.player.UserManager;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -80,7 +81,7 @@ public class SmeltingTracker {
             return null;
         }
 
-        return (Furnace) inventory.getHolder();
+        return (Furnace) PaperLib.getHolder(inventory, false).getHolder();
     }
 
     public boolean isFurnaceOwned(Furnace furnace) {
@@ -92,8 +93,9 @@ public class SmeltingTracker {
             return;
 
         //Don't swap ownership if its the same player
-        if(getFurnaceOwner(furnace) != null) {
-            if(getFurnaceOwner(furnace).getUniqueId().equals(player.getUniqueId()))
+        OfflinePlayer owner = getFurnaceOwner(furnace);
+        if(owner != null) {
+            if(owner.getUniqueId().equals(player.getUniqueId()))
                 return;
         }
 


### PR DESCRIPTION
Adds a whole bunch of small improvements, mainly by cutting down on repeated UserManager#getPlayer and by adopting PaperLib to avoid taking blockstate snapshots when getting blockstates/inventory holders.

As a side effect of no longer using block state snapshots I also unintentionally fixed #4705, since the state with the updated brewing time was never being set back to the brewing stand.

Currently the only place a non-snapshot is held onto is also the alchemy code, I've tested it a bit by destroying a brewing stand in the middle of brewing and everything seemed to work as expected, so I'd call that a win.