### PR TITLE
Fix stacked Chimaera Wing item loss

### DIFF
--- a/src/main/java/com/gmail/nossr50/runnables/items/ChimaeraWingWarmup.java
+++ b/src/main/java/com/gmail/nossr50/runnables/items/ChimaeraWingWarmup.java
@@ -86,7 +86,7 @@ public class ChimaeraWingWarmup extends CancellableRunnable {
             }
         }
 
-        expendChimaeraWing(player, mcMMO.p.getGeneralConfig().getChimaeraUseCost(),
+        expendChimaeraWing(player, player.getInventory().getItemInMainHand().getAmount(),
                 player.getInventory().getItemInMainHand());
         mmoPlayer.actualizeChimeraWingLastUse();
         mmoPlayer.setTeleportCommenceLocation(null);


### PR DESCRIPTION
Before: Having more than one Chimaera Wing in the main hand and right clicking to use them deletes the entire stack.

After: It removes one Chimaera Wing from the stack as it's supposed to.