### PR TITLE
Fix archery entity tracking failing often on Folia

### DIFF
--- a/src/main/java/com/gmail/nossr50/skills/archery/Archery.java
+++ b/src/main/java/com/gmail/nossr50/skills/archery/Archery.java
@@ -6,9 +6,10 @@ import com.gmail.nossr50.datatypes.skills.SubSkillType;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.ItemUtils;
 import com.gmail.nossr50.util.skills.RankUtils;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.bukkit.Material;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -16,7 +17,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 public class Archery {
-    private static final List<TrackedEntity> trackedEntities = new ArrayList<>();
+    private static final Map<UUID, TrackedEntity> trackedEntities = new ConcurrentHashMap<>();
 
     public static double skillShotMaxBonusDamage = mcMMO.p.getAdvancedConfig()
             .getSkillShotDamageMax();
@@ -27,25 +28,12 @@ public class Archery {
             .getArcheryDistanceMultiplier();
 
     protected static void incrementTrackerValue(LivingEntity livingEntity) {
-        for (TrackedEntity trackedEntity : trackedEntities) {
-            if (trackedEntity.getLivingEntity().getEntityId() == livingEntity.getEntityId()) {
-                trackedEntity.incrementArrowCount();
-                return;
-            }
-        }
-
-        addToTracker(livingEntity); // If the entity isn't tracked yet
-    }
-
-    protected static void addToTracker(LivingEntity livingEntity) {
-        TrackedEntity trackedEntity = new TrackedEntity(livingEntity);
-
+        final TrackedEntity trackedEntity = trackedEntities.computeIfAbsent(livingEntity.getUniqueId(), k -> new TrackedEntity(livingEntity));
         trackedEntity.incrementArrowCount();
-        trackedEntities.add(trackedEntity);
     }
 
     protected static void removeFromTracker(TrackedEntity trackedEntity) {
-        trackedEntities.remove(trackedEntity);
+        trackedEntities.remove(trackedEntity.getID());
     }
 
     /**
@@ -54,17 +42,11 @@ public class Archery {
      * @param livingEntity The entity hit by the arrows
      */
     public static void arrowRetrievalCheck(@NotNull LivingEntity livingEntity) {
-        for (Iterator<TrackedEntity> entityIterator = trackedEntities.iterator();
-                entityIterator.hasNext(); ) {
-            TrackedEntity trackedEntity = entityIterator.next();
-
-            if (trackedEntity.getID() == livingEntity.getUniqueId()) {
-                ItemUtils.spawnItems(null, livingEntity.getLocation(),
-                        new ItemStack(Material.ARROW), trackedEntity.getArrowCount(),
-                        ItemSpawnReason.ARROW_RETRIEVAL_ACTIVATED);
-                entityIterator.remove();
-                return;
-            }
+        final TrackedEntity trackedEntity = trackedEntities.remove(livingEntity.getUniqueId());
+        if (trackedEntity != null) {
+            ItemUtils.spawnItems(null, livingEntity.getLocation(),
+                    new ItemStack(Material.ARROW), trackedEntity.getArrowCount(),
+                    ItemSpawnReason.ARROW_RETRIEVAL_ACTIVATED);
         }
     }
 


### PR DESCRIPTION
The issue that this PR aims to solve is an IllegalStateException thrown by folia when getEntityId is called on an entity in a different region, this can happen whenever incrementTrackerValue is called with more than two TrackedEntity instances in the list.

I also updated the class to use a map instead of a list, since it's a simpler and more efficient way to do this.