### PR TITLE
Add event for players taming an entity

### DIFF
--- a/src/main/java/com/gmail/nossr50/events/skills/taming/McMMOPlayerTameEntityEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/skills/taming/McMMOPlayerTameEntityEvent.java
@@ -1,0 +1,67 @@
+package com.gmail.nossr50.events.skills.taming;
+
+import com.gmail.nossr50.datatypes.experience.XPGainReason;
+import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
+import com.gmail.nossr50.events.experience.McMMOPlayerExperienceEvent;
+import com.google.common.base.Preconditions;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player has tamed an entity, and we are about to award them experience for it.
+ */
+public class McMMOPlayerTameEntityEvent extends McMMOPlayerExperienceEvent {
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private float xpGained;
+    private final Entity tamedEntity;
+
+    @ApiStatus.Internal
+    public McMMOPlayerTameEntityEvent(@NotNull Player player, float xp, @NotNull Entity tamedEntity) {
+        super(player, PrimarySkillType.TAMING, XPGainReason.PVE);
+        this.xpGained = xp;
+        this.tamedEntity = tamedEntity;
+    }
+
+    /**
+     * @return The raw experience that the player will receive.
+     */
+    public float getXpGained() {
+        return this.xpGained;
+    }
+
+    /**
+     * @param xpGained The raw experience that the player will receive.
+     * @throws IllegalArgumentException if xpGained is NaN or infinite.
+     */
+    public void setXpGained(float xpGained) {
+        Preconditions.checkArgument(Float.isFinite(xpGained), "new gained xp must be a number");
+
+        this.xpGained = xpGained;
+    }
+
+    @NotNull
+    public Entity getTamedEntity() {
+        return tamedEntity;
+    }
+
+    /**
+     * @apiNote Cancelling this event prevents experience from being awarded, but the entity will remain tamed.
+     */
+    @Override
+    public void setCancelled(boolean cancelled) {
+        super.setCancelled(cancelled);
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/com/gmail/nossr50/events/skills/taming/McMMOPlayerTameEntityEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/skills/taming/McMMOPlayerTameEntityEvent.java
@@ -1,13 +1,12 @@
 package com.gmail.nossr50.events.skills.taming;
 
 import com.gmail.nossr50.datatypes.experience.XPGainReason;
+import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.events.experience.McMMOPlayerExperienceEvent;
 import com.google.common.base.Preconditions;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -16,14 +15,23 @@ import org.jetbrains.annotations.NotNull;
 public class McMMOPlayerTameEntityEvent extends McMMOPlayerExperienceEvent {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
+    private final McMMOPlayer mmoPlayer;
     private float xpGained;
     private final Entity tamedEntity;
 
-    @ApiStatus.Internal
-    public McMMOPlayerTameEntityEvent(@NotNull Player player, float xp, @NotNull Entity tamedEntity) {
-        super(player, PrimarySkillType.TAMING, XPGainReason.PVE);
+    public McMMOPlayerTameEntityEvent(@NotNull McMMOPlayer mmoPlayer, float xp, @NotNull Entity tamedEntity) {
+        super(mmoPlayer.getPlayer(), PrimarySkillType.TAMING, XPGainReason.PVE);
+        this.mmoPlayer = mmoPlayer;
         this.xpGained = xp;
         this.tamedEntity = tamedEntity;
+    }
+
+    /**
+     * @return The {@link McMMOPlayer} associated with this event.
+     */
+    @NotNull
+    public McMMOPlayer getMcMMOPlayer() {
+        return mmoPlayer;
     }
 
     /**
@@ -35,10 +43,11 @@ public class McMMOPlayerTameEntityEvent extends McMMOPlayerExperienceEvent {
 
     /**
      * @param xpGained The raw experience that the player will receive.
-     * @throws IllegalArgumentException if xpGained is NaN or infinite.
+     * @throws IllegalArgumentException if xpGained is NaN, infinite, or not positive.
      */
     public void setXpGained(float xpGained) {
         Preconditions.checkArgument(Float.isFinite(xpGained), "new gained xp must be a number");
+        Preconditions.checkArgument(xpGained > 0, "new gained xp must be a positive number");
 
         this.xpGained = xpGained;
     }

--- a/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
@@ -2,12 +2,14 @@ package com.gmail.nossr50.skills.taming;
 
 import com.gmail.nossr50.config.experience.ExperienceConfig;
 import com.gmail.nossr50.datatypes.experience.XPGainReason;
+import com.gmail.nossr50.datatypes.experience.XPGainSource;
 import com.gmail.nossr50.datatypes.interactions.NotificationType;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.datatypes.skills.SubSkillType;
 import com.gmail.nossr50.datatypes.skills.subskills.taming.CallOfTheWildType;
 import com.gmail.nossr50.datatypes.skills.subskills.taming.TamingSummon;
+import com.gmail.nossr50.events.skills.taming.McMMOPlayerTameEntityEvent;
 import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.metadata.MobMetaFlagType;
@@ -136,7 +138,13 @@ public class TamingManager extends SkillManager {
      * @param entity The LivingEntity to award XP for
      */
     public void awardTamingXP(@NotNull LivingEntity entity) {
-        applyXpGain(ExperienceConfig.getInstance().getTamingXP(entity.getType()), XPGainReason.PVE);
+        int xp = ExperienceConfig.getInstance().getTamingXP(entity.getType());
+
+        final McMMOPlayerTameEntityEvent event = new McMMOPlayerTameEntityEvent(getPlayer(), xp, entity);
+        mcMMO.p.getServer().getPluginManager().callEvent(event);
+
+        if (!event.isCancelled())
+            applyXpGain(event.getXpGained(), XPGainReason.PVE, XPGainSource.SELF);
     }
 
     /**

--- a/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
@@ -140,7 +140,7 @@ public class TamingManager extends SkillManager {
     public void awardTamingXP(@NotNull LivingEntity entity) {
         int xp = ExperienceConfig.getInstance().getTamingXP(entity.getType());
 
-        final McMMOPlayerTameEntityEvent event = new McMMOPlayerTameEntityEvent(getPlayer(), xp, entity);
+        final McMMOPlayerTameEntityEvent event = new McMMOPlayerTameEntityEvent(mmoPlayer, xp, entity);
         mcMMO.p.getServer().getPluginManager().callEvent(event);
 
         if (!event.isCancelled())


### PR DESCRIPTION
Adds an event that allows plugins to modify xp gain for taming specific entities, or to cancel the xp gain outright.