### PR TITLE
fix(experience): parse diminished returns value from correct field

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/experience/ExperienceConfig.java
@@ -298,7 +298,7 @@ public class ExperienceConfig extends BukkitConfig {
 
     /* Diminished Returns */
     public float getDiminishedReturnsCap() {
-        return (float) config.getDouble("Dimished_Returns.Guaranteed_Minimum_Percentage", 0.05D);
+        return (float) config.getDouble("Diminished_Returns.Guaranteed_Minimum_Percentage", 0.05D);
     }
 
     public boolean getDiminishedReturnsEnabled() {


### PR DESCRIPTION
`ExperienceConfig` was attempting to parse the min diminished returns value from a field named `Dimished_Returns`, while the field in the config is correctly named `Diminished_Returns`. This means that, with diminished returns enabled, the config field is essentially ignored and diminished returns always use the default `0.05`.

This corrects the config to parse using the correct field name.