### PR TITLE
Fixed a bug that caused empty buckets to burn. Fix #4940:

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/InventoryListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/InventoryListener.java
@@ -68,7 +68,7 @@ public class InventoryListener implements Listener {
                 furnaceState instanceof Furnace ? ((Furnace) furnaceState).getInventory()
                         .getSmelting() : null;
 
-        if (!ItemUtils.isSmeltable(smelting)) {
+        if (!ItemUtils.isSmeltable(smelting) || event.getBurnTime() <= 0) {
             return;
         }
 

--- a/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
@@ -34,6 +34,7 @@ public class SmeltingManager extends SkillManager {
      * @param burnTime The initial burn time from the {@link FurnaceBurnEvent}
      */
     public int fuelEfficiency(int burnTime) {
+        if (burnTime <= 0) return 0;
         return Math.min(Short.MAX_VALUE, Math.max(1, burnTime * getFuelEfficiencyMultiplier()));
     }
 


### PR DESCRIPTION
https://github.com/mcMMO-Dev/mcMMO/issues/4940
Empty buckets can be placed in the FURNACE with vanilla specifications.
An empty bucket has a burnTime of 0, but if you put 0 in the fuelEfficiency method, 1 will be returned.
If burnTime is then set to 1 by the setBurnTime method, the software will consume the empty bucket with a burnTime of 1.