### PR TITLE
 RepairManager: Fix unsafe enchantments being stripped, CombatUtils: Use instanceof for IronGolem

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/repair/RepairManager.java
@@ -374,7 +374,7 @@ public class RepairManager extends SkillManager {
                 if (enchantLevel > enchant.getKey().getMaxLevel()) {
                     enchantLevel = enchant.getKey().getMaxLevel();
 
-                    item.addEnchantment(enchant.getKey(), enchantLevel);
+                    item.addUnsafeEnchantment(enchant.getKey(), enchantLevel);
                 }
             }
 

--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -883,8 +883,8 @@ public final class CombatUtils {
                 EntityType type = target.getType();
 
                 if (ExperienceConfig.getInstance().hasCombatXP(type)) {
-                    if (type == EntityType.IRON_GOLEM) {
-                        if (!((IronGolem) target).isPlayerCreated()) {
+                    if (type == EntityType.IRON_GOLEM && target instanceof IronGolem ironGolem) {
+                        if (!ironGolem.isPlayerCreated()) {
                             baseXP = ExperienceConfig.getInstance().getCombatXP(type);
                         }
                     } else {


### PR DESCRIPTION
RepairManager: Fix unsafe enchantments being stripped
CombatUtils: Use instanceof for IronGolem check to avoid cast exceptions for pets/npcs/...