### PR TITLE
Fix packaging error on windows #4911

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version> <!-- At this time Spigot is including 29.0 Guava classes that we are using -->
+            <version>32.1.1-jre</version> <!-- At this time Spigot is including 29.0 Guava classes that we are using -->
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This fixes https://github.com/mcMMO-Dev/mcMMO/issues/4911

Tested on Windows 11 locally using 'mvn clean package install'. Console output not included due to containing personal information (PC username), however can comfirm this solves the POSIX issue.