### PR TITLE
Fix build failure from missing dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-bukkit</artifactId>
+            <version>7.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-core</artifactId>
             <version>7.0.7</version>


### PR DESCRIPTION
WorldGuardManager.java has `com.sk89q.worledit.bukkit.*` imports which are not included with just worldguard-core, so any new environment will have build failure. Adding worldedit-bukkit to pom.xml resolves this.