### PR TITLE
Fix acrobatics damage calculations

### DIFF
--- a/src/main/java/com/gmail/nossr50/datatypes/skills/subskills/acrobatics/Roll.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/skills/subskills/acrobatics/Roll.java
@@ -76,7 +76,12 @@ public class Roll extends AcrobaticsSubSkill {
                     // no-op - fall was fatal or otherwise did not get processed
                     return false;
                 }
-                entityDamageEvent.setDamage(rollResult.getModifiedDamage());
+
+                // Clear out the damage from falling so that way our modified damage doesn't get re-reduced by protection/feather falling
+                entityDamageEvent.setDamage(0);
+                // Send the damage is MAGIC so that it cuts through all resistances
+                // This is fine because we considered protection/featherfalling in the rollCheck method
+                entityDamageEvent.setDamage(EntityDamageEvent.DamageModifier.MAGIC, rollResult.getModifiedDamage());
 
                 if (entityDamageEvent.getFinalDamage() == 0) {
                     entityDamageEvent.setCancelled(true);
@@ -216,7 +221,7 @@ public class Roll extends AcrobaticsSubSkill {
      */
     @VisibleForTesting
     public RollResult rollCheck(McMMOPlayer mmoPlayer, EntityDamageEvent entityDamageEvent) {
-        double baseDamage = entityDamageEvent.getDamage();
+        double baseDamage = entityDamageEvent.getFinalDamage();
         final boolean isGraceful = mmoPlayer.getPlayer().isSneaking();
         final RollResult.Builder rollResultBuilder
                 = new RollResult.Builder(entityDamageEvent, isGraceful);


### PR DESCRIPTION
Currently, acrobatics does it's damage calculates pre-vanilla damage reductions which leads to a non-fatal fall being considered fatal. 

This leads to armored players never procing Roll or Graceful Landing when they infact should, as their fall damage was not fatal.

This change uses the getFinalDamage() method instead of getDamage() method which will use the post-vanilla reduction damage calculation to calculate fatality as well as mcMMO's further reductions.

Using setDamage would re-trigger vanilla damage reductions and would result in a double-reduction, both pre and post mcMMO calculations, so we instead setDamage to 0 from this fall and set a new damage with the DamageType of MAGIC which bypasses resistances.

This is perfectly fine because vanilla reductions are already factored into the fall before mcMMO does any modification, and the server will never see a death from "magic" since Roll will not run any modifications should the fall be fatal.