### PR TITLE
Fix blast mining bonus drops option not working

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -275,7 +275,7 @@ public class MiningManager extends SkillManager {
      * @return the Blast Mining tier
      */
     public int getDropMultiplier() {
-        if (mcMMO.p.getAdvancedConfig().isBlastMiningBonusDropsEnabled()) {
+        if (!mcMMO.p.getAdvancedConfig().isBlastMiningBonusDropsEnabled()) {
             return 0;
         }
 


### PR DESCRIPTION
Credit to Mads on the discord for finding this bug, tested it myself aswell to confirm that it's fixed.