### PR TITLE
Remove globally affecting call to Locale#setDefault

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/skills/SkillCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/skills/SkillCommand.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -34,8 +35,8 @@ public abstract class SkillCommand implements TabExecutor {
     public static final String ABILITY_GENERIC_TEMPLATE = "Ability.Generic.Template";
     protected PrimarySkillType skill;
 
-    protected DecimalFormat percent = new DecimalFormat("##0.00%");
-    protected DecimalFormat decimal = new DecimalFormat("##0.00");
+    protected DecimalFormat percent = new DecimalFormat("##0.00%", DecimalFormatSymbols.getInstance(Locale.US));
+    protected DecimalFormat decimal = new DecimalFormat("##0.00", DecimalFormatSymbols.getInstance(Locale.US));
     protected McMMOPlayer mmoPlayer;
 
     private final CommandExecutor skillGuideCommand;

--- a/src/main/java/com/gmail/nossr50/datatypes/party/Party.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/party/Party.java
@@ -18,13 +18,14 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.UUID;
+import java.text.DecimalFormatSymbols;
+import java.util.*;
 import java.util.function.Predicate;
 
 public class Party {
+
+    private static final DecimalFormat percent = new DecimalFormat("##0.00%", DecimalFormatSymbols.getInstance(Locale.US));
+
     private final @NotNull Predicate<CommandSender> samePartyPredicate;
     private final LinkedHashMap<UUID, String> members = new LinkedHashMap<>();
     private final List<Player> onlineMembers = new ArrayList<>();
@@ -204,7 +205,6 @@ public class Party {
     }
 
     public String getXpToLevelPercentage() {
-        DecimalFormat percent = new DecimalFormat("##0.00%");
         return percent.format(this.getXp() / getXpToLevel());
     }
 

--- a/src/main/java/com/gmail/nossr50/locale/LocaleLoader.java
+++ b/src/main/java/com/gmail/nossr50/locale/LocaleLoader.java
@@ -109,7 +109,7 @@ public final class LocaleLoader {
 
     public static String formatString(String string, Object... messageArguments) {
         if (messageArguments != null) {
-            MessageFormat formatter = new MessageFormat("");
+            MessageFormat formatter = new MessageFormat("", Locale.US);
             formatter.applyPattern(string.replace("'", "''"));
             string = formatter.format(messageArguments);
         }
@@ -121,7 +121,7 @@ public final class LocaleLoader {
 
     public static @NotNull TextComponent formatComponent(@NotNull String string, Object... messageArguments) {
         if (messageArguments != null) {
-            MessageFormat formatter = new MessageFormat("");
+            MessageFormat formatter = new MessageFormat("", Locale.US);
             formatter.applyPattern(string.replace("'", "''"));
             string = formatter.format(messageArguments);
         }
@@ -138,7 +138,6 @@ public final class LocaleLoader {
 
     private static void initialize() {
         if (bundle == null) {
-            Locale.setDefault(new Locale("en", "US"));
             Locale locale = null;
 
             String[] myLocale = mcMMO.p.getGeneralConfig().getLocale().split("[-_ ]");

--- a/src/main/java/com/gmail/nossr50/runnables/backups/CleanBackupsTask.java
+++ b/src/main/java/com/gmail/nossr50/runnables/backups/CleanBackupsTask.java
@@ -107,7 +107,7 @@ public class CleanBackupsTask extends CancellableRunnable {
     }
 
     private Date getDate(String fileName) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss", Locale.US);
         Date date;
 
         try {

--- a/src/main/java/com/gmail/nossr50/util/Motd.java
+++ b/src/main/java/com/gmail/nossr50/util/Motd.java
@@ -8,6 +8,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 public final class Motd {
     public static final String PERK_PREFIX = LocaleLoader.getString("MOTD.PerksPrefix") + " ";
@@ -101,7 +103,7 @@ public final class Motd {
         double cooldownReduction = 1 - (PerksUtils.handleCooldownPerks(player, 12) / 12.0);
 
         if (cooldownReduction > 0.0) {
-            DecimalFormat percent = new DecimalFormat("##0.00%");
+            DecimalFormat percent = new DecimalFormat("##0.00%", DecimalFormatSymbols.getInstance(Locale.US));
             player.sendMessage(PERK_PREFIX + LocaleLoader.getString("Effects.Template", LocaleLoader.getString("Perks.Cooldowns.Name"), LocaleLoader.getString("Perks.Cooldowns.Desc", percent.format(cooldownReduction))));
         }
     }

--- a/src/main/java/com/gmail/nossr50/util/random/ProbabilityUtil.java
+++ b/src/main/java/com/gmail/nossr50/util/random/ProbabilityUtil.java
@@ -14,11 +14,13 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 import static java.util.Objects.requireNonNull;
 
 public class ProbabilityUtil {
-    public static final @NotNull DecimalFormat percent = new DecimalFormat("##0.00%");
+    public static final @NotNull DecimalFormat percent = new DecimalFormat("##0.00%", DecimalFormatSymbols.getInstance(Locale.US));
     public static final double LUCKY_MODIFIER = 1.333D;
 
     /**

--- a/src/main/java/com/gmail/nossr50/util/text/StringUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/text/StringUtils.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,8 +19,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class StringUtils {
 
-    protected static final DecimalFormat percent = new DecimalFormat("##0.00%");
-    protected static final DecimalFormat shortDecimal = new DecimalFormat("##0.0");
+    protected static final DecimalFormat percent = new DecimalFormat("##0.00%", DecimalFormatSymbols.getInstance(Locale.US));
+    protected static final DecimalFormat shortDecimal = new DecimalFormat("##0.0", DecimalFormatSymbols.getInstance(Locale.US));
 
     // Using concurrent hash maps to avoid concurrency issues (Folia)
     private static final Map<EntityType, String> formattedEntityStrings = new ConcurrentHashMap<>();

--- a/src/main/java/net/shatteredlands/shatt/backup/ZipLibrary.java
+++ b/src/main/java/net/shatteredlands/shatt/backup/ZipLibrary.java
@@ -11,6 +11,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -43,7 +44,7 @@ public class ZipLibrary {
 
         // Generate the proper date for the backup filename
         Date date = new Date();
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH-mm-ss", Locale.US);
         File fileZip = new File(BACKUP_DIRECTORY + File.separator + dateFormat.format(date) + ".zip");
 
         // Create the Source List, and add directories/etc to the file.


### PR DESCRIPTION
Greetings!

The call to `Locale#setDefault` within `LocaleLoader#initialize` threw me for quite the massive loop today, as it affected multiple other plugins which assumed `Locale#getDefault` to be the JVM's, and thus the system's locale, which mcMMO hard-coded to `en_US`.

While I have to admit that those other developers don't quite adhere to best practises by depending on this global state either, I still wholeheartedly believe that mcMMO should refrain from altering JVM-global-state nonetheless.

Also, since this initialization may occur after executing some of the `static`-blocks of other classes containing various formatters, many test-cases failed to execute due to formatting-discrepancies on my local machine, having had a non-english locale configured.

My proposal represents merely a quick patch, as to cut out altering global state, but the ideal solution would obviously be to use the locale as configured on the plugin; that would demand a few architectural changes, which I do not quite have the resources for, at this point in time.

I hope that this tiny but still rather significant issue can be settled soon.

Best Regards,
BlvckBytes