### PR TITLE
Make PAPI expansion persist

### DIFF
--- a/src/main/java/com/gmail/nossr50/placeholders/PapiExpansion.java
+++ b/src/main/java/com/gmail/nossr50/placeholders/PapiExpansion.java
@@ -42,6 +42,11 @@ public class PapiExpansion extends PlaceholderExpansion {
     }
 
     @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
     public String getRequiredPlugin() {
         return "mcMMO";
     }


### PR DESCRIPTION
Currently, `/papi reload` removes the expansion from the list of loaded expansions. This will make it persist across reloads. This should really be PAPI's default.