### PR TITLE
Redo XP perks

### DIFF
--- a/src/main/java/com/gmail/nossr50/placeholders/PapiExpansion.java
+++ b/src/main/java/com/gmail/nossr50/placeholders/PapiExpansion.java
@@ -8,9 +8,11 @@ import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.Permissions;
 import com.gmail.nossr50.util.player.UserManager;
+import com.gmail.nossr50.util.skills.XPBoostAmount;
 import com.gmail.nossr50.util.text.StringUtils;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -151,22 +153,13 @@ public class PapiExpansion extends PlaceholderExpansion {
         final McMMOPlayer user = UserManager.getPlayer(player);
         if (user == null) return null;
 
-        double modifier = 1.0F;
-
-        if (Permissions.customXpBoost(player, skill))
-            modifier = ExperienceConfig.getInstance().getCustomXpPerkBoost();
-        else if (Permissions.quadrupleXp(player, skill))
-            modifier = 4;
-        else if (Permissions.tripleXp(player, skill))
-            modifier = 3;
-        else if (Permissions.doubleAndOneHalfXp(player, skill))
-            modifier = 2.5;
-        else if (Permissions.doubleXp(player, skill))
-            modifier = 2;
-        else if (Permissions.oneAndOneHalfXp(player, skill))
-            modifier = 1.5;
-        else if (Permissions.oneAndOneTenthXp(player, skill))
-            modifier = 1.1;
+        double modifier = XPBoostAmount.NONE;
+        for (XPBoostAmount xpBoostAmount : XPBoostAmount.getByHighestMultiplier()) {
+            if (xpBoostAmount.hasBoostPermission(player, skill)) {
+                modifier = xpBoostAmount.getMultiplier();
+                break;
+            }
+        }
 
         return String.valueOf(modifier);
     }

--- a/src/main/java/com/gmail/nossr50/util/Permissions.java
+++ b/src/main/java/com/gmail/nossr50/util/Permissions.java
@@ -113,41 +113,49 @@ public final class Permissions {
     public static boolean lucky(Permissible permissible, PrimarySkillType skill) { return permissible.hasPermission("mcmmo.perks.lucky." + skill.toString().toLowerCase(Locale.ENGLISH)); }
 
     /* XP PERKS */
-    public static boolean quadrupleXp(Permissible permissible, PrimarySkillType skill) { 
+    @Deprecated
+    public static boolean quadrupleXp(Permissible permissible, PrimarySkillType skill) {
         return permissible.hasPermission("mcmmo.perks.xp.quadruple.all")
-            || permissible.hasPermission("mcmmo.perks.xp.quadruple." + skill.toString().toLowerCase(Locale.ENGLISH)); 
-    }
-    
-    public static boolean tripleXp(Permissible permissible, PrimarySkillType skill) { 
-        return permissible.hasPermission("mcmmo.perks.xp.triple.all")
-            || permissible.hasPermission("mcmmo.perks.xp.triple." + skill.toString().toLowerCase(Locale.ENGLISH)); 
-    }
-    
-    public static boolean doubleAndOneHalfXp(Permissible permissible, PrimarySkillType skill) { 
-        return permissible.hasPermission("mcmmo.perks.xp.150percentboost.all")
-            || permissible.hasPermission("mcmmo.perks.xp.150percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); 
-    }
-    
-    public static boolean doubleXp(Permissible permissible, PrimarySkillType skill) { 
-        return permissible.hasPermission("mcmmo.perks.xp.double.all")
-            || permissible.hasPermission("mcmmo.perks.xp.double." + skill.toString().toLowerCase(Locale.ENGLISH)); 
-    }
-    
-    public static boolean oneAndOneHalfXp(Permissible permissible, PrimarySkillType skill) { 
-        return permissible.hasPermission("mcmmo.perks.xp.50percentboost.all")
-            || permissible.hasPermission("mcmmo.perks.xp.50percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+            || permissible.hasPermission("mcmmo.perks.xp.quadruple." + skill.toString().toLowerCase(Locale.ENGLISH));
     }
 
+    @Deprecated
+    public static boolean tripleXp(Permissible permissible, PrimarySkillType skill) {
+        return permissible.hasPermission("mcmmo.perks.xp.triple.all")
+            || permissible.hasPermission("mcmmo.perks.xp.triple." + skill.toString().toLowerCase(Locale.ENGLISH));
+    }
+
+    @Deprecated
+    public static boolean doubleAndOneHalfXp(Permissible permissible, PrimarySkillType skill) {
+        return permissible.hasPermission("mcmmo.perks.xp.150percentboost.all")
+            || permissible.hasPermission("mcmmo.perks.xp.150percentboost." + skill.toString().toLowerCase(Locale.ENGLISH));
+    }
+
+    @Deprecated
+    public static boolean doubleXp(Permissible permissible, PrimarySkillType skill) {
+        return permissible.hasPermission("mcmmo.perks.xp.double.all")
+            || permissible.hasPermission("mcmmo.perks.xp.double." + skill.toString().toLowerCase(Locale.ENGLISH));
+    }
+
+    @Deprecated
+    public static boolean oneAndOneHalfXp(Permissible permissible, PrimarySkillType skill) {
+        return permissible.hasPermission("mcmmo.perks.xp.50percentboost.all")
+            || permissible.hasPermission("mcmmo.perks.xp.50percentboost." + skill.toString().toLowerCase(Locale.ENGLISH));
+    }
+
+    @Deprecated
     public static boolean oneAndAQuarterXp(Permissible permissible, PrimarySkillType skill) {
         return permissible.hasPermission("mcmmo.perks.xp.25percentboost.all")
                 || permissible.hasPermission("mcmmo.perks.xp.25percentboost." + skill.toString().toLowerCase(Locale.ENGLISH));
     }
 
-    public static boolean oneAndOneTenthXp(Permissible permissible, PrimarySkillType skill) { 
+    @Deprecated
+    public static boolean oneAndOneTenthXp(Permissible permissible, PrimarySkillType skill) {
         return permissible.hasPermission("mcmmo.perks.xp.10percentboost.all")
-            || permissible.hasPermission("mcmmo.perks.xp.10percentboost." + skill.toString().toLowerCase(Locale.ENGLISH)); 
+            || permissible.hasPermission("mcmmo.perks.xp.10percentboost." + skill.toString().toLowerCase(Locale.ENGLISH));
     }
 
+    @Deprecated
     public static boolean customXpBoost(Permissible permissible, PrimarySkillType skill) {
         return permissible.hasPermission("mcmmo.perks.xp.customboost.all")
             || permissible.hasPermission("mcmmo.perks.xp.customboost." + skill.toString().toLowerCase(Locale.ENGLISH));

--- a/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/PerksUtils.java
@@ -1,6 +1,5 @@
 package com.gmail.nossr50.util.skills;
 
-import com.gmail.nossr50.config.experience.ExperienceConfig;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.events.skills.SkillActivationPerkEvent;
@@ -47,28 +46,17 @@ public final class PerksUtils {
     }
 
     public static float handleXpPerks(Player player, float xp, PrimarySkillType skill) {
-        double modifier = 1.0F;
+        double modifier = XPBoostAmount.NONE;
 
-        if (Permissions.customXpBoost(player, skill)) {
-            if (UserManager.getPlayer(player) != null && UserManager.getPlayer(player).isDebugMode()) {
-                player.sendMessage(ChatColor.GOLD + "[DEBUG] " + ChatColor.DARK_GRAY + "XP Perk Multiplier IS CUSTOM! ");
+        for (XPBoostAmount xpBoostAmount : XPBoostAmount.getByHighestMultiplier()) {
+            if (xpBoostAmount.hasBoostPermission(player, skill)) {
+                modifier = xpBoostAmount.getMultiplier();
+
+                if (xpBoostAmount == XPBoostAmount.CUSTOM && UserManager.getPlayer(player) != null && UserManager.getPlayer(player).isDebugMode()) {
+                    player.sendMessage(ChatColor.GOLD + "[DEBUG] " + ChatColor.DARK_GRAY + "XP perk multiplier is custom!");
+                }
+                break;
             }
-
-             modifier = ExperienceConfig.getInstance().getCustomXpPerkBoost();
-        } else if (Permissions.quadrupleXp(player, skill)) {
-            modifier = 4;
-        } else if (Permissions.tripleXp(player, skill)) {
-            modifier = 3;
-        } else if (Permissions.doubleAndOneHalfXp(player, skill)) {
-            modifier = 2.5;
-        } else if (Permissions.doubleXp(player, skill)) {
-            modifier = 2;
-        } else if (Permissions.oneAndOneHalfXp(player, skill)) {
-            modifier = 1.5;
-        } else if (Permissions.oneAndAQuarterXp(player, skill)) {
-            modifier = 1.25;
-        } else if (Permissions.oneAndOneTenthXp(player, skill)) {
-            modifier = 1.1;
         }
 
         float modifiedXP = (float) (xp * modifier);

--- a/src/main/java/com/gmail/nossr50/util/skills/XPBoostAmount.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/XPBoostAmount.java
@@ -1,0 +1,94 @@
+package com.gmail.nossr50.util.skills;
+
+import com.gmail.nossr50.config.experience.ExperienceConfig;
+import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
+import org.bukkit.permissions.Permissible;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class XPBoostAmount {
+
+    public static final double NONE = 1.0;
+
+    public static final XPBoostAmount QUADRUPLE = new XPBoostAmount(4.0, "mcmmo.perks.xp.quadruple.%s");
+    public static final XPBoostAmount TRIPLE = new XPBoostAmount(3.0, "mcmmo.perks.xp.triple.%s");
+    public static final XPBoostAmount DOUBLE_AND_ONE_HALF = new XPBoostAmount(2.5, "mcmmo.perks.xp.150percentboost.%s");
+    public static final XPBoostAmount DOUBLE = new XPBoostAmount(2.0, "mcmmo.perks.xp.double.%s");
+    public static final XPBoostAmount ONE_AND_ONE_HALF = new XPBoostAmount(1.5, "mcmmo.perks.xp.50percentboost.%s");
+    public static final XPBoostAmount ONE_AND_ONE_QUARTER = new XPBoostAmount(1.25, "mcmmo.perks.xp.25percentboost.%s");
+    public static final XPBoostAmount ONE_AND_ONE_TENTH = new XPBoostAmount(1.1, "mcmmo.perks.xp.10percentboost.%s");
+    public static final XPBoostAmount CUSTOM = new XPBoostAmount(ExperienceConfig.getInstance().getCustomXpPerkBoost(), "mcmmo.perks.xp.customboost.%s");
+
+
+    private String FIELD_NAME;
+    private final double multiplier;
+    private final String permissionNode;
+
+    public XPBoostAmount(double multiplier, String permissionNode) {
+        this.multiplier = multiplier;
+        this.permissionNode = permissionNode;
+    }
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public String getPermissionNode() {
+        return permissionNode;
+    }
+
+
+
+    public boolean hasBoostPermission(Permissible permissible, PrimarySkillType skill) {
+        return permissible.hasPermission(String.format(permissionNode, "all")) ||
+                permissible.hasPermission(String.format(permissionNode, skill.toString().toLowerCase(Locale.ENGLISH)));
+    }
+
+
+    // Make this class work like an enum
+
+    @Override
+    public String toString() {
+        return FIELD_NAME;
+    }
+
+    public String name() {
+        return FIELD_NAME;
+    }
+
+    public static final Map<String, XPBoostAmount> VALUES = new HashMap<>();
+    public static final List<XPBoostAmount> VALUES_SORTED_BY_MULTIPLIER = new ArrayList<>(); // Faster to just sort once since mcMMO doesn't have any reloading anyway
+
+    static {
+        for (Field field : XPBoostAmount.class.getDeclaredFields()) {
+            if (field.getType() == XPBoostAmount.class) {
+                try {
+                    XPBoostAmount itemType = (XPBoostAmount) field.get(null);
+                    itemType.FIELD_NAME = field.getName();
+                    VALUES.put(field.getName(), itemType);
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        VALUES_SORTED_BY_MULTIPLIER.addAll(VALUES.values().stream().sorted((a, b) -> Double.compare(b.getMultiplier(), a.getMultiplier())).toList());
+    }
+
+    public static XPBoostAmount valueOf(String name) {
+        return VALUES.get(name);
+    }
+
+    public static List<XPBoostAmount> values() {
+        return VALUES.values().stream().toList();
+    }
+
+    public static List<XPBoostAmount> getByHighestMultiplier() {
+        return VALUES_SORTED_BY_MULTIPLIER;
+    }
+}


### PR DESCRIPTION
This PR removes the old 'else if' chain used for xp perks and replaces it with an enum class for faster usage and other benefits. This PR also brings another important change by ensuring  the **highest** XP multiplier amount is always used for the player.

Before this change, mcMMO would always use the custom multiplier if the player had permission for it even if it was lower than other multiplier amounts. This would cause conflicts for those who want to use the custom xp amount for a lower xp boost, and then give their players higher boost amounts later on.