### PR TITLE
Fix slime spawner exploit

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -46,6 +46,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.ProjectileSource;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static com.gmail.nossr50.util.MobMetadataUtils.*;
 
@@ -57,6 +58,7 @@ public class EntityListener implements Listener {
      * check if a {@link Player} has a {@link Trident} enchanted with "Piercing".
      */
     private final NamespacedKey piercingEnchantment = NamespacedKey.minecraft("piercing");
+    private final List<EntityType> transformableEntities = Arrays.asList(EntityType.SLIME, EntityType.MAGMA_CUBE);
 
     public EntityListener(final mcMMO pluginRef) {
         this.pluginRef = pluginRef;
@@ -76,7 +78,7 @@ public class EntityListener implements Listener {
             }
 
             // Clear the original slime/magma cubes metadata - it's dead.
-            if (Arrays.asList(EntityType.SLIME, EntityType.MAGMA_CUBE).contains(livingEntity.getType())) {
+            if (transformableEntities.contains(livingEntity.getType())) {
                 mcMMO.getTransientMetadataTools().cleanLivingEntityMetadata(livingEntity);
             }
         }
@@ -662,7 +664,7 @@ public class EntityListener implements Listener {
         LivingEntity entity = event.getEntity();
 
         // Clear metadata for Slimes/Magma Cubes after transformation events take place, otherwise small spawned slimes will not have any tags
-        if (Arrays.asList(EntityType.SLIME, EntityType.MAGMA_CUBE).contains(entity.getType())) {
+        if (transformableEntities.contains(entity.getType())) {
             return;
         }
 

--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -45,6 +45,8 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.projectiles.ProjectileSource;
 
+import java.util.Arrays;
+
 import static com.gmail.nossr50.util.MobMetadataUtils.*;
 
 public class EntityListener implements Listener {
@@ -71,6 +73,11 @@ public class EntityListener implements Listener {
                         addMobFlags(livingEntity, transformedEntity);
                     }
                 }
+            }
+
+            // Clear the original slime/magma cubes metadata - it's dead.
+            if (Arrays.asList(EntityType.SLIME, EntityType.MAGMA_CUBE).contains(livingEntity.getType())) {
+                mcMMO.getTransientMetadataTools().cleanLivingEntityMetadata(livingEntity);
             }
         }
     }
@@ -652,7 +659,14 @@ public class EntityListener implements Listener {
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEntityDeathLowest(EntityDeathEvent event) {
-        mcMMO.getTransientMetadataTools().cleanLivingEntityMetadata(event.getEntity());
+        LivingEntity entity = event.getEntity();
+
+        // Clear metadata for Slimes/Magma Cubes after transformation events take place, otherwise small spawned slimes will not have any tags
+        if (Arrays.asList(EntityType.SLIME, EntityType.MAGMA_CUBE).contains(entity.getType())) {
+            return;
+        }
+
+        mcMMO.getTransientMetadataTools().cleanLivingEntityMetadata(entity);
     }
 
     /**


### PR DESCRIPTION
Currently, slime/magma cube meta gets cleaned at death which fires before the Transform event. This means the smaller slimes/magma cubes from a spawner slime will not have tags carry over, allowing players to farm combat skills from spawned mobs.

This PR moves cleaning for Slimes/Magma Cubes to after the transform event, which we know means the slime is dead anyways, so it's fine to clean them there.