### PR TITLE
Update ProtocolLib dependency to net.dmulloy2 namespace (deprecated repo fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,11 +236,6 @@
     </pluginRepositories>
 
     <repositories>
-        <!-- Protocol Lib Repository -->
-        <repository>
-            <id>dmulloy2-repo</id>
-            <url>https://repo.dmulloy2.net/repository/public/</url>
-        </repository>
         <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
@@ -292,7 +287,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.comphenix.protocol</groupId>
+            <groupId>net.dmulloy2</groupId>
             <artifactId>ProtocolLib</artifactId>
             <version>5.3.0</version>
             <scope>compile</scope>


### PR DESCRIPTION
Addresses deprecation noted in [ProtocolLib Issue #3528](https://github.com/dmulloy2/ProtocolLib/issues/3528).

`repo.dmulloy2.net` is deprecated causing issues with pulling dependencies when using Mcmmo as a dep or during building, With the change to Maven Central as the prefered repo for protocollib the namespace had to be changed from `com.comphenix.protocol` to `net.dmulloy2`

Due to just a dependency fix, no functional changes are being done in this PR

Thanks!
