### PR TITLE
Fix initial delay for rupture task

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/swords/SwordsManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/swords/SwordsManager.java
@@ -95,7 +95,7 @@ public class SwordsManager extends SkillManager {
 
             RuptureTaskMeta ruptureTaskMeta = new RuptureTaskMeta(mcMMO.p, ruptureTask);
 
-            mcMMO.p.getFoliaLib().getImpl().runAtEntityTimer(mmoPlayer.getPlayer(), ruptureTask, 0, 1);
+            mcMMO.p.getFoliaLib().getImpl().runAtEntityTimer(mmoPlayer.getPlayer(), ruptureTask, 1, 1);
             target.setMetadata(MetadataConstants.METADATA_KEY_RUPTURE, ruptureTaskMeta);
 
 //            if (mmoPlayer.useChatNotifications()) {


### PR DESCRIPTION
Pretty simple change, Folia schedulers don't allow repeated tasks with an initial delay of <= 0 ticks.

Stack trace for reference (posted by someone else on the discord): https://pastes.dev/YX5BU1UXOX