### PR TITLE
Update PlaceholderAPI dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.3</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
For some reason, only the latest 2 versions are present on the repository. Fixes building the project.