### PR TITLE
Fix illegal blastmining drops

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -31,54 +31,77 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import static com.gmail.nossr50.util.ItemUtils.isPickaxe;
 
 public class MiningManager extends SkillManager {
 
-    public static final String BUDDING_AMETHYST = "budding_amethyst";
-    public static final Collection<Material> BLAST_MINING_BLACKLIST = Set.of(Material.SPAWNER);
-
     public MiningManager(@NotNull McMMOPlayer mcMMOPlayer) {
         super(mcMMOPlayer, PrimarySkillType.MINING);
     }
 
+    /**
+     * Determines if the player can use Demolitions Expertise.
+     *
+     * @return true if the player can use Demolitions Expertise, false otherwise
+     */
     public boolean canUseDemolitionsExpertise() {
-        if (!RankUtils.hasUnlockedSubskill(getPlayer(), SubSkillType.MINING_DEMOLITIONS_EXPERTISE))
-            return false;
-
-        return getSkillLevel() >= BlastMining.getDemolitionExpertUnlockLevel() && Permissions.demolitionsExpertise(getPlayer());
+        return RankUtils.hasUnlockedSubskill(getPlayer(), SubSkillType.MINING_DEMOLITIONS_EXPERTISE)
+                && getSkillLevel() >= BlastMining.getDemolitionExpertUnlockLevel()
+                && Permissions.demolitionsExpertise(getPlayer());
     }
 
+    /**
+     * Determines if the player can detonate TNT remotely.
+     *
+     * @return true if the player can detonate TNT remotely, false otherwise
+     */
     public boolean canDetonate() {
         Player player = getPlayer();
-
         return canUseBlastMining() && player.isSneaking()
-                && (isPickaxe(getPlayer().getInventory().getItemInMainHand()) || player.getInventory().getItemInMainHand().getType() == mcMMO.p.getGeneralConfig().getDetonatorItem())
+                && (isPickaxe(player.getInventory().getItemInMainHand())
+                || player.getInventory().getItemInMainHand().getType() == mcMMO.p.getGeneralConfig().getDetonatorItem())
                 && Permissions.remoteDetonation(player);
     }
 
+    /**
+     * Determines if the player can use Blast Mining.
+     *
+     * @return true if the player can use Blast Mining, false otherwise
+     */
     public boolean canUseBlastMining() {
-        //Not checking permissions?
         return RankUtils.hasUnlockedSubskill(getPlayer(), SubSkillType.MINING_BLAST_MINING);
     }
 
+    /**
+     * Determines if the player can use Bigger Bombs.
+     *
+     * @return true if the player can use Bigger Bombs, false otherwise
+     */
     public boolean canUseBiggerBombs() {
-        if (!RankUtils.hasUnlockedSubskill(getPlayer(), SubSkillType.MINING_BIGGER_BOMBS))
-            return false;
-
-        return getSkillLevel() >= BlastMining.getBiggerBombsUnlockLevel() && Permissions.biggerBombs(getPlayer());
+        return RankUtils.hasUnlockedSubskill(getPlayer(), SubSkillType.MINING_BIGGER_BOMBS)
+                && getSkillLevel() >= BlastMining.getBiggerBombsUnlockLevel()
+                && Permissions.biggerBombs(getPlayer());
     }
 
+    /**
+     * Determines if the player can trigger Double Drops.
+     *
+     * @return true if the player can trigger Double Drops, false otherwise
+     */
     public boolean canDoubleDrop() {
-        return RankUtils.hasUnlockedSubskill(getPlayer(), SubSkillType.MINING_DOUBLE_DROPS) && Permissions.isSubSkillEnabled(getPlayer(), SubSkillType.MINING_DOUBLE_DROPS);
+        return RankUtils.hasUnlockedSubskill(getPlayer(), SubSkillType.MINING_DOUBLE_DROPS)
+                && Permissions.isSubSkillEnabled(getPlayer(), SubSkillType.MINING_DOUBLE_DROPS);
     }
 
+    /**
+     * Determines if the player can trigger Mother Lode.
+     *
+     * @return true if the player can trigger Mother Lode, false otherwise
+     */
     public boolean canMotherLode() {
         return Permissions.canUseSubSkill(getPlayer(), SubSkillType.MINING_MOTHER_LODE);
     }
-
 
     /**
      * Process double drops & XP gain for Mining.
@@ -98,14 +121,15 @@ public class MiningManager extends SkillManager {
             SkillUtils.handleDurabilityChange(getPlayer().getInventory().getItemInMainHand(), mcMMO.p.getGeneralConfig().getAbilityToolDamage());
         }
 
-        if (!mcMMO.p.getGeneralConfig().getDoubleDropsEnabled(PrimarySkillType.MINING, blockState.getType()) || !canDoubleDrop())
+        if (!mcMMO.p.getGeneralConfig().getDoubleDropsEnabled(PrimarySkillType.MINING, blockState.getType()) || !canDoubleDrop()) {
             return;
+        }
 
         boolean silkTouch = player.getInventory().getItemInMainHand().containsEnchantment(Enchantment.SILK_TOUCH);
 
-        if (silkTouch && !mcMMO.p.getAdvancedConfig().getDoubleDropSilkTouchEnabled())
+        if (silkTouch && !mcMMO.p.getAdvancedConfig().getDoubleDropSilkTouchEnabled()) {
             return;
-
+        }
         //Mining mastery allows for a chance of triple drops
         if (canMotherLode()) {
             //Triple Drops failed so do a normal double drops check
@@ -118,20 +142,30 @@ public class MiningManager extends SkillManager {
         }
     }
 
+    /**
+     * Processes triple drops for Mining.
+     *
+     * @param blockState The {@link BlockState} to check ability activation for
+     * @return true if triple drops were successful, false otherwise
+     */
     private boolean processTripleDrops(@NotNull BlockState blockState) {
         //TODO: Make this readable
         if (ProbabilityUtil.isSkillRNGSuccessful(SubSkillType.MINING_MOTHER_LODE, mmoPlayer)) {
             BlockUtils.markDropsAsBonus(blockState, 2);
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
+    /**
+     * Processes double drops for Mining.
+     *
+     * @param blockState The {@link BlockState} to check ability activation for
+     */
     private void processDoubleDrops(@NotNull BlockState blockState) {
-        //TODO: Make this readable
         if (ProbabilityUtil.isSkillRNGSuccessful(SubSkillType.MINING_DOUBLE_DROPS, mmoPlayer)) {
-            boolean useTriple = mmoPlayer.getAbilityMode(SuperAbilityType.SUPER_BREAKER) && mcMMO.p.getAdvancedConfig().getAllowMiningTripleDrops();
+            boolean useTriple = mmoPlayer.getAbilityMode(SuperAbilityType.SUPER_BREAKER)
+                    && mcMMO.p.getAdvancedConfig().getAllowMiningTripleDrops();
             BlockUtils.markDropsAsBonus(blockState, useTriple);
         }
     }
@@ -165,7 +199,8 @@ public class MiningManager extends SkillManager {
 
         mmoPlayer.setAbilityDATS(SuperAbilityType.BLAST_MINING, System.currentTimeMillis());
         mmoPlayer.setAbilityInformed(SuperAbilityType.BLAST_MINING, false);
-        mcMMO.p.getFoliaLib().getImpl().runAtEntityLater(mmoPlayer.getPlayer(), new AbilityCooldownTask(mmoPlayer, SuperAbilityType.BLAST_MINING), (long) SuperAbilityType.BLAST_MINING.getCooldown() * Misc.TICK_CONVERSION_FACTOR);
+        mcMMO.p.getFoliaLib().getImpl().runAtEntityLater(mmoPlayer.getPlayer(), new AbilityCooldownTask(mmoPlayer, SuperAbilityType.BLAST_MINING),
+                (long) SuperAbilityType.BLAST_MINING.getCooldown() * Misc.TICK_CONVERSION_FACTOR);
     }
 
     /**
@@ -175,66 +210,56 @@ public class MiningManager extends SkillManager {
      * @param event The {@link EntityExplodeEvent}
      */
     public void blastMiningDropProcessing(float yield, EntityExplodeEvent event) {
-        if (yield == 0)
-            return;
+        if (yield == 0) return;
 
         var increasedYieldFromBonuses = yield + (yield * getOreBonus());
-        // Strip out only stuff that gives mining XP
+
         List<BlockState> ores = new ArrayList<>();
-        List<BlockState> notOres = new ArrayList<>();
+        List<BlockState> nonOres = new ArrayList<>();
+
         for (Block targetBlock : event.blockList()) {
             BlockState blockState = targetBlock.getState();
 
-            if(mcMMO.getUserBlockTracker().isIneligible(targetBlock))
-                continue;
+            if (mcMMO.getUserBlockTracker().isIneligible(targetBlock)) continue;
 
             if (ExperienceConfig.getInstance().getXp(PrimarySkillType.MINING, targetBlock) != 0) {
                 if (BlockUtils.isOre(blockState) && !(targetBlock instanceof Container)) {
                     ores.add(blockState);
+                } else {
+                    nonOres.add(blockState);
                 }
             } else {
-                notOres.add(blockState);
+                nonOres.add(blockState);
             }
         }
 
         int xp = 0;
         int dropMultiplier = getDropMultiplier();
 
-        for(BlockState blockState : notOres) {
-            if (isDropIllegal(blockState.getType()))
-                continue;
-
-            if (Probability.ofPercent(50).evaluate()) {
-                ItemUtils.spawnItem(getPlayer(),
-                        Misc.getBlockCenter(blockState),
-                        new ItemStack(blockState.getType()),
-                        ItemSpawnReason.BLAST_MINING_DEBRIS_NON_ORES); // Initial block that would have been dropped
-            }
+        for (BlockState blockState : nonOres) {
+            Collection<ItemStack> drops = blockState.getBlock().getDrops(mmoPlayer.getPlayer().getInventory().getItemInMainHand());
+            ItemUtils.spawnItems(getPlayer(), Misc.getBlockCenter(blockState), drops, ItemSpawnReason.BLAST_MINING_DEBRIS_NON_ORES);
         }
+
         for (BlockState blockState : ores) {
             // currentOreYield only used for drop calculations for ores
             float currentOreYield = increasedYieldFromBonuses;
 
-            if (isDropIllegal(blockState.getType())) {
-                continue;
-            }
-
             // Always give XP for every ore destroyed
             xp += Mining.getBlockXp(blockState);
-            while(currentOreYield > 0) {
+            while (currentOreYield > 0) {
                 if (Probability.ofValue(currentOreYield).evaluate()) {
                     Collection<ItemStack> oreDrops = isPickaxe(mmoPlayer.getPlayer().getInventory().getItemInMainHand())
                             ? blockState.getBlock().getDrops(mmoPlayer.getPlayer().getInventory().getItemInMainHand())
                             : List.of(new ItemStack(blockState.getType()));
                     ItemUtils.spawnItems(getPlayer(), Misc.getBlockCenter(blockState),
-                            oreDrops, BLAST_MINING_BLACKLIST, ItemSpawnReason.BLAST_MINING_ORES);
+                            oreDrops, ItemSpawnReason.BLAST_MINING_ORES);
 
                     if (mcMMO.p.getAdvancedConfig().isBlastMiningBonusDropsEnabled()) {
                         for (int i = 1; i < dropMultiplier; i++) {
                             ItemUtils.spawnItems(getPlayer(),
                                     Misc.getBlockCenter(blockState),
                                     oreDrops,
-                                    BLAST_MINING_BLACKLIST,
                                     ItemSpawnReason.BLAST_MINING_ORES_BONUS_DROP);
                         }
                     }
@@ -243,20 +268,8 @@ public class MiningManager extends SkillManager {
             }
         }
 
-        // Replace the event blocklist with the newYield list
         event.setYield(0F);
         applyXpGain(xp, XPGainReason.PVE);
-    }
-
-    /**
-     * Checks if it would be illegal (in vanilla) to obtain the block
-     * Certain things should never drop ( such as budding_amethyst )
-     *
-     * @param material target material
-     * @return true if it's not legal to obtain the block through normal gameplay
-     */
-    public boolean isDropIllegal(@NotNull Material material) {
-        return material.getKey().getKey().equalsIgnoreCase(BUDDING_AMETHYST);
     }
 
     /**
@@ -269,6 +282,12 @@ public class MiningManager extends SkillManager {
         return (float) (radius + getBlastRadiusModifier());
     }
 
+    /**
+     * Processes damage reduction for Demolitions Expertise.
+     *
+     * @param damage initial damage
+     * @return reduced damage
+     */
     public double processDemolitionsExpertise(double damage) {
         return damage * ((100.0D - getBlastDamageModifier()) / 100.0D);
     }
@@ -283,9 +302,9 @@ public class MiningManager extends SkillManager {
     }
 
     /**
-     * Gets the Blast Mining tier
+     * Gets the ore bonus for Blast Mining.
      *
-     * @return the Blast Mining tier
+     * @return the ore bonus as a float value
      */
     public float getOreBonus() {
         return (float) (mcMMO.p.getAdvancedConfig().getOreBonus(getBlastMiningTier()) / 100F);
@@ -296,27 +315,39 @@ public class MiningManager extends SkillManager {
         return mcMMO.p.getAdvancedConfig().getOreBonus(rank);
     }
 
+    /**
+     * Gets the debris reduction for Blast Mining.
+     *
+     * @param rank the current rank of Blast Mining
+     * @return the debris reduction as a double value
+     */
     public static double getDebrisReduction(int rank) {
         return mcMMO.p.getAdvancedConfig().getDebrisReduction(rank);
     }
 
     /**
-     * Gets the Blast Mining tier
+     * Gets the debris reduction for the player's current Blast Mining tier.
      *
-     * @return the Blast Mining tier
+     * @return the debris reduction as a double value
      */
     public double getDebrisReduction() {
         return getDebrisReduction(getBlastMiningTier());
     }
 
+    /**
+     * Gets the drop multiplier for Blast Mining.
+     *
+     * @param rank the current rank of Blast Mining
+     * @return the drop multiplier
+     */
     public static int getDropMultiplier(int rank) {
         return mcMMO.p.getAdvancedConfig().getDropMultiplier(rank);
     }
 
     /**
-     * Gets the Blast Mining tier
+     * Gets the drop multiplier for the player's current Blast Mining tier.
      *
-     * @return the Blast Mining tier
+     * @return the drop multiplier
      */
     public int getDropMultiplier() {
         if (!mcMMO.p.getAdvancedConfig().isBlastMiningBonusDropsEnabled()) {
@@ -332,23 +363,28 @@ public class MiningManager extends SkillManager {
     }
 
     /**
-     * Gets the Blast Mining tier
+     * Gets the blast radius modifier for the player's current Blast Mining tier.
      *
-     * @return the Blast Mining tier
+     * @return the blast radius modifier
      */
     public double getBlastRadiusModifier() {
         return BlastMining.getBlastRadiusModifier(getBlastMiningTier());
     }
 
     /**
-     * Gets the Blast Mining tier
+     * Gets the blast damage modifier for the player's current Blast Mining tier.
      *
-     * @return the Blast Mining tier
+     * @return the blast damage modifier
      */
     public double getBlastDamageModifier() {
         return BlastMining.getBlastDamageDecrease(getBlastMiningTier());
     }
 
+    /**
+     * Checks if the Blast Mining cooldown is over.
+     *
+     * @return true if the cooldown is over, false otherwise
+     */
     private boolean blastMiningCooldownOver() {
         int timeRemaining = mmoPlayer.calculateTimeRemaining(SuperAbilityType.BLAST_MINING);
 

--- a/src/main/java/com/gmail/nossr50/util/ItemUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/ItemUtils.java
@@ -130,13 +130,15 @@ public final class ItemUtils {
      */
     public static boolean hasItemIncludingOffHand(Player player, Material material) {
         // Checks main inventory / item bar
-        boolean containsInMain = player.getInventory().contains(material);
-
-        if (containsInMain) {
-            return true;
+        for (ItemStack itemStack : player.getInventory().getContents()) {
+            if (itemStack != null && itemStack.getType() == material) {
+                return true;
+            }
         }
 
-        return player.getInventory().getItemInOffHand().getType() == material;
+        // Check off-hand
+        ItemStack offHandItem = player.getInventory().getItemInOffHand();
+        return offHandItem != null && offHandItem.getType() == material;
     }
 
     /**
@@ -147,18 +149,29 @@ public final class ItemUtils {
      * @param amount   Amount of the material to remove
      */
     public static void removeItemIncludingOffHand(@NotNull Player player, @NotNull Material material, int amount) {
-        // Checks main inventory / item bar
-        if (player.getInventory().contains(material)) {
-            player.getInventory().removeItem(new ItemStack(material, amount));
-            return;
+        // Remove from main inventory
+        for (ItemStack itemStack : player.getInventory().getContents()) {
+            if (itemStack != null && itemStack.getType() == material) {
+                int stackAmount = itemStack.getAmount();
+                if (stackAmount > amount) {
+                    itemStack.setAmount(stackAmount - amount);
+                    return;
+                } else {
+                    player.getInventory().removeItem(itemStack);
+                    amount -= stackAmount;
+                    if (amount <= 0) {
+                        return;
+                    }
+                }
+            }
         }
 
-        // Check off-hand
-        final ItemStack offHandItem = player.getInventory().getItemInOffHand();
-        if (offHandItem.getType() == material) {
-            int newAmount = offHandItem.getAmount() - amount;
-            if (newAmount > 0) {
-                offHandItem.setAmount(newAmount);
+        // Remove from off-hand
+        ItemStack offHandItem = player.getInventory().getItemInOffHand();
+        if (offHandItem != null && offHandItem.getType() == material) {
+            int stackAmount = offHandItem.getAmount();
+            if (stackAmount > amount) {
+                offHandItem.setAmount(stackAmount - amount);
             } else {
                 player.getInventory().setItemInOffHand(new ItemStack(Material.AIR));
             }

--- a/src/main/resources/potions.yml
+++ b/src/main/resources/potions.yml
@@ -19,6 +19,8 @@ Concoctions:
         - WATER_LILY
         - PUFFERFISH
         - DRAGON_BREATH
+        - STONE
+        - SLIME_BLOCK
     Tier_Two_Ingredients:
         - CARROT
         - SLIME_BALL
@@ -79,6 +81,8 @@ Potions:
             BLAZE_POWDER: POTION_OF_MUNDANE
             REDSTONE: POTION_OF_MUNDANE
             RABBIT_FOOT: POTION_OF_MUNDANE
+            STONE: POTION_OF_MUNDANE
+            SLIME_BLOCK: POTION_OF_MUNDANE
     POTION_OF_WATER_UNCRAFTABLE:
         Material: POTION
         PotionData:
@@ -96,6 +100,8 @@ Potions:
             BLAZE_POWDER: POTION_OF_MUNDANE
             REDSTONE: POTION_OF_MUNDANE
             RABBIT_FOOT: POTION_OF_MUNDANE
+            STONE: POTION_OF_MUNDANE
+            SLIME_BLOCK: POTION_OF_MUNDANE
     POTION_OF_MUNDANE:
         Material: POTION
         PotionData:
@@ -135,6 +141,8 @@ Potions:
             GHAST_TEAR: POTION_OF_REGENERATION
             TURTLE_HELMET: POTION_OF_TURTLE_MASTER
             RABBIT_FOOT: POTION_OF_LEAPING
+            STONE: POTION_OF_INFESTATION
+            SLIME_BLOCK: POTION_OF_OOZING
     POTION_OF_NIGHT_VISION:
         Material: POTION
         PotionData:
@@ -421,6 +429,18 @@ Potions:
             Extended: true
         Children:
             GUNPOWDER: SPLASH_POTION_OF_SLOW_FALLING_EXTENDED
+    POTION_OF_INFESTATION:
+        Material: POTION
+        PotionData:
+            PotionType: INFESTED
+        Children:
+            GUNPOWDER: SPLASH_POTION_OF_INFESTATION
+    POTION_OF_OOZING:
+        Material: POTION
+        PotionData:
+            PotionType: OOZING
+        Children:
+            GUNPOWDER: SPLASH_POTION_OF_OOZING
     POTION_OF_ABSORPTION:
         Name: Potion Of Absorption
         Material: POTION
@@ -704,6 +724,8 @@ Potions:
             SPIDER_EYE: SPLASH_POTION_OF_MUNDANE
             REDSTONE: SPLASH_POTION_OF_MUNDANE
             MAGMA_CREAM: SPLASH_POTION_OF_MUNDANE
+            STONE: SPLASH_POTION_OF_MUNDANE
+            SLIME_BLOCK: SPLASH_POTION_OF_MUNDANE
     SPLASH_POTION_OF_MUNDANE:
         Material: SPLASH_POTION
         PotionData:
@@ -743,6 +765,8 @@ Potions:
             SPIDER_EYE: SPLASH_POTION_OF_POISON
             INK_SAC: SPLASH_POTION_OF_BLINDNESS
             PUFFERFISH: SPLASH_POTION_OF_WATER_BREATHING
+            STONE: SPLASH_POTION_OF_INFESTATION
+            SLIME_BLOCK: SPLASH_POTION_OF_OOZING
     SPLASH_POTION_OF_NIGHT_VISION:
         Material: SPLASH_POTION
         PotionData:
@@ -1029,6 +1053,18 @@ Potions:
             Extended: true
         Children:
             DRAGON_BREATH: LINGERING_POTION_OF_SLOW_FALLING_EXTENDED
+    SPLASH_POTION_OF_INFESTATION:
+        Material: SPLASH_POTION
+        PotionData:
+            PotionType: INFESTED
+        Children:
+            DRAGON_BREATH: LINGERING_POTION_OF_INFESTATION
+    SPLASH_POTION_OF_OOZING:
+        Material: SPLASH_POTION
+        PotionData:
+            PotionType: OOZING
+        Children:
+            DRAGON_BREATH: LINGERING_POTION_OF_OOZING
     SPLASH_POTION_OF_ABSORPTION:
         Name: Splash Potion Of Absorption
         Material: SPLASH_POTION
@@ -1309,6 +1345,8 @@ Potions:
             SUGAR: LINGERING_POTION_OF_MUNDANE
             SPIDER_EYE: LINGERING_POTION_OF_MUNDANE
             MAGMA_CREAM: LINGERING_POTION_OF_MUNDANE
+            STONE: LINGERING_POTION_OF_MUNDANE
+            SLIME_BLOCK: LINGERING_POTION_OF_MUNDANE
     LINGERING_POTION_OF_MUNDANE:
         Material: LINGERING_POTION
         PotionData:
@@ -1343,6 +1381,8 @@ Potions:
             ROTTEN_FLESH: LINGERING_POTION_OF_HUNGER
             MAGMA_CREAM: LINGERING_POTION_OF_FIRE_RESISTANCE
             PUFFERFISH: LINGERING_POTION_OF_WATER_BREATHING
+            STONE: LINGERING_POTION_OF_INFESTATION
+            SLIME_BLOCK: LINGERING_POTION_OF_OOZING
     LINGERING_POTION_OF_NIGHT_VISION:
         Material: LINGERING_POTION
         PotionData:
@@ -1576,6 +1616,14 @@ Potions:
         PotionData:
             PotionType: SLOW_FALLING
             Extended: true
+    LINGERING_POTION_OF_INFESTATION:
+        Material: LINGERING_POTION
+        PotionData:
+            PotionType: INFESTED
+    LINGERING_POTION_OF_OOZING:
+        Material: LINGERING_POTION
+        PotionData:
+            PotionType: OOZING
     LINGERING_POTION_OF_ABSORPTION:
         Name: Lingering Potion Of Absorption
         Material: LINGERING_POTION

--- a/src/util/java/mcMMO/PotionConfigGenerator.java
+++ b/src/util/java/mcMMO/PotionConfigGenerator.java
@@ -104,6 +104,8 @@ public class PotionConfigGenerator {
                 case WEAKNESS :
                 case TURTLE_MASTER:
                 case SLOW_FALLING:
+                case INFESTED:
+                case OOZING:
                     return type.name();
                 default :
                     return "";
@@ -310,6 +312,24 @@ public class PotionConfigGenerator {
                 return "CONDUIT_POWER";
             case 30:
                 return "DOLPHINS_GRACE";
+            case 31:
+                return "BAD_OMEN";
+            case 32:
+                return "HERO_OF_THE_VILLAGE";
+            case 33:
+                return "DARKNESS";
+            case 34:
+                return "TRIAL_OMEN";
+            case 35:
+                return "RAID_OMEN";
+            case 36:
+                return "WIND_CHARGED";
+            case 37:
+                return "WEAVING";
+            case 38:
+                return "OOZING";
+            case 39:
+                return "INFESTED";
             default :
                 return "UNKNOWN_EFFECT_TYPE_" + type.getId();
         }
@@ -362,6 +382,8 @@ public class PotionConfigGenerator {
                 children.put(new Ingredient(Material.MAGMA_CREAM), new WriteablePotion(current.mat, PotionType.MUNDANE));
                 children.put(new Ingredient(Material.GLISTERING_MELON_SLICE), new WriteablePotion(current.mat, PotionType.MUNDANE));
                 children.put(new Ingredient(Material.GHAST_TEAR), new WriteablePotion(current.mat, PotionType.MUNDANE));
+                children.put(new Ingredient(Material.STONE), new WriteablePotion(current.mat, PotionType.MUNDANE));
+                children.put(new Ingredient(Material.SLIME_BLOCK), new WriteablePotion(current.mat, PotionType.MUNDANE));
                 return;
             case AWKWARD :
                 assert(!current.data.isExtended());
@@ -377,6 +399,8 @@ public class PotionConfigGenerator {
                 children.put(new Ingredient(Material.BLAZE_POWDER), new WriteablePotion(current.mat, PotionType.STRENGTH));
                 children.put(new Ingredient(Material.TURTLE_HELMET), new WriteablePotion(current.mat, PotionType.TURTLE_MASTER));
                 children.put(new Ingredient(Material.PHANTOM_MEMBRANE), new WriteablePotion(current.mat, PotionType.SLOW_FALLING));
+                children.put(new Ingredient(Material.STONE), new WriteablePotion(current.mat, PotionType.INFESTATION));
+                children.put(new Ingredient(Material.SLIME_BLOCK), new WriteablePotion(current.mat, PotionType.OOZING));
                 // mcMMO custom potions
                 double mod = 1;
                 if (current.mat == Material.SPLASH_POTION) {
@@ -503,6 +527,8 @@ public class PotionConfigGenerator {
                     children.put(new Ingredient(Material.REDSTONE), new WriteablePotion(current.mat, new PotionData(current.data.getType(), true, false)));
                 }
                 return;
+            case INFESTATION :
+            case OOZING :
             case LUCK :
             case MUNDANE :
             case THICK :


### PR DESCRIPTION
Fixed so now spawners actually dont drop from blastmining, mining wont spawn illegal items anymore, before items like suspisous sand, infested_stone and similar illegal items were requiable with blastmining.

Removed double drops from non-mining related blocks Added stone types back into the drops w/o double drops 

Added Javadoc