### PR TITLE
Fix spectral arrows

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -181,7 +181,7 @@ public final class CombatUtils {
     }
 
     private static void processCrossbowsCombat(@NotNull LivingEntity target, @NotNull Player player,
-                                               @NotNull EntityDamageByEntityEvent event, @NotNull Arrow arrow) {
+                                               @NotNull EntityDamageByEntityEvent event, @NotNull AbstractArrow arrow) {
         double initialDamage = event.getDamage();
 
         final McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
@@ -384,7 +384,7 @@ public final class CombatUtils {
     }
 
     private static void processArcheryCombat(@NotNull LivingEntity target, @NotNull Player player,
-                                             @NotNull EntityDamageByEntityEvent event, @NotNull Arrow arrow) {
+                                             @NotNull EntityDamageByEntityEvent event, @NotNull AbstractArrow arrow) {
         double initialDamage = event.getDamage();
 
         final McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
@@ -566,7 +566,7 @@ public final class CombatUtils {
                     }
                 }
             }
-        } else if (painSource instanceof Arrow arrow) {
+        } else if (painSource instanceof AbstractArrow arrow) {
             ProjectileSource projectileSource = arrow.getShooter();
             boolean isCrossbow = isCrossbowProjectile(arrow);
             if (projectileSource instanceof Player player) {
@@ -1055,7 +1055,7 @@ public final class CombatUtils {
      *
      * @param arrow the projectile
      */
-    public static void delayArrowMetaCleanup(@NotNull Arrow arrow) {
+    public static void delayArrowMetaCleanup(@NotNull AbstractArrow arrow) {
         mcMMO.p.getFoliaLib().getScheduler().runLater(() -> ProjectileUtils.cleanupProjectileMetadata(arrow), 20*120);
     }
 }

--- a/src/main/java/com/gmail/nossr50/util/skills/ProjectileUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/ProjectileUtils.java
@@ -3,6 +3,7 @@ package com.gmail.nossr50.util.skills;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.MetadataConstants;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.AbstractArrow;
 import org.bukkit.entity.Arrow;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
@@ -32,7 +33,7 @@ public class ProjectileUtils {
      *
      * @param arrow projectile
      */
-    public static void cleanupProjectileMetadata(@NotNull Arrow arrow) {
+    public static void cleanupProjectileMetadata(@NotNull AbstractArrow arrow) {
         ARROW_METADATA_KEYS.stream()
                 .filter(arrow::hasMetadata)
                 .forEach(key -> arrow.removeMetadata(key, mcMMO.p));
@@ -61,7 +62,7 @@ public class ProjectileUtils {
                 });
     }
 
-    public static boolean isCrossbowProjectile(@NotNull Arrow arrow) {
+    public static boolean isCrossbowProjectile(@NotNull AbstractArrow arrow) {
         return arrow.isShotFromCrossbow()
                 || arrow.hasMetadata(MetadataConstants.METADATA_KEY_CROSSBOW_PROJECTILE);
     }


### PR DESCRIPTION
Currently spectral arrows don't give crossbow or archery xp

SpectralArrow does not extend Arrow only AbstractArrow, AbstractArrow can be an Arrow, SpectralArrow or a Trident. Trident is already checked in a previous statement so this should be fine 