### PR TITLE
Initiated fix so it at least load on 1.20.5

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
@@ -130,7 +130,6 @@ public class PotionConfig extends LegacyConfigLoader {
                 ConfigurationSection potionData = potion_section.getConfigurationSection("PotionData");
                 data = new PotionData(PotionType.valueOf(potionData.getString("PotionType", "WATER")), potionData.getBoolean("Extended", false), potionData.getBoolean("Upgraded", false));
             }
-
             Material material = Material.POTION;
             String mat = potion_section.getString("Material", null);
             if (mat != null) {
@@ -181,7 +180,7 @@ public class PotionConfig extends LegacyConfigLoader {
             }
 
             return new AlchemyPotion(material, data, name, lore, effects, color, children);
-        } catch (Exception e) {
+        } catch (Exception | NoClassDefFoundError e) {
             mcMMO.p.getLogger().warning("Failed to load Alchemy potion: " + potion_section.getName());
             return null;
         }

--- a/src/main/java/com/gmail/nossr50/config/treasure/FishingTreasureConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/treasure/FishingTreasureConfig.java
@@ -224,7 +224,9 @@ public class FishingTreasureConfig extends BukkitConfig {
                     }
                     boolean extended = config.getBoolean(type + "." + treasureName + ".PotionData.Extended", false);
                     boolean upgraded = config.getBoolean(type + "." + treasureName + ".PotionData.Upgraded", false);
-                    itemMeta.setBasePotionData(new PotionData(potionType, extended, upgraded));
+                    try {
+                        itemMeta.setBasePotionData(new PotionData(potionType, extended, upgraded));
+                    } catch (Exception | NoClassDefFoundError ignore){}
 
                     if (customName != null) {
                         itemMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', customName));

--- a/src/main/java/com/gmail/nossr50/util/EnchantmentUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/EnchantmentUtils.java
@@ -17,7 +17,8 @@ public class EnchantmentUtils {
         enchants.put("BLAST_PROTECTION", Enchantment.PROTECTION_EXPLOSIONS);
         enchants.put("PROJECTILE_PROTECTION", Enchantment.PROTECTION_PROJECTILE);
         enchants.put("RESPIRATION", Enchantment.OXYGEN);
-        enchants.put("INFINITY", Enchantment.ARROW_INFINITE);
+        enchants.put("INFINITY", Enchantment.getByName("INFINITE"));
+        //enchants.put("INFINITY", Enchantment.ARROW_INFINITE);
         enchants.put("AQUA_AFFINITY", Enchantment.WATER_WORKER);
         enchants.put("UNBREAKING", Enchantment.DURABILITY);
         enchants.put("SMITE", Enchantment.DAMAGE_UNDEAD);


### PR DESCRIPTION
This is only a beginning of tests it out on 1.20.5, PotionData is gone completely and ARROW_INFINITE is called only INFINITE. 

The enchantment could be solved with either version check or try catch. About the PotionData I think the plan is you should use  PotionType class. don't know how new that class is and if should be a wrapper class. If it is easier to split up the extended and upgraded in the config than they have to type full name? could also be optional between full name or the short name.