### PR TITLE
Add commands.yml-driven Bukkit command exposure

### DIFF
--- a/src/main/java/com/gmail/nossr50/commands/McmmoCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/McmmoCommand.java
@@ -4,6 +4,7 @@ import com.gmail.nossr50.commands.party.PartySubcommandType;
 import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.Permissions;
+import com.gmail.nossr50.util.commands.CommandSyntaxFormatter;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -62,16 +63,21 @@ public class McmmoCommand implements CommandExecutor {
     }
 
     private void displayGeneralCommands(CommandSender sender) {
-        sender.sendMessage(LocaleLoader.getString("Commands.Stats"));
-        sender.sendMessage(LocaleLoader.getString("Commands.SkillInfo"));
-        sender.sendMessage(LocaleLoader.getString("Commands.Leaderboards"));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.Stats")));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.SkillInfo")));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.Leaderboards")));
 
         if (Permissions.inspect(sender)) {
-            sender.sendMessage(LocaleLoader.getString("Commands.Inspect"));
+            sender.sendMessage(CommandSyntaxFormatter.transformText(
+                    LocaleLoader.getString("Commands.Inspect")));
         }
 
         if (Permissions.mcability(sender)) {
-            sender.sendMessage(LocaleLoader.getString("Commands.ToggleAbility"));
+            sender.sendMessage(CommandSyntaxFormatter.transformText(
+                    LocaleLoader.getString("Commands.ToggleAbility")));
         }
     }
 
@@ -104,19 +110,26 @@ public class McmmoCommand implements CommandExecutor {
     private void displayPartyCommands(CommandSender sender) {
         if (Permissions.party(sender)) {
             sender.sendMessage(LocaleLoader.getString("Commands.Party.Commands"));
-            sender.sendMessage(LocaleLoader.getString("Commands.Party1"));
-            sender.sendMessage(LocaleLoader.getString("Commands.Party2"));
-            sender.sendMessage(LocaleLoader.getString("Commands.Party.Quit"));
+            sender.sendMessage(CommandSyntaxFormatter.transformText(
+                    LocaleLoader.getString("Commands.Party1")));
+            sender.sendMessage(CommandSyntaxFormatter.transformText(
+                    LocaleLoader.getString("Commands.Party2")));
+            sender.sendMessage(CommandSyntaxFormatter.transformText(
+                    LocaleLoader.getString("Commands.Party.Quit")));
 
             if (Permissions.partyChat(sender)) {
-                sender.sendMessage(LocaleLoader.getString("Commands.Party.Toggle"));
+                sender.sendMessage(CommandSyntaxFormatter.transformText(
+                        LocaleLoader.getString("Commands.Party.Toggle")));
             }
 
-            sender.sendMessage(LocaleLoader.getString("Commands.Party.Invite"));
-            sender.sendMessage(LocaleLoader.getString("Commands.Party.Accept"));
+            sender.sendMessage(CommandSyntaxFormatter.transformText(
+                    LocaleLoader.getString("Commands.Party.Invite")));
+            sender.sendMessage(CommandSyntaxFormatter.transformText(
+                    LocaleLoader.getString("Commands.Party.Accept")));
 
             if (Permissions.partySubcommand(sender, PartySubcommandType.TELEPORT)) {
-                sender.sendMessage(LocaleLoader.getString("Commands.Party.Teleport"));
+                sender.sendMessage(CommandSyntaxFormatter.transformText(
+                        LocaleLoader.getString("Commands.Party.Teleport")));
             }
         }
     }

--- a/src/main/java/com/gmail/nossr50/commands/McscoreboardCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/McscoreboardCommand.java
@@ -2,6 +2,7 @@ package com.gmail.nossr50.commands;
 
 import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.mcMMO;
+import com.gmail.nossr50.util.commands.CommandSyntaxFormatter;
 import com.gmail.nossr50.util.commands.CommandUtils;
 import com.gmail.nossr50.util.scoreboards.ScoreboardManager;
 import com.google.common.collect.ImmutableList;
@@ -91,10 +92,14 @@ public class McscoreboardCommand implements TabExecutor {
     }
 
     private boolean help(CommandSender sender) {
-        sender.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Help.0"));
-        sender.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Help.1"));
-        sender.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Help.2"));
-        sender.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Help.3"));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.Scoreboard.Help.0")));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.Scoreboard.Help.1")));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.Scoreboard.Help.2")));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.Scoreboard.Help.3")));
         return true;
     }
 }

--- a/src/main/java/com/gmail/nossr50/commands/party/PartyCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/party/PartyCommand.java
@@ -6,6 +6,7 @@ import com.gmail.nossr50.datatypes.party.Party;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.util.Permissions;
+import com.gmail.nossr50.util.commands.CommandSyntaxFormatter;
 import com.gmail.nossr50.util.commands.CommandUtils;
 import com.gmail.nossr50.util.player.UserManager;
 import com.google.common.collect.ImmutableList;
@@ -252,9 +253,12 @@ public class PartyCommand implements TabExecutor {
     }
 
     private boolean printUsage(Player player) {
-        player.sendMessage(LocaleLoader.getString("Party.Help.0", "/party join"));
-        player.sendMessage(LocaleLoader.getString("Party.Help.1", "/party create"));
-        player.sendMessage(LocaleLoader.getString("Party.Help.2", "/party ?"));
+        player.sendMessage(LocaleLoader.getString("Party.Help.0",
+                CommandSyntaxFormatter.command("party", "join")));
+        player.sendMessage(LocaleLoader.getString("Party.Help.1",
+                CommandSyntaxFormatter.command("party", "create")));
+        player.sendMessage(LocaleLoader.getString("Party.Help.2",
+                CommandSyntaxFormatter.command("party", "help")));
         return true;
     }
 
@@ -268,4 +272,3 @@ public class PartyCommand implements TabExecutor {
                 "woodcutting") || category.equalsIgnoreCase("misc");
     }
 }
-

--- a/src/main/java/com/gmail/nossr50/commands/party/PartyHelpCommand.java
+++ b/src/main/java/com/gmail/nossr50/commands/party/PartyHelpCommand.java
@@ -1,6 +1,8 @@
 package com.gmail.nossr50.commands.party;
 
 import com.gmail.nossr50.locale.LocaleLoader;
+import com.gmail.nossr50.mcMMO;
+import com.gmail.nossr50.util.commands.CommandSyntaxFormatter;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -13,18 +15,35 @@ public class PartyHelpCommand implements CommandExecutor {
             @NotNull String label, String[] args) {
         if (args.length == 1) {
             sender.sendMessage(
-                    LocaleLoader.getString("Party.Help.3", "/party join", "/party quit"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.1", "/party create"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.4", "/party <lock|unlock>"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.5", "/party password"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.6", "/party kick"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.7", "/party leader"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.8", "/party disband"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.9", "/party itemshare"));
-            sender.sendMessage(LocaleLoader.getString("Party.Help.10", "/party xpshare"));
+                    LocaleLoader.getString("Party.Help.3",
+                            CommandSyntaxFormatter.command("party", "join"),
+                            CommandSyntaxFormatter.command("party", "quit")));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.1",
+                    CommandSyntaxFormatter.command("party", "create")));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.4",
+                    "/" + mcMMO.p.getCommandExposureRegistry().getDisplayRoot("party") + " <"
+                            + mcMMO.p.getCommandExposureRegistry().getPreferredDisplayToken(
+                                    "party", "lock")
+                            + "|"
+                            + mcMMO.p.getCommandExposureRegistry().getPreferredDisplayToken(
+                                    "party", "unlock")
+                            + ">"));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.5",
+                    CommandSyntaxFormatter.command("party", "password")));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.6",
+                    CommandSyntaxFormatter.command("party", "kick")));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.7",
+                    CommandSyntaxFormatter.command("party", "owner")));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.8",
+                    CommandSyntaxFormatter.command("party", "disband")));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.9",
+                    CommandSyntaxFormatter.command("party", "itemshare")));
+            sender.sendMessage(LocaleLoader.getString("Party.Help.10",
+                    CommandSyntaxFormatter.command("party", "xpshare")));
             return true;
         }
-        sender.sendMessage(LocaleLoader.getString("Commands.Usage.1", "party", "help"));
+        sender.sendMessage(CommandSyntaxFormatter.transformText(
+                LocaleLoader.getString("Commands.Usage.1", "party", "help")));
         return true;
     }
 }

--- a/src/main/java/com/gmail/nossr50/config/commands/CommandExposureConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/commands/CommandExposureConfig.java
@@ -1,0 +1,23 @@
+package com.gmail.nossr50.config.commands;
+
+import com.gmail.nossr50.config.BukkitConfig;
+import com.gmail.nossr50.util.commands.CommandExposureRegistry;
+import java.io.File;
+import org.jetbrains.annotations.NotNull;
+
+public class CommandExposureConfig extends BukkitConfig {
+    private final @NotNull CommandExposureRegistry registry;
+
+    public CommandExposureConfig(@NotNull File dataFolder) {
+        super("commands.yml", dataFolder);
+        registry = new CommandExposureRegistry(config);
+    }
+
+    @Override
+    protected void loadKeys() {
+    }
+
+    public @NotNull CommandExposureRegistry getRegistry() {
+        return registry;
+    }
+}

--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -10,6 +10,7 @@ import com.gmail.nossr50.config.HiddenConfig;
 import com.gmail.nossr50.config.RankConfig;
 import com.gmail.nossr50.config.SoundConfig;
 import com.gmail.nossr50.config.WorldBlacklist;
+import com.gmail.nossr50.config.commands.CommandExposureConfig;
 import com.gmail.nossr50.config.experience.ExperienceConfig;
 import com.gmail.nossr50.config.party.PartyConfig;
 import com.gmail.nossr50.config.skills.alchemy.PotionConfig;
@@ -60,6 +61,7 @@ import com.gmail.nossr50.util.MinecraftGameVersionFactory;
 import com.gmail.nossr50.util.blockmeta.ChunkManager;
 import com.gmail.nossr50.util.blockmeta.ChunkManagerFactory;
 import com.gmail.nossr50.util.blockmeta.UserBlockTracker;
+import com.gmail.nossr50.util.commands.CommandExposureRegistry;
 import com.gmail.nossr50.util.commands.CommandRegistrationManager;
 import com.gmail.nossr50.util.experience.FormulaManager;
 import com.gmail.nossr50.util.platform.MinecraftGameVersion;
@@ -149,6 +151,7 @@ public class mcMMO extends JavaPlugin {
     private GeneralConfig generalConfig;
     private AdvancedConfig advancedConfig;
     private PartyConfig partyConfig;
+    private CommandExposureConfig commandExposureConfig;
     private PotionConfig potionConfig;
     private CustomItemSupportConfig customItemSupportConfig;
     private EnchantmentMapper enchantmentMapper;
@@ -198,6 +201,7 @@ public class mcMMO extends JavaPlugin {
             advancedConfig = new AdvancedConfig(getDataFolder());
             partyConfig = new PartyConfig(getDataFolder());
             customItemSupportConfig = new CustomItemSupportConfig(getDataFolder());
+            commandExposureConfig = new CommandExposureConfig(getDataFolder());
 
             //Store this value so other plugins can check it
             isRetroModeEnabled = generalConfig.getIsRetroMode();
@@ -356,6 +360,10 @@ public class mcMMO extends JavaPlugin {
 
     public static MaterialMapStore getMaterialMapStore() {
         return materialMapStore;
+    }
+
+    public @NotNull CommandExposureRegistry getCommandExposureRegistry() {
+        return commandExposureConfig.getRegistry();
     }
 
     private void checkForOutdatedAPI() {

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandExposureEntry.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandExposureEntry.java
@@ -1,0 +1,27 @@
+package com.gmail.nossr50.util.commands;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+public record CommandExposureEntry(
+        boolean enabled,
+        boolean registerOriginal,
+        @NotNull List<String> aliases,
+        @NotNull Map<String, List<String>> subcommands,
+        @NotNull Map<String, List<String>> arguments,
+        @NotNull CommandTabCompleteMode tabCompleteMode
+) {
+    public static @NotNull CommandExposureEntry defaults(boolean registerOriginal,
+            @NotNull CommandTabCompleteMode tabCompleteMode) {
+        return new CommandExposureEntry(
+                true,
+                registerOriginal,
+                List.of(),
+                new LinkedHashMap<>(),
+                new LinkedHashMap<>(),
+                tabCompleteMode
+        );
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandExposureManager.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandExposureManager.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -43,7 +44,16 @@ public final class CommandExposureManager {
 
         CommandExposureRegistry registry = mcMMO.p.getCommandExposureRegistry();
         Map<String, PluginCommand> managedCommands = collectManagedCommands(registry);
+        applyConfiguredExposure(commandMap, knownCommands, registry, managedCommands,
+                mcMMO.p.getLogger(), CommandExposureManager::syncCommands);
+    }
 
+    static void applyConfiguredExposure(@NotNull CommandMap commandMap,
+            @NotNull Map<String, Command> knownCommands,
+            @NotNull CommandExposureRegistry registry,
+            @NotNull Map<String, PluginCommand> managedCommands,
+            @NotNull Logger logger,
+            @NotNull Runnable syncCommandsAction) {
         Map<String, List<String>> requestedRoots = new LinkedHashMap<>();
 
         for (Map.Entry<String, PluginCommand> entry : managedCommands.entrySet()) {
@@ -60,7 +70,7 @@ public final class CommandExposureManager {
         }
 
         Map<String, Set<String>> rejectedRoots = collectRejectedRoots(requestedRoots, managedCommands,
-                knownCommands);
+                knownCommands, logger);
 
         pruneRejectedRoots(requestedRoots, rejectedRoots);
 
@@ -79,7 +89,7 @@ public final class CommandExposureManager {
             List<String> roots = requestedRoots.get(commandId);
             String canonicalName = commandId;
             if (roots == null || roots.isEmpty()) {
-                mcMMO.p.getLogger().warning("Disabling command '" + commandId
+                logger.warning("Disabling command '" + commandId
                         + "' because commands.yml leaves it with no registered root or alias.");
                 registry.setAppliedRoots(commandId, List.of());
                 continue;
@@ -96,7 +106,7 @@ public final class CommandExposureManager {
             commandMap.register(canonicalName, command);
         }
 
-        syncCommands();
+        syncCommandsAction.run();
     }
 
     private static void applyWrappers(@NotNull String commandId, @NotNull PluginCommand command) {
@@ -146,17 +156,20 @@ public final class CommandExposureManager {
     private static @NotNull Map<String, Set<String>> collectRejectedRoots(
             @NotNull Map<String, List<String>> requestedRoots,
             @NotNull Map<String, PluginCommand> managedCommands,
-            @NotNull Map<String, Command> knownCommands) {
+            @NotNull Map<String, Command> knownCommands,
+            @NotNull Logger logger) {
         Map<String, Set<String>> rejectedRoots = new LinkedHashMap<>();
 
-        collectInternalConflicts(requestedRoots, rejectedRoots);
-        collectExternalConflicts(requestedRoots, managedCommands, knownCommands, rejectedRoots);
+        collectInternalConflicts(requestedRoots, rejectedRoots, logger);
+        collectExternalConflicts(requestedRoots, managedCommands, knownCommands, rejectedRoots,
+                logger);
 
         return rejectedRoots;
     }
 
     private static void collectInternalConflicts(@NotNull Map<String, List<String>> requestedRoots,
-            @NotNull Map<String, Set<String>> rejectedRoots) {
+            @NotNull Map<String, Set<String>> rejectedRoots,
+            @NotNull Logger logger) {
         Map<String, List<String>> rootsToCommands = new LinkedHashMap<>();
 
         for (Map.Entry<String, List<String>> entry : requestedRoots.entrySet()) {
@@ -173,7 +186,7 @@ public final class CommandExposureManager {
                             .add(entry.getKey());
                 }
 
-                mcMMO.p.getLogger().warning("Skipping conflicting alias '" + entry.getKey()
+                logger.warning("Skipping conflicting alias '" + entry.getKey()
                         + "' for "
                         + String.join(", ", entry.getValue())
                         + " because it is configured for multiple mcMMO commands.");
@@ -184,7 +197,8 @@ public final class CommandExposureManager {
     private static void collectExternalConflicts(@NotNull Map<String, List<String>> requestedRoots,
             @NotNull Map<String, PluginCommand> managedCommands,
             @NotNull Map<String, Command> knownCommands,
-            @NotNull Map<String, Set<String>> rejectedRoots) {
+            @NotNull Map<String, Set<String>> rejectedRoots,
+            @NotNull Logger logger) {
         Collection<PluginCommand> managedValues = managedCommands.values();
 
         for (Map.Entry<String, List<String>> entry : requestedRoots.entrySet()) {
@@ -198,7 +212,7 @@ public final class CommandExposureManager {
 
                 rejectedRoots.computeIfAbsent(commandId, ignored -> new LinkedHashSet<>())
                         .add(root.toLowerCase());
-                mcMMO.p.getLogger().warning("Skipping conflicting alias '" + root + "' for '"
+                logger.warning("Skipping conflicting alias '" + root + "' for '"
                         + commandId
                         + "' because it is already registered by another Bukkit command.");
             }

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandExposureManager.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandExposureManager.java
@@ -1,0 +1,329 @@
+package com.gmail.nossr50.util.commands;
+
+import com.gmail.nossr50.mcMMO;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.SimpleCommandMap;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.SimplePluginManager;
+import org.jetbrains.annotations.NotNull;
+
+public final class CommandExposureManager {
+    private CommandExposureManager() {
+    }
+
+    public static void applyConfiguredExposure() {
+        CommandMap commandMap;
+        Map<String, Command> knownCommands;
+
+        try {
+            commandMap = getCommandMap();
+            knownCommands = getKnownCommands(commandMap);
+        } catch (IllegalStateException exception) {
+            mcMMO.p.getLogger().warning("Command exposure config could not access Bukkit internals"
+                    + " on this server implementation. Falling back to legacy command registration.");
+            mcMMO.p.getLogger().warning(exception.getMessage());
+            return;
+        }
+
+        CommandExposureRegistry registry = mcMMO.p.getCommandExposureRegistry();
+        Map<String, PluginCommand> managedCommands = collectManagedCommands(registry);
+
+        Map<String, List<String>> requestedRoots = new LinkedHashMap<>();
+
+        for (Map.Entry<String, PluginCommand> entry : managedCommands.entrySet()) {
+            String commandId = entry.getKey();
+            CommandExposureEntry exposureEntry = registry.getEntry(commandId);
+
+            if (!exposureEntry.enabled()) {
+                unregister(entry.getValue(), commandMap, knownCommands);
+                registry.setAppliedRoots(commandId, List.of());
+                continue;
+            }
+
+            requestedRoots.put(commandId, computeRequestedRoots(entry.getValue(), exposureEntry));
+        }
+
+        Map<String, Set<String>> rejectedRoots = collectRejectedRoots(requestedRoots, managedCommands,
+                knownCommands);
+
+        pruneRejectedRoots(requestedRoots, rejectedRoots);
+
+        for (PluginCommand command : managedCommands.values()) {
+            unregister(command, commandMap, knownCommands);
+        }
+
+        for (Map.Entry<String, PluginCommand> entry : managedCommands.entrySet()) {
+            String commandId = entry.getKey();
+            CommandExposureEntry exposureEntry = registry.getEntry(commandId);
+            if (!exposureEntry.enabled()) {
+                continue;
+            }
+
+            PluginCommand command = entry.getValue();
+            List<String> roots = requestedRoots.get(commandId);
+            String canonicalName = commandId;
+            if (roots == null || roots.isEmpty()) {
+                mcMMO.p.getLogger().warning("Disabling command '" + commandId
+                        + "' because commands.yml leaves it with no registered root or alias.");
+                registry.setAppliedRoots(commandId, List.of());
+                continue;
+            }
+
+            applyWrappers(commandId, command);
+            command.setName(roots.get(0));
+            command.setLabel(roots.get(0));
+            command.setAliases(roots.subList(1, roots.size()));
+            if (command.getUsage() != null) {
+                command.setUsage(CommandSyntaxFormatter.transformText(command.getUsage()));
+            }
+            registry.setAppliedRoots(commandId, roots);
+            commandMap.register(canonicalName, command);
+        }
+
+        syncCommands();
+    }
+
+    private static void applyWrappers(@NotNull String commandId, @NotNull PluginCommand command) {
+        CommandExecutor originalExecutor = command.getExecutor();
+        if (originalExecutor == null) {
+            return;
+        }
+
+        TabCompleter originalTabCompleter = originalExecutor instanceof TabCompleter
+                ? (TabCompleter) originalExecutor
+                : command.getTabCompleter();
+
+        ConfiguredCommandAdapter adapter = new ConfiguredCommandAdapter(commandId, originalExecutor,
+                originalTabCompleter);
+        command.setExecutor(adapter);
+        command.setTabCompleter(adapter);
+    }
+
+    private static @NotNull Map<String, PluginCommand> collectManagedCommands(
+            @NotNull CommandExposureRegistry registry) {
+        Map<String, PluginCommand> commands = new LinkedHashMap<>();
+
+        for (String commandId : registry.getManagedCommandIds()) {
+            PluginCommand command = mcMMO.p.getCommand(commandId);
+            if (command == null || command.getExecutor() == null) {
+                continue;
+            }
+            commands.put(commandId, command);
+        }
+
+        return commands;
+    }
+
+    private static @NotNull List<String> computeRequestedRoots(@NotNull PluginCommand command,
+            @NotNull CommandExposureEntry entry) {
+        LinkedHashSet<String> roots = new LinkedHashSet<>();
+
+        if (entry.registerOriginal()) {
+            roots.add(command.getName());
+            roots.addAll(command.getAliases());
+        }
+
+        roots.addAll(entry.aliases());
+        return List.copyOf(roots);
+    }
+
+    private static @NotNull Map<String, Set<String>> collectRejectedRoots(
+            @NotNull Map<String, List<String>> requestedRoots,
+            @NotNull Map<String, PluginCommand> managedCommands,
+            @NotNull Map<String, Command> knownCommands) {
+        Map<String, Set<String>> rejectedRoots = new LinkedHashMap<>();
+
+        collectInternalConflicts(requestedRoots, rejectedRoots);
+        collectExternalConflicts(requestedRoots, managedCommands, knownCommands, rejectedRoots);
+
+        return rejectedRoots;
+    }
+
+    private static void collectInternalConflicts(@NotNull Map<String, List<String>> requestedRoots,
+            @NotNull Map<String, Set<String>> rejectedRoots) {
+        Map<String, List<String>> rootsToCommands = new LinkedHashMap<>();
+
+        for (Map.Entry<String, List<String>> entry : requestedRoots.entrySet()) {
+            for (String root : entry.getValue()) {
+                rootsToCommands.computeIfAbsent(root.toLowerCase(), ignored -> new ArrayList<>())
+                        .add(entry.getKey());
+            }
+        }
+
+        for (Map.Entry<String, List<String>> entry : rootsToCommands.entrySet()) {
+            if (entry.getValue().size() > 1) {
+                for (String commandId : entry.getValue()) {
+                    rejectedRoots.computeIfAbsent(commandId, ignored -> new LinkedHashSet<>())
+                            .add(entry.getKey());
+                }
+
+                mcMMO.p.getLogger().warning("Skipping conflicting alias '" + entry.getKey()
+                        + "' for "
+                        + String.join(", ", entry.getValue())
+                        + " because it is configured for multiple mcMMO commands.");
+            }
+        }
+    }
+
+    private static void collectExternalConflicts(@NotNull Map<String, List<String>> requestedRoots,
+            @NotNull Map<String, PluginCommand> managedCommands,
+            @NotNull Map<String, Command> knownCommands,
+            @NotNull Map<String, Set<String>> rejectedRoots) {
+        Collection<PluginCommand> managedValues = managedCommands.values();
+
+        for (Map.Entry<String, List<String>> entry : requestedRoots.entrySet()) {
+            String commandId = entry.getKey();
+
+            for (String root : entry.getValue()) {
+                Command existing = knownCommands.get(root.toLowerCase());
+                if (existing == null || managedValues.contains(existing)) {
+                    continue;
+                }
+
+                rejectedRoots.computeIfAbsent(commandId, ignored -> new LinkedHashSet<>())
+                        .add(root.toLowerCase());
+                mcMMO.p.getLogger().warning("Skipping conflicting alias '" + root + "' for '"
+                        + commandId
+                        + "' because it is already registered by another Bukkit command.");
+            }
+        }
+    }
+
+    private static void pruneRejectedRoots(@NotNull Map<String, List<String>> requestedRoots,
+            @NotNull Map<String, Set<String>> rejectedRoots) {
+        for (Map.Entry<String, List<String>> entry : requestedRoots.entrySet()) {
+            Set<String> commandRejectedRoots = rejectedRoots.getOrDefault(entry.getKey(),
+                    Collections.emptySet());
+
+            if (commandRejectedRoots.isEmpty()) {
+                continue;
+            }
+
+            List<String> filteredRoots = entry.getValue().stream()
+                    .filter(root -> !commandRejectedRoots.contains(root.toLowerCase()))
+                    .toList();
+            requestedRoots.put(entry.getKey(), filteredRoots);
+        }
+    }
+
+    private static void unregister(@NotNull PluginCommand command, @NotNull CommandMap commandMap,
+            @NotNull Map<String, Command> knownCommands) {
+        command.unregister(commandMap);
+
+        List<String> keysToRemove = new ArrayList<>();
+        for (Map.Entry<String, Command> entry : knownCommands.entrySet()) {
+            if (entry.getValue() == command) {
+                keysToRemove.add(entry.getKey());
+            }
+        }
+
+        for (String key : keysToRemove) {
+            knownCommands.remove(key);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static @NotNull Map<String, Command> getKnownCommands(@NotNull CommandMap commandMap) {
+        if (!(commandMap instanceof SimpleCommandMap simpleCommandMap)) {
+            throw new IllegalStateException("Unsupported CommandMap implementation: " + commandMap);
+        }
+
+        try {
+            Field knownCommandsField = SimpleCommandMap.class.getDeclaredField("knownCommands");
+            knownCommandsField.setAccessible(true);
+            return (Map<String, Command>) knownCommandsField.get(simpleCommandMap);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to access Bukkit known commands map.",
+                    exception);
+        }
+    }
+
+    private static @NotNull CommandMap getCommandMap() {
+        PluginManager pluginManager = Bukkit.getPluginManager();
+
+        if (!(pluginManager instanceof SimplePluginManager simplePluginManager)) {
+            throw new IllegalStateException(
+                    "Unsupported PluginManager implementation: " + pluginManager.getClass());
+        }
+
+        try {
+            Field commandMapField = SimplePluginManager.class.getDeclaredField("commandMap");
+            commandMapField.setAccessible(true);
+            return (CommandMap) commandMapField.get(simplePluginManager);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to access Bukkit command map.", exception);
+        }
+    }
+
+    private static final class ConfiguredCommandAdapter implements TabExecutor {
+        private final String commandId;
+        private final CommandExecutor delegate;
+        private final TabCompleter tabCompleter;
+
+        private ConfiguredCommandAdapter(@NotNull String commandId, @NotNull CommandExecutor delegate,
+                TabCompleter tabCompleter) {
+            this.commandId = commandId;
+            this.delegate = delegate;
+            this.tabCompleter = tabCompleter;
+        }
+
+        @Override
+        public boolean onCommand(@NotNull org.bukkit.command.CommandSender sender,
+                @NotNull Command command,
+                @NotNull String label,
+                @NotNull String[] args) {
+            String[] normalizedArgs = mcMMO.p.getCommandExposureRegistry().normalizeArguments(
+                    commandId, args);
+            return delegate.onCommand(sender, command, label, normalizedArgs);
+        }
+
+        @Override
+        public List<String> onTabComplete(@NotNull org.bukkit.command.CommandSender sender,
+                @NotNull Command command,
+                @NotNull String alias,
+                @NotNull String[] args) {
+            if (tabCompleter == null) {
+                return List.of();
+            }
+
+            String[] normalizedArgs = mcMMO.p.getCommandExposureRegistry().normalizeArguments(
+                    commandId, args);
+            List<String> completions = tabCompleter.onTabComplete(sender, command, alias,
+                    normalizedArgs);
+
+            if (completions == null) {
+                return List.of();
+            }
+
+            return mcMMO.p.getCommandExposureRegistry().transformTabCompletions(commandId,
+                    normalizedArgs, completions);
+        }
+    }
+
+    private static void syncCommands() {
+        try {
+            Method syncCommands = Bukkit.getServer().getClass().getMethod("syncCommands");
+            syncCommands.invoke(Bukkit.getServer());
+        } catch (ReflectiveOperationException exception) {
+            mcMMO.p.getLogger().warning("Command exposure config could not sync the server command"
+                    + " tree after applying commands.yml changes. Client-side command suggestions"
+                    + " may still show stale roots on this server implementation.");
+        }
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandExposureRegistry.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandExposureRegistry.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.NotNull;
 public class CommandExposureRegistry {
     private static final List<String> MANAGED_COMMAND_IDS = List.of(
             "mmoxpbar",
-            "mmocompat",
             "mmoinfo",
             "mmodebug",
             "mcability",

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandExposureRegistry.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandExposureRegistry.java
@@ -1,0 +1,482 @@
+package com.gmail.nossr50.util.commands;
+
+import com.gmail.nossr50.mcMMO;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+public class CommandExposureRegistry {
+    private static final List<String> MANAGED_COMMAND_IDS = List.of(
+            "mmoxpbar",
+            "mmocompat",
+            "mmoinfo",
+            "mmodebug",
+            "mcability",
+            "mcgod",
+            "mcchatspy",
+            "mcmmo",
+            "mcnotify",
+            "mcrefresh",
+            "mcscoreboard",
+            "xprate",
+            "mcpurge",
+            "mcremove",
+            "mmoshowdb",
+            "mcconvert",
+            "addlevels",
+            "addxp",
+            "mmoedit",
+            "skillreset",
+            "party",
+            "ptp",
+            "inspect",
+            "mccooldown",
+            "mcrank",
+            "mcstats",
+            "mctop",
+            "acrobatics",
+            "alchemy",
+            "archery",
+            "axes",
+            "crossbows",
+            "excavation",
+            "fishing",
+            "herbalism",
+            "maces",
+            "mining",
+            "repair",
+            "salvage",
+            "smelting",
+            "spears",
+            "swords",
+            "taming",
+            "tridents",
+            "unarmed",
+            "woodcutting",
+            "mcmmoreloadlocale"
+    );
+
+    private final Map<String, CommandExposureEntry> entries = new LinkedHashMap<>();
+    private final Map<String, List<String>> appliedRoots = new LinkedHashMap<>();
+
+    public CommandExposureRegistry(@NotNull YamlConfiguration config) {
+        boolean defaultRegisterOriginal = config.getBoolean(
+                "commands.defaults.registerOriginalRoot",
+                true);
+        CommandTabCompleteMode defaultMode = parseMode(
+                config.getString("commands.defaults.tabCompleteMode"),
+                "commands.defaults.tabCompleteMode");
+
+        for (String commandId : MANAGED_COMMAND_IDS) {
+            entries.put(commandId, readEntry(config, commandId, defaultRegisterOriginal,
+                    defaultMode));
+        }
+
+        logUnknownConfiguredCommands(config);
+    }
+
+    public @NotNull CommandExposureEntry getEntry(@NotNull String commandId) {
+        return entries.getOrDefault(commandId, CommandExposureEntry.defaults(true,
+                CommandTabCompleteMode.BOTH));
+    }
+
+    public @NotNull List<String> getManagedCommandIds() {
+        return MANAGED_COMMAND_IDS;
+    }
+
+    public void setAppliedRoots(@NotNull String commandId, @NotNull List<String> roots) {
+        appliedRoots.put(commandId, List.copyOf(roots));
+    }
+
+    public @NotNull String getDisplayRoot(@NotNull String commandId) {
+        List<String> roots = appliedRoots.get(commandId);
+        if (roots != null && !roots.isEmpty()) {
+            return roots.get(0);
+        }
+
+        CommandExposureEntry entry = getEntry(commandId);
+        if (!entry.aliases().isEmpty()) {
+            return entry.aliases().get(0);
+        }
+
+        return commandId;
+    }
+
+    public @NotNull String getPreferredDisplayToken(@NotNull String commandId,
+            @NotNull String canonicalToken) {
+        List<String> variants = new ArrayList<>();
+        CommandExposureEntry entry = getEntry(commandId);
+
+        variants.addAll(entry.subcommands().getOrDefault(canonicalToken, List.of()));
+        variants.addAll(entry.arguments().getOrDefault(canonicalToken, List.of()));
+
+        for (String variant : variants) {
+            if (!variant.equalsIgnoreCase(canonicalToken)) {
+                return variant;
+            }
+        }
+
+        return canonicalToken;
+    }
+
+    public @NotNull String[] normalizeArguments(@NotNull String commandId, @NotNull String[] args) {
+        if (args.length == 0) {
+            return args;
+        }
+
+        String[] normalized = Arrays.copyOf(args, args.length);
+        CommandExposureEntry entry = getEntry(commandId);
+
+        switch (commandId) {
+            case "mcmmo" -> normalizeToken(entry.subcommands(), normalized, 0);
+            case "party" -> normalizePartyArguments(entry, normalized);
+            case "ptp" -> normalizeToken(entry.arguments(), normalized, 0);
+            case "mcconvert" -> normalizeMcconvertArguments(entry, normalized);
+            case "mcscoreboard" -> normalizeToken(entry.arguments(), normalized, 0);
+            case "xprate" -> normalizeXprateArguments(entry, normalized);
+            case "mmoxpbar" -> normalizeToken(entry.arguments(), normalized, 0);
+            case "addlevels", "addxp", "mmoedit" -> normalizeExperienceArguments(entry, normalized);
+            case "skillreset" -> normalizeSkillResetArguments(entry, normalized);
+            default -> {
+            }
+        }
+
+        return normalized;
+    }
+
+    public @NotNull List<String> transformTabCompletions(@NotNull String commandId,
+            @NotNull String[] args,
+            @NotNull Collection<String> completions) {
+        CommandExposureEntry entry = getEntry(commandId);
+        Map<String, List<String>> tokenMap = getCompletionTokenMap(commandId, args);
+
+        if (tokenMap.isEmpty() || entry.tabCompleteMode() == CommandTabCompleteMode.CANONICAL) {
+            return List.copyOf(completions);
+        }
+
+        LinkedHashSet<String> transformed = new LinkedHashSet<>();
+        for (String completion : completions) {
+            String canonicalToken = findCanonical(tokenMap, completion);
+            List<String> configuredTokens = canonicalToken == null ? null : tokenMap.get(
+                    canonicalToken);
+
+            if (entry.tabCompleteMode() == CommandTabCompleteMode.BOTH || configuredTokens == null
+                    || configuredTokens.isEmpty()) {
+                transformed.add(completion);
+            }
+
+            if (configuredTokens != null) {
+                boolean addedDistinctToken = false;
+                for (String configuredToken : configuredTokens) {
+                    if (entry.tabCompleteMode() == CommandTabCompleteMode.TRANSLATED
+                            && configuredToken.equalsIgnoreCase(canonicalToken)) {
+                        continue;
+                    }
+
+                    if (!configuredToken.equalsIgnoreCase(completion)) {
+                        transformed.add(configuredToken);
+                        addedDistinctToken = true;
+                    }
+                }
+
+                if (!addedDistinctToken && entry.tabCompleteMode() == CommandTabCompleteMode.TRANSLATED) {
+                    transformed.add(completion);
+                }
+            }
+        }
+
+        return List.copyOf(transformed);
+    }
+
+    private void normalizePartyArguments(@NotNull CommandExposureEntry entry,
+            @NotNull String[] normalized) {
+        normalizeToken(entry.subcommands(), normalized, 0);
+
+        if (normalized.length < 2) {
+            return;
+        }
+
+        String subcommand = normalizeToken(normalized[0]);
+        if (Set.of("xpshare", "itemshare", "lock", "chat", "password", "teleport")
+                .contains(subcommand)) {
+            normalizeToken(entry.arguments(), normalized, 1);
+        }
+    }
+
+    private void normalizeMcconvertArguments(@NotNull CommandExposureEntry entry,
+            @NotNull String[] normalized) {
+        normalizeToken(entry.subcommands(), normalized, 0);
+
+        if (normalized.length > 1) {
+            normalizeToken(entry.arguments(), normalized, 1);
+        }
+    }
+
+    private void normalizeXprateArguments(@NotNull CommandExposureEntry entry,
+            @NotNull String[] normalized) {
+        if (normalized.length == 1) {
+            normalizeToken(entry.arguments(), normalized, 0);
+            return;
+        }
+
+        if (normalized.length > 1) {
+            normalizeToken(entry.arguments(), normalized, 1);
+        }
+    }
+
+    private void normalizeExperienceArguments(@NotNull CommandExposureEntry entry,
+            @NotNull String[] normalized) {
+        int skillIndex;
+
+        if (normalized.length == 2 || (normalized.length == 3 && isSilentToken(entry, normalized[2]))) {
+            skillIndex = 0;
+        } else if (normalized.length >= 3) {
+            skillIndex = 1;
+        } else {
+            return;
+        }
+
+        normalizeToken(entry.arguments(), normalized, skillIndex);
+
+        if (normalized.length > skillIndex + 2) {
+            normalizeToken(entry.arguments(), normalized, normalized.length - 1);
+        }
+    }
+
+    private void normalizeSkillResetArguments(@NotNull CommandExposureEntry entry,
+            @NotNull String[] normalized) {
+        int skillIndex = normalized.length == 1 ? 0 : 1;
+        normalizeToken(entry.arguments(), normalized, skillIndex);
+    }
+
+    private boolean isSilentToken(@NotNull CommandExposureEntry entry, @NotNull String token) {
+        String canonicalToken = findCanonical(entry.arguments(), token);
+        return "-s".equalsIgnoreCase(canonicalToken) || "-s".equalsIgnoreCase(token);
+    }
+
+    private @NotNull Map<String, List<String>> getCompletionTokenMap(@NotNull String commandId,
+            @NotNull String[] args) {
+        CommandExposureEntry entry = getEntry(commandId);
+
+        return switch (commandId) {
+            case "mcmmo" -> args.length == 1 ? entry.subcommands() : Map.of();
+            case "party" -> getPartyCompletionTokens(entry, args);
+            case "ptp", "mcscoreboard" -> args.length == 1 ? entry.arguments() : Map.of();
+            case "xprate" -> args.length == 1 || args.length == 2 ? entry.arguments() : Map.of();
+            case "mmoxpbar" -> args.length == 1 ? entry.arguments() : Map.of();
+            case "mcconvert" -> args.length == 1 ? entry.subcommands()
+                    : args.length == 2 ? entry.arguments() : Map.of();
+            case "addlevels", "addxp", "mmoedit" -> getExperienceCompletionTokens(args,
+                    entry.arguments());
+            case "skillreset" -> args.length == 2 ? entry.arguments() : Map.of();
+            default -> Map.of();
+        };
+    }
+
+    private @NotNull Map<String, List<String>> getExperienceCompletionTokens(@NotNull String[] args,
+            @NotNull Map<String, List<String>> tokenMap) {
+        return switch (args.length) {
+            case 2, 3, 4 -> tokenMap;
+            default -> Map.of();
+        };
+    }
+
+    private @NotNull Map<String, List<String>> getPartyCompletionTokens(
+            @NotNull CommandExposureEntry entry,
+            @NotNull String[] args) {
+        if (args.length == 1) {
+            return entry.subcommands();
+        }
+
+        if (args.length == 2) {
+            String subcommand = findCanonical(entry.subcommands(), args[0]);
+            if (subcommand == null) {
+                subcommand = normalizeToken(args[0]);
+            }
+
+            if (Set.of("xpshare", "itemshare", "lock", "chat", "password", "teleport")
+                    .contains(subcommand)) {
+                return entry.arguments();
+            }
+        }
+
+        return Map.of();
+    }
+
+    private void normalizeToken(@NotNull Map<String, List<String>> tokenMap,
+            @NotNull String[] normalized,
+            int index) {
+        if (index < 0 || index >= normalized.length) {
+            return;
+        }
+
+        String canonical = findCanonical(tokenMap, normalized[index]);
+        if (canonical != null) {
+            normalized[index] = canonical;
+        }
+    }
+
+    private @NotNull String normalizeToken(@NotNull String token) {
+        return token.toLowerCase(Locale.ENGLISH);
+    }
+
+    private String findCanonical(@NotNull Map<String, List<String>> tokenMap, @NotNull String token) {
+        String normalizedToken = normalizeToken(token);
+        for (Map.Entry<String, List<String>> entry : tokenMap.entrySet()) {
+            if (normalizeToken(entry.getKey()).equals(normalizedToken)) {
+                return entry.getKey();
+            }
+
+            for (String variant : entry.getValue()) {
+                if (normalizeToken(variant).equals(normalizedToken)) {
+                    return entry.getKey();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private @NotNull CommandExposureEntry readEntry(@NotNull YamlConfiguration config,
+            @NotNull String commandId,
+            boolean defaultRegisterOriginal,
+            @NotNull CommandTabCompleteMode defaultMode) {
+        String path = "commands." + commandId;
+
+        if (!config.isConfigurationSection(path)) {
+            return CommandExposureEntry.defaults(defaultRegisterOriginal, defaultMode);
+        }
+
+        boolean enabled = config.getBoolean(path + ".enabled", true);
+        boolean registerOriginal = config.getBoolean(path + ".registerOriginalRoot",
+                defaultRegisterOriginal);
+        String perCommandModeValue = config.getString(path + ".tabCompleteMode");
+        CommandTabCompleteMode tabCompleteMode = perCommandModeValue == null
+                ? defaultMode
+                : parseMode(perCommandModeValue, path + ".tabCompleteMode");
+
+        return new CommandExposureEntry(
+                enabled,
+                registerOriginal,
+                readTokens(config, path + ".aliases", commandId + ".aliases"),
+                readTokenSection(config.getConfigurationSection(path + ".subcommands"),
+                        commandId + ".subcommands"),
+                readTokenSection(config.getConfigurationSection(path + ".arguments"),
+                        commandId + ".arguments"),
+                tabCompleteMode
+        );
+    }
+
+    private @NotNull CommandTabCompleteMode parseMode(String value, String path) {
+        CommandTabCompleteMode mode = CommandTabCompleteMode.fromConfig(value);
+        if (value != null && !mode.name().equalsIgnoreCase(value)) {
+            mcMMO.p.getLogger().warning("Invalid tab completion mode at commands.yml path '"
+                    + path + "': " + value + ". Falling back to BOTH.");
+        }
+        return mode;
+    }
+
+    private @NotNull Map<String, List<String>> readTokenSection(ConfigurationSection section,
+            String path) {
+        Map<String, List<String>> tokens = new LinkedHashMap<>();
+        Map<String, String> reverseLookup = new LinkedHashMap<>();
+
+        if (section == null) {
+            return tokens;
+        }
+
+        for (String canonicalToken : section.getKeys(false)) {
+            List<String> values = sanitizeTokens(section.getStringList(canonicalToken),
+                    path + "." + canonicalToken);
+            List<String> acceptedValues = new ArrayList<>();
+
+            for (String value : values) {
+                String existingCanonical = reverseLookup.putIfAbsent(normalizeToken(value),
+                        canonicalToken);
+
+                if (existingCanonical != null && !existingCanonical.equalsIgnoreCase(
+                        canonicalToken)) {
+                    mcMMO.p.getLogger().warning("Ignoring conflicting token '" + value
+                            + "' in commands.yml at " + path + "." + canonicalToken
+                            + " because it is already mapped to '" + existingCanonical + "'.");
+                    continue;
+                }
+
+                acceptedValues.add(value);
+            }
+
+            if (!acceptedValues.isEmpty()) {
+                tokens.put(canonicalToken, List.copyOf(acceptedValues));
+            }
+        }
+
+        return tokens;
+    }
+
+    private @NotNull List<String> readTokens(@NotNull YamlConfiguration config, @NotNull String path,
+            @NotNull String label) {
+        return sanitizeTokens(config.getStringList(path), label);
+    }
+
+    private @NotNull List<String> sanitizeTokens(@NotNull List<String> rawTokens,
+            @NotNull String label) {
+        LinkedHashSet<String> sanitized = new LinkedHashSet<>();
+
+        for (String rawToken : rawTokens) {
+            if (rawToken == null) {
+                continue;
+            }
+
+            String token = rawToken.trim();
+            if (token.isBlank()) {
+                mcMMO.p.getLogger().warning("Ignoring blank command token in commands.yml at "
+                        + label + ".");
+                continue;
+            }
+
+            if (token.contains(" ") || token.contains("\t")) {
+                mcMMO.p.getLogger().warning("Ignoring command token with whitespace in commands.yml at "
+                        + label + ": " + token);
+                continue;
+            }
+
+            if (token.startsWith("/")) {
+                mcMMO.p.getLogger().warning("Ignoring command token with leading '/' in commands.yml at "
+                        + label + ": " + token);
+                continue;
+            }
+
+            sanitized.add(token);
+        }
+
+        return List.copyOf(sanitized);
+    }
+
+    private void logUnknownConfiguredCommands(@NotNull YamlConfiguration config) {
+        ConfigurationSection section = config.getConfigurationSection("commands");
+        if (section == null) {
+            return;
+        }
+
+        Set<String> knownSections = section.getKeys(false).stream()
+                .filter(key -> !"defaults".equalsIgnoreCase(key))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        for (String configuredCommand : knownSections) {
+            if (!MANAGED_COMMAND_IDS.contains(configuredCommand)) {
+                mcMMO.p.getLogger().warning("Ignoring unknown Bukkit command in commands.yml: "
+                        + configuredCommand);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandRegistrationManager.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandRegistrationManager.java
@@ -458,5 +458,7 @@ public final class CommandRegistrationManager {
 
         // Admin commands
         registerReloadLocaleCommand();
+
+        CommandExposureManager.applyConfiguredExposure();
     }
 }

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandSyntaxFormatter.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandSyntaxFormatter.java
@@ -1,0 +1,64 @@
+package com.gmail.nossr50.util.commands;
+
+import com.gmail.nossr50.mcMMO;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+public final class CommandSyntaxFormatter {
+    private CommandSyntaxFormatter() {
+    }
+
+    public static @NotNull String command(@NotNull String commandId, @NotNull String... tokens) {
+        StringBuilder builder = new StringBuilder("/").append(getRegistry().getDisplayRoot(
+                commandId));
+
+        for (String token : tokens) {
+            builder.append(' ').append(getRegistry().getPreferredDisplayToken(commandId, token));
+        }
+
+        return builder.toString();
+    }
+
+    public static @NotNull String transformText(@NotNull String text) {
+        String transformed = text;
+
+        for (String commandId : getRegistry().getManagedCommandIds()) {
+            String canonicalRoot = "/" + commandId;
+            String displayRoot = "/" + getRegistry().getDisplayRoot(commandId);
+
+            transformed = transformed.replace(canonicalRoot, displayRoot);
+
+            for (Map.Entry<String, String> tokenEntry : getDisplayTokens(commandId).entrySet()) {
+                transformed = transformed.replace(displayRoot + " " + tokenEntry.getKey(),
+                        displayRoot + " " + tokenEntry.getValue());
+                transformed = transformed.replace("<" + tokenEntry.getKey() + ">",
+                        "<" + tokenEntry.getValue() + ">");
+            }
+        }
+
+        return transformed;
+    }
+
+    private static @NotNull Map<String, String> getDisplayTokens(@NotNull String commandId) {
+        Map<String, String> displayTokens = new LinkedHashMap<>();
+        CommandExposureEntry entry = getRegistry().getEntry(commandId);
+
+        for (Map.Entry<String, List<String>> tokenEntry : entry.subcommands().entrySet()) {
+            displayTokens.put(tokenEntry.getKey(),
+                    getRegistry().getPreferredDisplayToken(commandId, tokenEntry.getKey()));
+        }
+
+        for (Map.Entry<String, List<String>> tokenEntry : entry.arguments().entrySet()) {
+            displayTokens.putIfAbsent(tokenEntry.getKey(),
+                    getRegistry().getPreferredDisplayToken(commandId, tokenEntry.getKey()));
+        }
+
+        return displayTokens;
+    }
+
+    private static @NotNull CommandExposureRegistry getRegistry() {
+        return mcMMO.p.getCommandExposureRegistry();
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/commands/CommandTabCompleteMode.java
+++ b/src/main/java/com/gmail/nossr50/util/commands/CommandTabCompleteMode.java
@@ -1,0 +1,21 @@
+package com.gmail.nossr50.util.commands;
+
+public enum CommandTabCompleteMode {
+    TRANSLATED,
+    BOTH,
+    CANONICAL;
+
+    public static CommandTabCompleteMode fromConfig(String value) {
+        if (value == null) {
+            return BOTH;
+        }
+
+        for (CommandTabCompleteMode mode : values()) {
+            if (mode.name().equalsIgnoreCase(value)) {
+                return mode;
+            }
+        }
+
+        return BOTH;
+    }
+}

--- a/src/main/resources/commands.yml
+++ b/src/main/resources/commands.yml
@@ -14,11 +14,6 @@ commands:
             show: []
             hide: []
 
-    mmocompat:
-        enabled: true
-        registerOriginalRoot: true
-        aliases: []
-
     mmoinfo:
         enabled: true
         registerOriginalRoot: true

--- a/src/main/resources/commands.yml
+++ b/src/main/resources/commands.yml
@@ -1,0 +1,315 @@
+commands:
+    defaults:
+        # Baseline for all commands. A command's own registerOriginalRoot value overrides this.
+        registerOriginalRoot: true
+        tabCompleteMode: both # translated | both | canonical; applies to subcommands and fixed arguments, not root command names
+
+    mmoxpbar:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            reset: []
+            disable: []
+            show: []
+            hide: []
+
+    mmocompat:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mmoinfo:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mmodebug:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcability:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcgod:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcchatspy:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcmmo:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        subcommands:
+            help: []
+
+    mcnotify:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcrefresh:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcscoreboard:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            clear: []
+            keep: []
+            time: []
+
+    xprate:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            reset: []
+            true: []
+            false: []
+
+    mcpurge:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcremove:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mmoshowdb:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcconvert:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        subcommands:
+            database: []
+            experience: []
+        arguments:
+            flatfile: []
+            sql: []
+            linear: []
+            exponential: []
+
+    addlevels:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            all: []
+            -s: []
+
+    addxp:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            all: []
+            -s: []
+
+    mmoedit:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            all: []
+            -s: []
+
+    skillreset:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            all: []
+
+    party:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        subcommands:
+            join: []
+            accept: []
+            create: []
+            help: []
+            info: []
+            quit: []
+            xpshare: []
+            itemshare: []
+            invite: []
+            kick: []
+            disband: []
+            owner: []
+            lock: []
+            unlock: []
+            password: []
+            rename: []
+            teleport: []
+            chat: []
+            alliance: []
+        arguments:
+            toggle: []
+            accept: []
+            acceptany: []
+            acceptall: []
+            on: []
+            off: []
+            clear: []
+            none: []
+            equal: []
+            random: []
+            loot: []
+            mining: []
+            herbalism: []
+            woodcutting: []
+            misc: []
+
+    ptp:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+        arguments:
+            toggle: []
+            accept: []
+            acceptany: []
+            acceptall: []
+
+    inspect:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mccooldown:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcrank:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcstats:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mctop:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    acrobatics:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    alchemy:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    archery:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    axes:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    crossbows:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    excavation:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    fishing:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    herbalism:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    maces:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mining:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    repair:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    salvage:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    smelting:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    spears:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    swords:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    taming:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    tridents:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    unarmed:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    woodcutting:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []
+
+    mcmmoreloadlocale:
+        enabled: true
+        registerOriginalRoot: true
+        aliases: []

--- a/src/test/java/com/gmail/nossr50/util/commands/CommandExposureManagerTest.java
+++ b/src/test/java/com/gmail/nossr50/util/commands/CommandExposureManagerTest.java
@@ -1,0 +1,127 @@
+package com.gmail.nossr50.util.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+class CommandExposureManagerTest {
+    @Test
+    void disabledCommandsAreUnregisteredAndNotReRegistered() {
+        CommandMap commandMap = mock(CommandMap.class);
+        Logger logger = mock(Logger.class);
+        Runnable syncCommands = mock(Runnable.class);
+        PluginCommand woodcutting = mockCommand("woodcutting");
+
+        Map<String, PluginCommand> managedCommands = Map.of("woodcutting", woodcutting);
+        Map<String, Command> knownCommands = new LinkedHashMap<>();
+        knownCommands.put("woodcutting", woodcutting);
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("commands.woodcutting.enabled", false);
+        CommandExposureRegistry registry = new CommandExposureRegistry(config);
+
+        CommandExposureManager.applyConfiguredExposure(commandMap, knownCommands, registry,
+                managedCommands, logger, syncCommands);
+
+        verify(woodcutting, atLeastOnce()).unregister(commandMap);
+        verify(commandMap, never()).register(eq("woodcutting"), any(Command.class));
+        verify(syncCommands).run();
+        assertEquals("woodcutting", registry.getDisplayRoot("woodcutting"));
+        assertTrue(knownCommands.isEmpty());
+    }
+
+    @Test
+    void customRootReplacesOriginalWhenRegisterOriginalRootIsDisabled() {
+        CommandMap commandMap = mock(CommandMap.class);
+        Logger logger = mock(Logger.class);
+        Runnable syncCommands = mock(Runnable.class);
+        PluginCommand party = mockCommand("party");
+
+        Map<String, PluginCommand> managedCommands = Map.of("party", party);
+        Map<String, Command> knownCommands = new LinkedHashMap<>();
+        knownCommands.put("party", party);
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("commands.party.registerOriginalRoot", false);
+        config.set("commands.party.aliases", List.of("grupo"));
+        CommandExposureRegistry registry = new CommandExposureRegistry(config);
+
+        CommandExposureManager.applyConfiguredExposure(commandMap, knownCommands, registry,
+                managedCommands, logger, syncCommands);
+
+        verify(party).setName("grupo");
+        verify(party).setLabel("grupo");
+        verify(party).setAliases(List.of());
+        verify(commandMap).register("party", party);
+        verify(syncCommands).run();
+        assertEquals("grupo", registry.getDisplayRoot("party"));
+        assertTrue(knownCommands.isEmpty());
+    }
+
+    @Test
+    void conflictingAliasesAreSkippedPerAliasInsteadOfDisablingBothCommands() {
+        CommandMap commandMap = mock(CommandMap.class);
+        Logger logger = mock(Logger.class);
+        Runnable syncCommands = mock(Runnable.class);
+        PluginCommand party = mockCommand("party");
+        PluginCommand ptp = mockCommand("ptp");
+
+        Map<String, PluginCommand> managedCommands = new LinkedHashMap<>();
+        managedCommands.put("party", party);
+        managedCommands.put("ptp", ptp);
+
+        Map<String, Command> knownCommands = new LinkedHashMap<>();
+        knownCommands.put("party", party);
+        knownCommands.put("ptp", ptp);
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("commands.party.registerOriginalRoot", false);
+        config.set("commands.party.aliases", List.of("shared", "grupo"));
+        config.set("commands.ptp.registerOriginalRoot", false);
+        config.set("commands.ptp.aliases", List.of("shared", "tele"));
+        CommandExposureRegistry registry = new CommandExposureRegistry(config);
+
+        CommandExposureManager.applyConfiguredExposure(commandMap, knownCommands, registry,
+                managedCommands, logger, syncCommands);
+
+        verify(party).setName("grupo");
+        verify(party).setAliases(List.of());
+        verify(ptp).setName("tele");
+        verify(ptp).setAliases(List.of());
+        verify(commandMap).register("party", party);
+        verify(commandMap).register("ptp", ptp);
+        verify(logger).warning("Skipping conflicting alias 'shared' for party, ptp because it is configured for multiple mcMMO commands.");
+        assertEquals("grupo", registry.getDisplayRoot("party"));
+        assertEquals("tele", registry.getDisplayRoot("ptp"));
+    }
+
+    private PluginCommand mockCommand(String name) {
+        PluginCommand command = mock(PluginCommand.class);
+        CommandExecutor executor = mock(CommandExecutor.class);
+
+        when(command.getName()).thenReturn(name);
+        when(command.getAliases()).thenReturn(List.of());
+        when(command.getExecutor()).thenReturn(executor);
+        when(command.getUsage()).thenReturn(null);
+
+        return command;
+    }
+}

--- a/src/test/java/com/gmail/nossr50/util/commands/CommandExposureRegistryTest.java
+++ b/src/test/java/com/gmail/nossr50/util/commands/CommandExposureRegistryTest.java
@@ -1,0 +1,57 @@
+package com.gmail.nossr50.util.commands;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.util.List;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+class CommandExposureRegistryTest {
+    @Test
+    void normalizesConfiguredPartyAliasesToCanonicalTokens() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("commands.defaults.registerOriginalRoot", true);
+        config.set("commands.defaults.tabCompleteMode", "both");
+        config.set("commands.party.subcommands.join", List.of("join", "entrar"));
+        config.set("commands.party.arguments.accept", List.of("accept", "aceitar"));
+
+        CommandExposureRegistry registry = new CommandExposureRegistry(config);
+
+        assertArrayEquals(new String[]{"join", "Steve"},
+                registry.normalizeArguments("party", new String[]{"entrar", "Steve"}));
+        assertArrayEquals(new String[]{"teleport", "accept"},
+                registry.normalizeArguments("party", new String[]{"teleport", "aceitar"}));
+    }
+
+    @Test
+    void translatedTabCompletionModePrefersConfiguredTokens() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("commands.defaults.registerOriginalRoot", true);
+        config.set("commands.defaults.tabCompleteMode", "translated");
+        config.set("commands.party.subcommands.join", List.of("join", "entrar"));
+
+        CommandExposureRegistry registry = new CommandExposureRegistry(config);
+
+        assertEquals("entrar", registry.getPreferredDisplayToken("party", "join"));
+        assertIterableEquals(List.of("entrar"),
+                registry.transformTabCompletions("party", new String[]{""}, List.of("join")));
+        assertIterableEquals(List.of("entrar"),
+                registry.transformTabCompletions("party", new String[]{""},
+                        List.of("join", "entrar")));
+    }
+
+    @Test
+    void translatedTabCompletionRetainsCanonicalWhenNoDistinctTranslationExists() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("commands.defaults.registerOriginalRoot", true);
+        config.set("commands.defaults.tabCompleteMode", "translated");
+        config.set("commands.party.subcommands.join", List.of("join"));
+
+        CommandExposureRegistry registry = new CommandExposureRegistry(config);
+
+        assertIterableEquals(List.of("join"),
+                registry.transformTabCompletions("party", new String[]{""}, List.of("join")));
+    }
+}


### PR DESCRIPTION
Adds a config-driven command exposure layer for Bukkit commands, including root aliases, command disabling, original root suppression, token normalization for translated subcommands/arguments, and matching help/tab completion behavior. Internal command handling stays canonical, conflicts are logged clearly, and the registration path now has focused tests.

I didn't touched ACF or mmocompat because i'm afraid of having my PR not merged.
I could continue cleaning that part of mcMMO if you approve my work here.

I also want tring hex in json components and making ranking position placeholders by skill and position number.