### PR TITLE
Fix AlchemyBrewTask NPE, Fix blastMiningDropProcessing (IllegalArgumentException: ... isn't an item)

### DIFF
--- a/src/main/java/com/gmail/nossr50/runnables/skills/AlchemyBrewTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/skills/AlchemyBrewTask.java
@@ -152,11 +152,13 @@ public class AlchemyBrewTask extends CancellableRunnable {
 
 
     private void finish() {
-        final McMMOPlayerBrewEvent event = new McMMOPlayerBrewEvent(mmoPlayer, brewingStand);
-        mcMMO.p.getServer().getPluginManager().callEvent(event);
+        if(mmoPlayer != null) {
+            final McMMOPlayerBrewEvent event = new McMMOPlayerBrewEvent(mmoPlayer, brewingStand);
+            mcMMO.p.getServer().getPluginManager().callEvent(event);
 
-        if (!event.isCancelled()) {
-            AlchemyPotionBrewer.finishBrewing(brewingStand, mmoPlayer, false);
+            if (!event.isCancelled()) {
+                AlchemyPotionBrewer.finishBrewing(brewingStand, mmoPlayer, false);
+            }
         }
 
         Alchemy.brewingStandMap.remove(brewingStand.getLocation());

--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -204,7 +204,7 @@ public class MiningManager extends SkillManager {
             if (isDropIllegal(blockState.getType()))
                 continue;
 
-            if (Probability.ofPercent(50).evaluate()) {
+            if (blockState.getType().isItem() && Probability.ofPercent(50).evaluate()) {
                 ItemUtils.spawnItem(getPlayer(),
                         Misc.getBlockCenter(blockState),
                         new ItemStack(blockState.getType()),


### PR DESCRIPTION
Fix McMMOPlayerBrewEvent NPE in AlchemyBrewTask#finish 
Fix blastMiningDropProcessing attempting to create ItemStacks from Materials that don't have valid items.