### PR TITLE
Set max display of spear master to two decimals

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/skills/SpearsCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/skills/SpearsCommand.java
@@ -61,7 +61,7 @@ public class SpearsCommand extends SkillCommand {
 
         if (canUseSubskill(player, SPEARS_SPEAR_MASTERY)) {
             messages.add(getStatMessage(SPEARS_SPEAR_MASTERY,
-                    String.valueOf(spearMasteryBonusDmg)));
+                    String.format("%.2f", spearMasteryBonusDmg)));
         }
 
         if (SkillUtils.canUseSubskill(player, SPEARS_MOMENTUM)) {


### PR DESCRIPTION
Fix display of spear mastery values.  Floating point issues were causing it to show with 16 decimals at some levels.