### PR TITLE
Less hacky isValid() performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
                             <include>net.kyori:option</include>
                             <include>net.kyori:adventure-text-serializer-craftbukkit</include>
                             <include>co.aikar:acf-bukkit</include>
-                            <include>com.github.technicallycoded:FoliaLib</include>
+                            <include>com.tcoded:FoliaLib</include>
                         </includes>
                     </artifactSet>
                     <relocations>
@@ -276,6 +276,10 @@
         <repository>
             <id>jitpack</id>
             <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>tcoded-releases</id>
+            <url>https://repo.tcoded.com/releases/</url>
         </repository>
     </repositories>
     <dependencies>
@@ -462,9 +466,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.technicallycoded</groupId>
+            <groupId>com.tcoded</groupId>
             <artifactId>FoliaLib</artifactId>
-            <version>main-SNAPSHOT</version>
+            <version>0.5.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -162,8 +162,11 @@ public class mcMMO extends JavaPlugin {
 
             //Folia lib plugin instance
             foliaLib = new FoliaLib(this);
-            InvalidTickDelayNotifier.disableNotifications = true;
-            foliaPerformanceHack();
+            foliaLib.getOptions().disableNotifications();
+            // Performance optimization
+            // This makes the scheduler behave differently between Spigot/Legacy-Paper & Folia/Modern-Paper
+            foliaLib.getOptions().disableIsValidOnNonFolia();
+
 
             setupFilePaths();
             generalConfig = new GeneralConfig(getDataFolder()); //Load before skillTools
@@ -314,37 +317,6 @@ public class mcMMO extends JavaPlugin {
 
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             new PapiExpansion().register();
-        }
-    }
-
-    private void foliaPerformanceHack() {
-        // Spigot can't use this optimization
-        if (!hasGlobalRegionScheduler()) {
-            return;
-        }
-
-        // Thanks SirSalad
-        // https://github.com/CraftYourTown/mcMMO/commit/2cffd64b127678411e20f0b8f9a3e3b87a649ee8
-        try {
-            final FoliaImplementation setScheduler = new FoliaImplementation(foliaLib);
-            final java.lang.reflect.Field scheduler = FoliaLib.class.getDeclaredField("scheduler");
-            scheduler.setAccessible(true);
-            scheduler.set(foliaLib, setScheduler);
-            scheduler.setAccessible(false);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            getLogger().warning("Unexpected exception when attempting to apply performance tweaks to FoliaLib");
-        }
-    }
-
-    private static boolean hasGlobalRegionScheduler() {
-        try {
-            // No parameters → empty Class<?> array
-            Bukkit.getServer()
-                    .getClass()
-                    .getMethod("getGlobalRegionScheduler");
-            return true;          // Method is present
-        } catch (NoSuchMethodException ignored) {
-            return false;         // Not running on Paper/Folia
         }
     }
 


### PR DESCRIPTION
Natively disables the isValid() check within FoliaLib when running spigot/paper without the need for 50 lines of reflection 🎉 

FYI: I have received a fair bit of feedback about Jitpack having reliability issues and/or being crazy slow at times. The repo therefore migrated to my own domain.