### PR TITLE
Added spawners to illegal drops for blast mining

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/mining/MiningManager.java
@@ -274,14 +274,15 @@ public class MiningManager extends SkillManager {
 
     /**
      * Checks if it would be illegal (in vanilla) to obtain the block
-     * Certain things should never drop (such as budding_amethyst and infested blocks)
+     * Certain things should never drop (such as budding_amethyst, infested blocks or spawners)
      *
      * @param material target material
      * @return true if it's not legal to get the block through normal gameplay
      */
     public boolean isDropIllegal(@NotNull Material material) {
         return isInfestedBlock(material.getKey().getKey())
-                || material.getKey().getKey().equalsIgnoreCase(BUDDING_AMETHYST);
+                || material.getKey().getKey().equalsIgnoreCase(BUDDING_AMETHYST)
+                || material == Material.SPAWNER;
     }
 
     /**


### PR DESCRIPTION
Related to: https://github.com/mcMMO-Dev/mcMMO/issues/5175

Spawners had a 10% chance of dropping when exploded with TNT (like most non-ores). Now they no longer drop