### PR TITLE
Fix self inflicted damage awarding skill xp

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/skills/CombatUtils.java
@@ -935,7 +935,8 @@ public final class CombatUtils {
         XPGainReason xpGainReason;
 
         if (target instanceof Player defender) {
-            if (!ExperienceConfig.getInstance().getExperienceGainsPlayerVersusPlayerEnabled()
+            if (defender.equals(mmoPlayer.getPlayer())
+                    || !ExperienceConfig.getInstance().getExperienceGainsPlayerVersusPlayerEnabled()
                     ||
                     (mcMMO.p.getPartyConfig().isPartyEnabled()
                             && mcMMO.p.getPartyManager()


### PR DESCRIPTION
For ranged skills like archery, crossbows & tridents it's currently possible to hit yourself with a projectile to gain experience in the corresponding skill when not in a party.

Feel free to close if this is intended, or let me know if the formatting should change (the existing formatting seems a bit awkward, so I was not sure how to preserve the same style).