### PR TITLE
Run rupture task on the target entity's scheduler

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/swords/SwordsManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/swords/SwordsManager.java
@@ -95,7 +95,7 @@ public class SwordsManager extends SkillManager {
 
             RuptureTaskMeta ruptureTaskMeta = new RuptureTaskMeta(mcMMO.p, ruptureTask);
 
-            mcMMO.p.getFoliaLib().getImpl().runAtEntityTimer(mmoPlayer.getPlayer(), ruptureTask, 1, 1);
+            mcMMO.p.getFoliaLib().getImpl().runAtEntityTimer(target, ruptureTask, 1, 1);
             target.setMetadata(MetadataConstants.METADATA_KEY_RUPTURE, ruptureTaskMeta);
 
 //            if (mmoPlayer.useChatNotifications()) {


### PR DESCRIPTION
The rupture task needs to run on the target's scheduler so that it doesn't fail when the player or target move into a different region.

Closes #5119