### PR TITLE
Add spears to the `fill<Material>ToolsWhiteList()` methods

### DIFF
--- a/src/main/java/com/gmail/nossr50/util/MaterialMapStore.java
+++ b/src/main/java/com/gmail/nossr50/util/MaterialMapStore.java
@@ -673,6 +673,7 @@ public class MaterialMapStore {
         woodTools.add("wooden_hoe");
         woodTools.add("wooden_pickaxe");
         woodTools.add("wooden_shovel");
+        woodTools.add("wooden_spear");
     }
 
     private void fillStoneToolsWhiteList() {
@@ -681,6 +682,7 @@ public class MaterialMapStore {
         stoneTools.add("stone_hoe");
         stoneTools.add("stone_pickaxe");
         stoneTools.add("stone_shovel");
+        stoneTools.add("stone_spear");
     }
 
     private void fillCopperToolsWhiteList() {
@@ -689,6 +691,7 @@ public class MaterialMapStore {
         copperTools.add("copper_hoe");
         copperTools.add("copper_pickaxe");
         copperTools.add("copper_shovel");
+        copperTools.add("copper_spear");
     }
 
     private void fillIronToolsWhiteList() {
@@ -697,6 +700,7 @@ public class MaterialMapStore {
         ironTools.add("iron_hoe");
         ironTools.add("iron_pickaxe");
         ironTools.add("iron_shovel");
+        ironTools.add("iron_spear");
 
         //Used for repair, remove in 2.2
         //TODO: Remove in config update
@@ -718,6 +722,7 @@ public class MaterialMapStore {
         goldTools.add("golden_hoe");
         goldTools.add("golden_pickaxe");
         goldTools.add("golden_shovel");
+        goldTools.add("golden_spear");
     }
 
     private void fillDiamondToolsWhiteList() {
@@ -726,6 +731,7 @@ public class MaterialMapStore {
         diamondTools.add("diamond_hoe");
         diamondTools.add("diamond_pickaxe");
         diamondTools.add("diamond_shovel");
+        diamondTools.add("diamond_spear");
     }
 
     private void fillNetheriteToolsWhiteList() {
@@ -734,6 +740,7 @@ public class MaterialMapStore {
         netheriteTools.add("netherite_hoe");
         netheriteTools.add("netherite_pickaxe");
         netheriteTools.add("netherite_shovel");
+        netheriteTools.add("netherite_spear");
     }
 
     private void fillGlassBlockWhiteList() {


### PR DESCRIPTION
This will ensure that a check against a <material> spear with the `is<Material>Tool()` method will return true. I believe this will fix the issue we were seeing on our server where with the default repair and salvage configuration files we could only repair copper spears and could salvage no spears. This is because the copper spear configuration in `repair.vanilla.yml` specifies the `RepairMaterial`: https://github.com/mcMMO-Dev/mcMMO/blob/1b8897b8abb203bbe1444cb20d1b64cd2db662b2/src/main/resources/repair.vanilla.yml#L110
However, no other spears have a corresponding configuration and none of the spears specify a `SalvageMaterial` in `salvage.vanilla.yml`. This resulted in the following debugging output entries:
```log
[08:48:36 INFO]: [mcMMO] [D] mcMMO found the following materials in the Repair config that are not supported by the version of Minecraft running on this server: IRON_SPEAR, WOODEN_SPEAR, NETHERITE_SPEAR, STONE_SPEAR, DIAMOND_SPEAR, GOLDEN_SPEAR
[08:48:36 INFO]: [mcMMO] [D] mcMMO found the following materials in the Salvage config that are not supported by the version of Minecraft running on this server: IRON_SPEAR, WOODEN_SPEAR, NETHERITE_SPEAR, STONE_SPEAR, COPPER_SPEAR, DIAMOND_SPEAR, GOLDEN_SPEAR
```