### PR TITLE
Cache ItemMeta instead of creating a new ItemMeta for each potion check

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
@@ -335,6 +335,10 @@ public class PotionConfig extends LegacyConfigLoader {
      * @return AlchemyPotion that corresponds to the given ItemStack.
      */
     public AlchemyPotion getPotion(ItemStack item) {
+        // Fast return if the item does not have any item meta to avoid initializing an unnecessary ItemMeta instance
+        if (!item.hasItemMeta())
+            return null;
+
         ItemMeta itemMeta = item.getItemMeta();
         final List<AlchemyPotion> potionList = alchemyPotions.values()
                 .stream()

--- a/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/skills/alchemy/PotionConfig.java
@@ -9,6 +9,7 @@ import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -334,9 +335,10 @@ public class PotionConfig extends LegacyConfigLoader {
      * @return AlchemyPotion that corresponds to the given ItemStack.
      */
     public AlchemyPotion getPotion(ItemStack item) {
+        ItemMeta itemMeta = item.getItemMeta();
         final List<AlchemyPotion> potionList = alchemyPotions.values()
                 .stream()
-                .filter(potion -> potion.isSimilarPotion(item))
+                .filter(potion -> potion.isSimilarPotion(item, itemMeta))
                 .toList();
         if(potionList.size() > 1) {
             mcMMO.p.getLogger().severe("Multiple potions defined in config have matched this potion, for mcMMO to behave" +

--- a/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
@@ -4,6 +4,7 @@ import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.PotionUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -49,13 +50,18 @@ public class AlchemyPotion {
     }
 
     public boolean isSimilarPotion(@NotNull ItemStack otherPotion) {
+        return isSimilarPotion(otherPotion, otherPotion.getItemMeta());
+    }
+
+    public boolean isSimilarPotion(@NotNull ItemStack otherPotion, @Nullable ItemMeta otherMeta) {
         requireNonNull(otherPotion, "otherPotion cannot be null");
+
         if (otherPotion.getType() != potionItemStack.getType()) {
             return false;
         }
 
         // no potion meta, no match
-        if (!otherPotion.hasItemMeta()) {
+        if (otherMeta == null) {
             return false;
         }
 
@@ -63,7 +69,7 @@ public class AlchemyPotion {
          * Compare custom effects on both potions.
          */
 
-        final PotionMeta otherPotionMeta = (PotionMeta) otherPotion.getItemMeta();
+        final PotionMeta otherPotionMeta = (PotionMeta) otherMeta;
         // compare custom effects on both potions, this has to be done in two traversals
         // comparing thisPotionMeta -> otherPotionMeta and otherPotionMeta -> thisPotionMeta
         if (hasDifferingCustomEffects(getAlchemyPotionMeta(), otherPotionMeta)

--- a/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
@@ -27,7 +27,7 @@ public class AlchemyPotion {
         this.potionConfigName = requireNonNull(potionConfigName, "potionConfigName cannot be null");
         this.potionItemStack = requireNonNull(potionItemStack, "potionItemStack cannot be null");
         this.alchemyPotionChildren = requireNonNull(alchemyPotionChildren, "alchemyPotionChildren cannot be null");
-        this.potionItemMeta = potionItemStack.getItemMeta(); // The potion item meta should never be null because it is a potion
+        this.potionItemMeta = requireNonNull(potionItemStack.getItemMeta(), "potionItemMeta cannot be null"); // The potion item meta should never be null because it is a potion, but if it is null, then something went terribly wrong
     }
 
     public @NotNull ItemStack toItemStack(int amount) {

--- a/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/skills/alchemy/AlchemyPotion.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 public class AlchemyPotion {
     private final @NotNull String potionConfigName;
     private final @NotNull ItemStack potionItemStack;
+    private final @NotNull ItemMeta potionItemMeta;
     private final @NotNull Map<ItemStack, String> alchemyPotionChildren;
 
     public AlchemyPotion(@NotNull String potionConfigName, @NotNull ItemStack potionItemStack,
@@ -26,6 +27,7 @@ public class AlchemyPotion {
         this.potionConfigName = requireNonNull(potionConfigName, "potionConfigName cannot be null");
         this.potionItemStack = requireNonNull(potionItemStack, "potionItemStack cannot be null");
         this.alchemyPotionChildren = requireNonNull(alchemyPotionChildren, "alchemyPotionChildren cannot be null");
+        this.potionItemMeta = potionItemStack.getItemMeta(); // The potion item meta should never be null because it is a potion
     }
 
     public @NotNull ItemStack toItemStack(int amount) {
@@ -120,7 +122,7 @@ public class AlchemyPotion {
     }
 
     public PotionMeta getAlchemyPotionMeta() {
-        return (PotionMeta) potionItemStack.getItemMeta();
+        return (PotionMeta) potionItemMeta;
     }
 
     public boolean isSplash() {


### PR DESCRIPTION
The `isSimilarPotion` is very expensive because the code attempts to get the `otherPotion` (in this case, the current item) `ItemMeta` on every comparison check, and initializing the `ItemMeta` is *very* expensive.

To avoid this, we only create the `ItemMeta` once and then reuse it in the `isSimilarPotion` check.

While on Spigot the ItemStack code does seem to cache the ItemMeta, on Paper it doesn't due to the ItemStack being delegated to the server ItemStack, the ItemMeta seems to be always be created on every `getItemMeta()` call.

![image](https://github.com/user-attachments/assets/b8858b52-c595-4920-9118-76fba600d8bd)
