### PR TITLE
fix(util): correctly match extended and upgraded potions

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/PotionUtil.java
+++ b/src/main/java/com/gmail/nossr50/util/PotionUtil.java
@@ -79,8 +79,8 @@ public class PotionUtil {
             String updatedName = convertLegacyNames(partialName).toUpperCase();
             return Arrays.stream(PotionType.values())
                     .filter(potionType -> getKeyGetKey(potionType).toUpperCase().contains(updatedName))
-                    .filter(potionType -> !isUpgraded || potionType.name().toUpperCase().contains(STRONG))
-                    .filter(potionType -> !isExtended || potionType.name().toUpperCase().contains(LONG))
+                    .filter(potionType -> isUpgraded == potionType.name().toUpperCase().startsWith(STRONG + "_"))
+                    .filter(potionType -> isExtended == potionType.name().toUpperCase().startsWith(LONG + "_"))
                     .findAny().orElse(null);
         }
     }


### PR DESCRIPTION
Closes #5172 

`PotionUtil::matchPotionType` was incorrectly using the `isUpgraded` and `isExtended` arguments. Each corresponding `filter` was always matching _every_ potion if the associated boolean was `false`, or if it started with the associated upgrade string _regardless_ of the provided parameter.

Instead, it should only match strong potions if `isUpgraded` is `true` and only match long potions if `isExtended` is true. I've updated the logic accordingly and slightly cleaned up the `LONG`/`STRONG` string comparisons to be a little stricter, ensuring they only match at the start.