### PR TITLE
Fix exceptions when shooting entities through worlds on folia

### DIFF
--- a/src/main/java/com/gmail/nossr50/runnables/skills/AwardCombatXpTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/skills/AwardCombatXpTask.java
@@ -5,6 +5,7 @@ import com.gmail.nossr50.datatypes.experience.XPGainReason;
 import com.gmail.nossr50.datatypes.experience.XPGainSource;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
+import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.CancellableRunnable;
 import org.bukkit.entity.LivingEntity;
 
@@ -44,6 +45,7 @@ public class AwardCombatXpTask extends CancellableRunnable {
             damage = Math.min(damage, ExperienceConfig.getInstance().getCombatHPCeiling());
         }
 
-        mcMMOPlayer.beginXpGain(primarySkillType, (int) (damage * baseXp), xpGainReason, XPGainSource.SELF);
+        final double finalDamage = damage;
+        mcMMO.p.getFoliaLib().getImpl().runAtEntity(mcMMOPlayer.getPlayer(), task -> mcMMOPlayer.beginXpGain(primarySkillType, (int) (finalDamage * baseXp), xpGainReason, XPGainSource.SELF));
     }
 }

--- a/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
@@ -287,6 +287,9 @@ public class TamingManager extends SkillManager {
         double range = 5;
         Player player = getPlayer();
 
+        if (!target.getWorld().equals(player.getWorld()))
+            return;
+
         for (Entity entity : player.getNearbyEntities(range, range, range)) {
             if (entity.getType() != EntityType.WOLF) {
                 continue;

--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -921,7 +921,7 @@ public final class CombatUtils {
         baseXP *= multiplier;
 
         if (baseXP > 0) {
-            mcMMO.p.getFoliaLib().getImpl().runAtEntity(mcMMOPlayer.getPlayer(), new AwardCombatXpTask(mcMMOPlayer, primarySkillType, baseXP, target, xpGainReason));
+            mcMMO.p.getFoliaLib().getImpl().runAtEntity(target, new AwardCombatXpTask(mcMMOPlayer, primarySkillType, baseXP, target, xpGainReason));
         }
     }
 


### PR DESCRIPTION
The AwardCombatXpTask checks the target's health to see how much damage was done, but running this on the player's scheduler can cause exceptions if the target is not in the same region, like if the target is on the other side of a nether portal.