### PR TITLE
Fix potion lengths being shorter/longer for newer potion types than vanilla

### DIFF
--- a/src/main/resources/potions.yml
+++ b/src/main/resources/potions.yml
@@ -1815,7 +1815,7 @@ Potions:
         Color: 0x878787
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: ["INFESTED 0 2500"]
+        Effects: ["INFESTED 0 3600"]
         Children:
             DRAGON_BREATH: LINGERING_POTION_OF_INFESTATION
     LINGERING_POTION_OF_INFESTATION:
@@ -1824,7 +1824,7 @@ Potions:
         Color: 0x878787
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: ["INFESTED 0 3000"]
+        Effects: ["INFESTED 0 900"]
     POTION_OF_WEAVING:
         Name: Potion of Weaving
         Material: POTION
@@ -1840,7 +1840,7 @@ Potions:
         Color: 0xC7C7C7
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: ["WEAVING 0 2500"]
+        Effects: ["WEAVING 0 3600"]
         Children:
             DRAGON_BREATH: LINGERING_POTION_OF_WEAVING
     LINGERING_POTION_OF_WEAVING:
@@ -1849,7 +1849,7 @@ Potions:
         Color: 0xC7C7C7
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: ["WEAVING 0 3000"]
+        Effects: ["WEAVING 0 900"]
     POTION_OF_WIND_CHARGING:
         Name: Potion of Wind Charging
         Material: POTION
@@ -1865,7 +1865,7 @@ Potions:
         Color: 0xBDC9FF
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: [ "WIND_CHARGED 0 2500" ]
+        Effects: [ "WIND_CHARGED 0 3600" ]
         Children:
             DRAGON_BREATH: LINGERING_POTION_OF_WIND_CHARGING
     LINGERING_POTION_WIND_CHARGING:
@@ -1874,7 +1874,7 @@ Potions:
         Color: 0xBDC9FF
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: [ "WIND_CHARGED 0 3000" ]
+        Effects: [ "WIND_CHARGED 0 900" ]
     POTION_OF_OOZING:
         Name: Potion of Oozing
         Material: POTION
@@ -1890,7 +1890,7 @@ Potions:
         Color: 0x03FF00
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: ["OOZING 0 2500"]
+        Effects: ["OOZING 0 3600"]
         Children:
             DRAGON_BREATH: LINGERING_POTION_OF_OOZING
     LINGERING_POTION_OF_OOZING:
@@ -1899,4 +1899,4 @@ Potions:
         Color: 0x03FF00
         PotionData:
             PotionType: UNCRAFTABLE
-        Effects: ["OOZING 0 3000"]
+        Effects: ["OOZING 0 900"]


### PR DESCRIPTION
Corrects the default potion durations for splash/lingering oozing, weaving, infested & wind charged potions. The splash duration for these is the same length as the normal duration, and the lingering duration is only 45 seconds.