### PR TITLE
Add null-safety and helper methods to AbilityAPI

### DIFF
--- a/src/main/java/com/gmail/nossr50/api/AbilityAPI.java
+++ b/src/main/java/com/gmail/nossr50/api/AbilityAPI.java
@@ -12,35 +12,39 @@ public final class AbilityAPI {
     }
 
     public static boolean berserkEnabled(Player player) {
-        return UserManager.getPlayer(player).getAbilityMode(SuperAbilityType.BERSERK);
+        return hasAbilityEnabled(player, SuperAbilityType.BERSERK);
     }
 
     public static boolean gigaDrillBreakerEnabled(Player player) {
-        return UserManager.getPlayer(player).getAbilityMode(SuperAbilityType.GIGA_DRILL_BREAKER);
+        return hasAbilityEnabled(player, SuperAbilityType.GIGA_DRILL_BREAKER);
     }
 
     public static boolean greenTerraEnabled(Player player) {
-        return UserManager.getPlayer(player).getAbilityMode(SuperAbilityType.GREEN_TERRA);
+        return hasAbilityEnabled(player, SuperAbilityType.GREEN_TERRA);
     }
 
     public static boolean serratedStrikesEnabled(Player player) {
-        return UserManager.getPlayer(player).getAbilityMode(SuperAbilityType.SERRATED_STRIKES);
+        return hasAbilityEnabled(player, SuperAbilityType.SERRATED_STRIKES);
     }
 
     public static boolean skullSplitterEnabled(Player player) {
-        return UserManager.getPlayer(player).getAbilityMode(SuperAbilityType.SKULL_SPLITTER);
+        return hasAbilityEnabled(player, SuperAbilityType.SKULL_SPLITTER);
     }
 
     public static boolean superBreakerEnabled(Player player) {
-        return UserManager.getPlayer(player).getAbilityMode(SuperAbilityType.SUPER_BREAKER);
+        return hasAbilityEnabled(player, SuperAbilityType.SUPER_BREAKER);
     }
 
     public static boolean treeFellerEnabled(Player player) {
-        return UserManager.getPlayer(player).getAbilityMode(SuperAbilityType.TREE_FELLER);
+        return hasAbilityEnabled(player, SuperAbilityType.TREE_FELLER);
     }
 
     public static boolean isAnyAbilityEnabled(Player player) {
         final McMMOPlayer mmoPlayer = UserManager.getPlayer(player);
+
+        if(mmoPlayer == null) {
+            return false;
+        }
 
         for (SuperAbilityType ability : SuperAbilityType.values()) {
             if (mmoPlayer.getAbilityMode(ability)) {
@@ -51,36 +55,57 @@ public final class AbilityAPI {
         return false;
     }
 
+    private static boolean hasAbilityEnabled(Player player, SuperAbilityType ability) {
+        McMMOPlayer mmoPlayer = UserManager.getPlayer(player);
+        return mmoPlayer != null && mmoPlayer.getAbilityMode(ability);
+    }
+
     public static void resetCooldowns(Player player) {
-        UserManager.getPlayer(player).resetCooldowns();
+        McMMOPlayer mmoPlayer = UserManager.getPlayer(player);
+
+        if(mmoPlayer == null) {
+            return;
+        }
+
+        mmoPlayer.resetCooldowns();
     }
 
     public static void setBerserkCooldown(Player player, long cooldown) {
-        UserManager.getPlayer(player).setAbilityDATS(SuperAbilityType.BERSERK, cooldown);
+        setAbilityCooldown(player, SuperAbilityType.BERSERK, cooldown);
     }
 
     public static void setGigaDrillBreakerCooldown(Player player, long cooldown) {
-        UserManager.getPlayer(player).setAbilityDATS(SuperAbilityType.GIGA_DRILL_BREAKER, cooldown);
+        setAbilityCooldown(player, SuperAbilityType.GIGA_DRILL_BREAKER, cooldown);
     }
 
     public static void setGreenTerraCooldown(Player player, long cooldown) {
-        UserManager.getPlayer(player).setAbilityDATS(SuperAbilityType.GREEN_TERRA, cooldown);
+        setAbilityCooldown(player, SuperAbilityType.GREEN_TERRA, cooldown);
     }
 
     public static void setSerratedStrikesCooldown(Player player, long cooldown) {
-        UserManager.getPlayer(player).setAbilityDATS(SuperAbilityType.SERRATED_STRIKES, cooldown);
+        setAbilityCooldown(player, SuperAbilityType.SERRATED_STRIKES, cooldown);
     }
 
     public static void setSkullSplitterCooldown(Player player, long cooldown) {
-        UserManager.getPlayer(player).setAbilityDATS(SuperAbilityType.SKULL_SPLITTER, cooldown);
+        setAbilityCooldown(player, SuperAbilityType.SKULL_SPLITTER, cooldown);
     }
 
     public static void setSuperBreakerCooldown(Player player, long cooldown) {
-        UserManager.getPlayer(player).setAbilityDATS(SuperAbilityType.SUPER_BREAKER, cooldown);
+        setAbilityCooldown(player, SuperAbilityType.SUPER_BREAKER, cooldown);
     }
 
     public static void setTreeFellerCooldown(Player player, long cooldown) {
-        UserManager.getPlayer(player).setAbilityDATS(SuperAbilityType.TREE_FELLER, cooldown);
+        setAbilityCooldown(player, SuperAbilityType.TREE_FELLER, cooldown);
+    }
+
+    private static void setAbilityCooldown(Player player, SuperAbilityType ability, long cooldown) {
+        McMMOPlayer mmoPlayer = UserManager.getPlayer(player);
+
+        if(mmoPlayer == null) {
+            return;
+        }
+
+        mmoPlayer.setAbilityDATS(ability, cooldown);
     }
 
     public static boolean isBleeding(LivingEntity entity) {


### PR DESCRIPTION
While using the API, I noticed occasional NPEs from the `AbilityAPI`. While I could add null checks myself prior to calling these methods, I felt it was more the API’s responsibility to handle this safely.

# Add null-safety and helper methods to AbilityAPI

This refactor improves the `AbilityAPI` by adding null checks around `UserManager.getPlayer(player)` calls to prevent potential NPEs.

### Changes
- Centralized ability checks into `hasAbilityEnabled(Player, SuperAbilityType)`
- Centralized cooldown setters into `setAbilityCooldown(Player, SuperAbilityType, long)`
- All public methods now safely handle cases where `McMMOPlayer` is not loaded

### Why
Without these checks, calling `AbilityAPI` methods too early (e.g., right after a player joins) can result in NPEs.  
This change makes the API safer to consume for plugins without requiring additional null checks from plugin authors.
