### PR TITLE
Fix leftover sync tp in taming subskill

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
@@ -304,7 +304,7 @@ public class TamingManager extends SkillManager {
 
         Player owner = getPlayer();
 
-        wolf.teleport(owner);
+        mcMMO.p.getFoliaLib().getScheduler().teleportAsync(wolf, owner.getLocation());
         NotificationManager.sendPlayerInformation(owner, NotificationType.SUBSKILL_MESSAGE,
                 "Taming.Listener.Wolf");
     }


### PR DESCRIPTION
The regular teleport method always throws on folia, this seems to be the only one that was left in the codebase.