### PR TITLE
Fix cat cotw on older versions

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
@@ -402,6 +402,7 @@ public class TamingManager extends SkillManager {
         callOfWildEntity.setCustomName(LocaleLoader.getString("Taming.Summon.Name.Format", getPlayer().getName(), StringUtils.getPrettyEntityTypeString(EntityType.WOLF)));
     }
 
+    @SuppressWarnings("deprecation")
     private void spawnCat(Location spawnLocation, EntityType entityType) {
         LivingEntity callOfWildEntity = (LivingEntity) getPlayer().getWorld().spawnEntity(spawnLocation, entityType);
 
@@ -414,14 +415,12 @@ public class TamingManager extends SkillManager {
 
         //Randomize the cat
         if (callOfWildEntity instanceof Ocelot) {
+            // Ocelot.Type is deprecated, but that's fine since this only runs on 1.13
             int numberOfTypes = Ocelot.Type.values().length;
             ((Ocelot) callOfWildEntity).setCatType(Ocelot.Type.values()[Misc.getRandom().nextInt(numberOfTypes)]);
-            ((Ocelot) callOfWildEntity).setAdult();
-        } else if (callOfWildEntity instanceof Cat) {
-            int numberOfTypes = Cat.Type.values().length;
-            ((Cat) callOfWildEntity).setCatType(Cat.Type.values()[Misc.getRandom().nextInt(numberOfTypes)]);
-            ((Cat) callOfWildEntity).setAdult();
         }
+
+        ((Ageable) callOfWildEntity).setAdult();
 
         callOfWildEntity.setCustomName(LocaleLoader.getString("Taming.Summon.Name.Format", getPlayer().getName(), StringUtils.getPrettyEntityTypeString(entityType)));
 


### PR DESCRIPTION
This bit of code was erroring out on older versions, since in the version of spigot that mcMMO compiles against, Cat.Type is an interface while it used to be an enum in older versions. After some testing, it seems this code was no longer needed at all, since the game already randomizes the cat type when spawning a new cat.