### PR TITLE
Fix custom drop compatibility with EcoEnchants and ExcellentEnchants

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -1,6 +1,7 @@
 package com.gmail.nossr50.listeners;
 
 import static com.gmail.nossr50.util.MetadataConstants.METADATA_KEY_BONUS_DROPS;
+import static com.gmail.nossr50.util.MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS;
 
 import com.gmail.nossr50.config.HiddenConfig;
 import com.gmail.nossr50.config.WorldBlacklist;
@@ -23,6 +24,7 @@ import com.gmail.nossr50.util.BlockUtils;
 import com.gmail.nossr50.util.ContainerMetadataUtils;
 import com.gmail.nossr50.util.EventUtils;
 import com.gmail.nossr50.util.ItemUtils;
+import com.gmail.nossr50.util.Misc;
 import com.gmail.nossr50.util.Permissions;
 import com.gmail.nossr50.util.player.UserManager;
 import com.gmail.nossr50.util.skills.SkillUtils;
@@ -74,13 +76,29 @@ public class BlockListener implements Listener {
         //Make sure we clean up metadata on these blocks
         final Block block = event.getBlock();
         if (event.isCancelled()) {
-            if (block.hasMetadata(METADATA_KEY_BONUS_DROPS)) {
-                block.removeMetadata(METADATA_KEY_BONUS_DROPS, plugin);
-            }
+            cleanupQueuedDropMetadata(block);
             return;
         }
 
         try {
+            final List<Item> eventItems = event.getItems();
+
+            if (!block.getMetadata(METADATA_KEY_QUEUED_BLOCK_DROPS).isEmpty()) {
+                MetadataValue queuedDropMeta = block
+                        .getMetadata(METADATA_KEY_QUEUED_BLOCK_DROPS).get(0);
+                Object queuedDrops = queuedDropMeta.value();
+
+                if (queuedDrops instanceof List<?> queuedDropList) {
+                    for (Object queuedDrop : queuedDropList) {
+                        if (!(queuedDrop instanceof ItemStack itemStack)) {
+                            continue;
+                        }
+
+                        ItemUtils.appendBlockDropEventItem(event, itemStack);
+                    }
+                }
+            }
+
             int tileEntityTolerance = 1;
 
             // beetroot hotfix, potentially other plants may need this fix
@@ -94,7 +112,6 @@ public class BlockListener implements Listener {
             boolean dontRewardTE = false; //If we suspect TEs are mixed in with other things don't reward bonus drops for anything that isn't a block
             int blockCount = 0;
 
-            final List<Item> eventItems = event.getItems();
             for (Item item : eventItems) {
                 //Track unique materials
                 uniqueMaterials.add(item.getItemStack().getType());
@@ -158,9 +175,16 @@ public class BlockListener implements Listener {
                 }
             }
         } finally {
-            if (block.hasMetadata(METADATA_KEY_BONUS_DROPS)) {
-                block.removeMetadata(METADATA_KEY_BONUS_DROPS, plugin);
-            }
+            cleanupQueuedDropMetadata(block);
+        }
+    }
+
+    private void cleanupQueuedDropMetadata(Block block) {
+        if (block.hasMetadata(METADATA_KEY_BONUS_DROPS)) {
+            block.removeMetadata(METADATA_KEY_BONUS_DROPS, plugin);
+        }
+        if (block.hasMetadata(METADATA_KEY_QUEUED_BLOCK_DROPS)) {
+            block.removeMetadata(METADATA_KEY_QUEUED_BLOCK_DROPS, plugin);
         }
     }
 
@@ -480,7 +504,7 @@ public class BlockListener implements Listener {
                 woodcuttingManager.processWoodcuttingBlockXP(block);
 
                 //Check for bonus drops
-                woodcuttingManager.processBonusDropCheck(block);
+                woodcuttingManager.processBonusDropCheck(block, true);
             }
         }
 

--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -48,6 +48,7 @@ import com.gmail.nossr50.skills.salvage.salvageables.SalvageableManager;
 import com.gmail.nossr50.skills.salvage.salvageables.SimpleSalvageableManager;
 import com.gmail.nossr50.util.ChimaeraWing;
 import com.gmail.nossr50.util.EnchantmentMapper;
+import com.gmail.nossr50.util.ItemUtils;
 import com.gmail.nossr50.util.LogFilter;
 import com.gmail.nossr50.util.LogUtils;
 import com.gmail.nossr50.util.MaterialMapStore;
@@ -207,6 +208,7 @@ public class mcMMO extends JavaPlugin {
             PluginManager pluginManager = getServer().getPluginManager();
             healthBarPluginEnabled = pluginManager.getPlugin("HealthBar") != null;
             projectKorraEnabled = pluginManager.getPlugin("ProjectKorra") != null;
+            ItemUtils.refreshCompatibilityRouting();
 
             upgradeManager = new UpgradeManager();
 

--- a/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
@@ -12,6 +12,7 @@ import com.gmail.nossr50.datatypes.skills.SubSkillType;
 import com.gmail.nossr50.datatypes.treasure.ExcavationTreasure;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.skills.SkillManager;
+import com.gmail.nossr50.util.BlockUtils;
 import com.gmail.nossr50.util.ItemUtils;
 import com.gmail.nossr50.util.Misc;
 import com.gmail.nossr50.util.Permissions;
@@ -56,7 +57,7 @@ public class ExcavationManager extends SkillManager {
                             && ProbabilityUtil.isStaticSkillRNGSuccessful(
                             PrimarySkillType.EXCAVATION, mmoPlayer,
                             treasure.getDropProbability())) {
-                        processExcavationBonusesOnBlock(treasure, centerOfBlock);
+                        processExcavationBonusesOnBlock(block, treasure, centerOfBlock);
                     }
                 }
             }
@@ -80,10 +81,19 @@ public class ExcavationManager extends SkillManager {
     @Deprecated(forRemoval = true, since = "2.2.024")
     public void processExcavationBonusesOnBlock(BlockState ignored, ExcavationTreasure treasure,
             Location location) {
-        processExcavationBonusesOnBlock(treasure, location);
+        processExcavationBonusesOnBlock(ignored.getBlock(), treasure, location);
     }
 
-    public void processExcavationBonusesOnBlock(ExcavationTreasure treasure, Location location) {
+    /**
+     * Processes a successful archaeology treasure roll for a broken block.
+     *
+     * @param block the block that triggered the archaeology reward
+     * @param treasure the treasure being awarded
+     * @param location the block center used for related reward effects
+     */
+    public void processExcavationBonusesOnBlock(@NotNull Block block,
+            @NotNull ExcavationTreasure treasure,
+            @NotNull Location location) {
         //Spawn Vanilla XP orbs if a dice roll succeeds
         if (ProbabilityUtil.isStaticSkillRNGSuccessful(
                 PrimarySkillType.EXCAVATION, mmoPlayer, getArchaelogyExperienceOrbChance())) {
@@ -92,8 +102,15 @@ public class ExcavationManager extends SkillManager {
 
         int xp = 0;
         xp += treasure.getXp();
-        ItemUtils.spawnItem(getPlayer(), location, treasure.getDrop(),
-                ItemSpawnReason.EXCAVATION_TREASURE);
+        if (ItemUtils.shouldUseDropQueueRouting() && ItemUtils.pushDropQueueIfPresent(getPlayer(),
+                location, List.of(treasure.getDrop()))) {
+            if (xp > 0) {
+                applyXpGain(xp, XPGainReason.PVE, XPGainSource.SELF);
+            }
+            return;
+        }
+
+        BlockUtils.queueBlockDrop(block, treasure.getDrop());
         if (xp > 0) {
             applyXpGain(xp, XPGainReason.PVE, XPGainSource.SELF);
         }

--- a/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingManager.java
@@ -112,28 +112,56 @@ public class WoodcuttingManager extends SkillManager {
     }
 
     public void processBonusDropCheck(@NotNull Block block) {
-        //TODO: Why isn't this using the item drop event? Potentially because of Tree Feller? This should be adjusted either way.
+        processBonusDropCheck(block, false);
+    }
+
+    /**
+     * Processes bonus drops for a block and optionally routes them through
+     * {@code BlockDropItemEvent} metadata instead of spawning them directly.
+     *
+     * @param block the block being broken
+     * @param useBlockDropEvent true to mark drops for the block drop event, false to spawn them
+     *                          immediately
+     */
+    public void processBonusDropCheck(@NotNull Block block, boolean useBlockDropEvent) {
         if (mcMMO.p.getGeneralConfig()
                 .getDoubleDropsEnabled(PrimarySkillType.WOODCUTTING, block.getType())) {
             //Mastery enabled for player
             if (Permissions.canUseSubSkill(getPlayer(), SubSkillType.WOODCUTTING_CLEAN_CUTS)) {
                 if (checkCleanCutsActivation(block.getType())) {
                     //Triple drops
-                    spawnHarvestLumberBonusDrops(block);
-                    spawnHarvestLumberBonusDrops(block);
+                    rewardHarvestLumberBonusDrops(block, useBlockDropEvent, 2);
                 } else {
                     //Harvest Lumber Check
                     if (checkHarvestLumberActivation(block.getType())) {
-                        spawnHarvestLumberBonusDrops(block);
+                        rewardHarvestLumberBonusDrops(block, useBlockDropEvent, 1);
                     }
                 }
                 //No Mastery (no Clean Cuts)
             } else if (Permissions.canUseSubSkill(getPlayer(),
                     SubSkillType.WOODCUTTING_HARVEST_LUMBER)) {
                 if (checkHarvestLumberActivation(block.getType())) {
-                    spawnHarvestLumberBonusDrops(block);
+                    rewardHarvestLumberBonusDrops(block, useBlockDropEvent, 1);
                 }
             }
+        }
+    }
+
+    private void rewardHarvestLumberBonusDrops(@NotNull Block block, boolean useBlockDropEvent,
+            int amount) {
+        if (useBlockDropEvent) {
+            if (ItemUtils.shouldUseDropQueueRouting()
+                    && ItemUtils.pushDropQueueIfPresent(getPlayer(), getBlockCenter(block),
+                    getHarvestLumberBonusDrops(block, amount))) {
+                return;
+            }
+
+            BlockUtils.markDropsAsBonus(block, amount);
+            return;
+        }
+
+        for (int i = 0; i < amount; i++) {
+            spawnHarvestLumberBonusDrops(block);
         }
     }
 
@@ -330,10 +358,10 @@ public class WoodcuttingManager extends SkillManager {
      * @param treeFellerBlocks List of blocks to be dropped
      */
     private void dropTreeFellerLootFromBlocks(@NotNull Set<Block> treeFellerBlocks) {
-        Player player = getPlayer();
+        final Player player = getPlayer();
         int xp = 0;
         int processedLogCount = 0;
-        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        final ItemStack itemStack = player.getInventory().getItemInMainHand();
 
         for (Block block : treeFellerBlocks) {
             int beforeXP = xp;
@@ -352,18 +380,14 @@ public class WoodcuttingManager extends SkillManager {
                 xp += processTreeFellerXPGains(block, processedLogCount);
 
                 //Drop displaced block
-                spawnItemsFromCollection(player, getBlockCenter(block),
-                        block.getDrops(itemStack), ItemSpawnReason.TREE_FELLER_DISPLACED_BLOCK);
+                dropTreeFellerDisplacedItems(block, player, itemStack);
 
                 //Bonus Drops / Harvest lumber checks
-                processBonusDropCheck(block);
+                processTreeFellerBonusDropCheck(block);
             } else if (BlockUtils.isNonWoodPartOfTree(block)) {
                 // 75% of the time do not drop leaf blocks
                 if (ThreadLocalRandom.current().nextInt(100) > 75) {
-                    spawnItemsFromCollection(player,
-                            getBlockCenter(block),
-                            block.getDrops(itemStack),
-                            ItemSpawnReason.TREE_FELLER_DISPLACED_BLOCK);
+                    dropTreeFellerDisplacedItems(block, player, itemStack);
                 } else if (hasUnlockedSubskill(player, SubSkillType.WOODCUTTING_KNOCK_ON_WOOD)) {
                     // if KnockOnWood is unlocked, then drop any saplings from the remaining blocks
                     ItemUtils.spawnItemsConditionally(block.getDrops(itemStack),
@@ -397,6 +421,52 @@ public class WoodcuttingManager extends SkillManager {
         }
 
         applyXpGain(xp, XPGainReason.PVE, XPGainSource.SELF);
+    }
+
+    private void dropTreeFellerDisplacedItems(@NotNull Block block, @NotNull Player player,
+            @NotNull ItemStack itemStack) {
+        final List<ItemStack> drops = List.copyOf(block.getDrops(itemStack));
+        ItemUtils.routeBlockDrops(player, block, getBlockCenter(block), drops,
+                ItemSpawnReason.TREE_FELLER_DISPLACED_BLOCK);
+    }
+
+    private void processTreeFellerBonusDropCheck(@NotNull Block block) {
+        if (!mcMMO.p.getGeneralConfig()
+                .getDoubleDropsEnabled(PrimarySkillType.WOODCUTTING, block.getType())) {
+            return;
+        }
+
+        if (Permissions.canUseSubSkill(getPlayer(), SubSkillType.WOODCUTTING_CLEAN_CUTS)) {
+            if (checkCleanCutsActivation(block.getType())) {
+                routeTreeFellerBonusDrops(block, 2);
+                return;
+            }
+
+            if (checkHarvestLumberActivation(block.getType())) {
+                routeTreeFellerBonusDrops(block, 1);
+            }
+            return;
+        }
+
+        if (Permissions.canUseSubSkill(getPlayer(), SubSkillType.WOODCUTTING_HARVEST_LUMBER)
+                && checkHarvestLumberActivation(block.getType())) {
+            routeTreeFellerBonusDrops(block, 1);
+        }
+    }
+
+    private void routeTreeFellerBonusDrops(@NotNull Block block, int amount) {
+        ItemUtils.routeBlockDrops(getPlayer(), block, getBlockCenter(block),
+                getHarvestLumberBonusDrops(block, amount), ItemSpawnReason.BONUS_DROPS);
+    }
+
+    private @NotNull List<ItemStack> getHarvestLumberBonusDrops(@NotNull Block block, int amount) {
+        final List<ItemStack> bonusDrops = new ArrayList<>();
+
+        for (int i = 0; i < amount; i++) {
+            bonusDrops.addAll(block.getDrops(getPlayer().getInventory().getItemInMainHand()));
+        }
+
+        return bonusDrops;
     }
 
     private int updateProcessedLogCount(int xp, int processedLogCount, int beforeXP) {

--- a/src/main/java/com/gmail/nossr50/util/BlockUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/BlockUtils.java
@@ -10,13 +10,18 @@ import com.gmail.nossr50.datatypes.skills.SubSkillType;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.player.UserManager;
 import com.gmail.nossr50.util.random.ProbabilityUtil;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.metadata.MetadataValue;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -122,6 +127,40 @@ public final class BlockUtils {
     public static void markDropsAsBonus(Block block, int amount) {
         block.setMetadata(MetadataConstants.METADATA_KEY_BONUS_DROPS,
                 new BonusDropMeta(amount, mcMMO.p));
+    }
+
+    /**
+     * Queues an extra item drop on a block so it can be surfaced through {@code BlockDropItemEvent}
+     * instead of being spawned independently.
+     *
+     * @param block the block whose drop event should carry the queued item
+     * @param itemStack the item to queue for the block drop event
+     */
+    public static void queueBlockDrop(@NotNull Block block, @NotNull ItemStack itemStack) {
+        if (!block.hasMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS)) {
+            block.setMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS,
+                    new FixedMetadataValue(mcMMO.p, List.of(itemStack.clone())));
+            return;
+        }
+
+        MetadataValue metadataValue = block
+                .getMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS).get(0);
+        Object metadata = metadataValue.value();
+        List<ItemStack> queuedDrops = new ArrayList<>(2);
+
+        if (metadata instanceof List<?> queuedMetadata) {
+            queuedDrops = new ArrayList<>(queuedMetadata.size() + 1);
+
+            for (Object queuedDrop : queuedMetadata) {
+                if (queuedDrop instanceof ItemStack queuedItemStack) {
+                    queuedDrops.add(queuedItemStack.clone());
+                }
+            }
+        }
+
+        queuedDrops.add(itemStack.clone());
+        block.setMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS,
+                new FixedMetadataValue(mcMMO.p, queuedDrops));
     }
 
     /**

--- a/src/main/java/com/gmail/nossr50/util/ItemUtils.java
+++ b/src/main/java/com/gmail/nossr50/util/ItemUtils.java
@@ -13,6 +13,7 @@ import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.skills.smelting.Smelting;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -23,9 +24,12 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -38,11 +42,26 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class ItemUtils {
+    private static final String ECO_ENCHANTS_PLUGIN_NAME = "EcoEnchants";
+    private static final String EXCELLENT_ENCHANTS_PLUGIN_NAME = "ExcellentEnchants";
+    private static volatile boolean compatibilityRoutingInitialized;
+    private static volatile boolean useDropQueueRouting;
+    private static volatile boolean useSyntheticBlockDropRouting;
     // Use custom name if available
     private static final Method customName;
+    private static final Method dropQueueApiGet;
+    private static final Method dropQueueApiCreateQueue;
+    private static final Method dropQueueSetLocation;
+    private static final Method dropQueueAddItems;
+    private static final Method dropQueuePush;
 
     static {
         customName = getCustomNameMethod();
+        dropQueueApiGet = getDropQueueApiGetMethod();
+        dropQueueApiCreateQueue = getDropQueueApiCreateQueueMethod();
+        dropQueueSetLocation = getDropQueueMethod("setLocation", Location.class);
+        dropQueueAddItems = getDropQueueMethod("addItems", Collection.class);
+        dropQueuePush = getDropQueueMethod("push");
     }
 
     private ItemUtils() {
@@ -53,6 +72,32 @@ public final class ItemUtils {
         try {
             return ItemMeta.class.getMethod("customName", Component.class);
         } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    private static Method getDropQueueApiGetMethod() {
+        try {
+            return Class.forName("com.willfp.eco.core.Eco").getMethod("get");
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    private static Method getDropQueueApiCreateQueueMethod() {
+        try {
+            return Class.forName("com.willfp.eco.core.Eco").getMethod("createDropQueue",
+                    Player.class);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    private static Method getDropQueueMethod(String methodName, Class<?>... parameterTypes) {
+        try {
+            return Class.forName("com.willfp.eco.core.drops.DropQueue").getMethod(methodName,
+                    parameterTypes);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
             return null;
         }
     }
@@ -71,12 +116,181 @@ public final class ItemUtils {
         }
     }
 
+    /**
+     * Pushes item drops through an optional external DropQueue API when it is present.
+     *
+     * @param player the player associated with the drop
+     * @param location the location the queue should use for non-telekinetic drops
+     * @param itemStacks the items to push through the optional drop queue
+     * @return true if the queue handled the drops, false if it is unavailable or reflection failed
+     */
+    public static boolean pushDropQueueIfPresent(@NotNull Player player, @NotNull Location location,
+            @NotNull Collection<ItemStack> itemStacks) {
+        if (dropQueueApiGet == null || dropQueueApiCreateQueue == null || dropQueueSetLocation == null
+                || dropQueueAddItems == null || dropQueuePush == null
+                || itemStacks.isEmpty()) {
+            return false;
+        }
+
+        try {
+            Object dropQueueApi = dropQueueApiGet.invoke(null);
+            Object dropQueue = dropQueueApiCreateQueue.invoke(dropQueueApi, player);
+            dropQueueSetLocation.invoke(dropQueue, location);
+            dropQueueAddItems.invoke(dropQueue, itemStacks);
+            dropQueuePush.invoke(dropQueue);
+            return true;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            mcMMO.p.getLogger().warning("Failed to route drops through optional DropQueue API: "
+                    + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Refreshes cached compatibility routing flags for optional enchant plugins.
+     */
+    public static void refreshCompatibilityRouting() {
+        useDropQueueRouting = hasPluginEnabled(ECO_ENCHANTS_PLUGIN_NAME);
+        useSyntheticBlockDropRouting = hasPluginEnabled(EXCELLENT_ENCHANTS_PLUGIN_NAME);
+        compatibilityRoutingInitialized = true;
+    }
+
+    /**
+     * Clears cached compatibility routing flags.
+     */
+    static void clearCompatibilityRoutingCache() {
+        compatibilityRoutingInitialized = false;
+        useDropQueueRouting = false;
+        useSyntheticBlockDropRouting = false;
+    }
+
+    /**
+     * @return true if a queue-oriented enchant plugin is active and mcMMO should prefer its queue API
+     */
+    public static boolean shouldUseDropQueueRouting() {
+        initializeCompatibilityRoutingIfNeeded();
+        return useDropQueueRouting;
+    }
+
+    /**
+     * @return true if a block-drop-oriented enchant plugin is active and mcMMO should prefer a
+     * synthetic {@link BlockDropItemEvent}
+     */
+    public static boolean shouldUseSyntheticBlockDropRouting() {
+        initializeCompatibilityRoutingIfNeeded();
+        return useSyntheticBlockDropRouting;
+    }
+
+    /**
+     * Routes manually generated block drops through the most compatible path available.
+     *
+     * @param player the player associated with the drops
+     * @param block the block that conceptually produced the drops
+     * @param location the drop location used for world-spawn fallback behavior
+     * @param itemStacks the drops to route
+     * @param itemSpawnReason the mcMMO spawn reason to use when entities must be created
+     */
+    public static void routeBlockDrops(@NotNull Player player,
+            @NotNull Block block,
+            @NotNull Location location,
+            @NotNull Collection<ItemStack> itemStacks,
+            @NotNull ItemSpawnReason itemSpawnReason) {
+        if (itemStacks.isEmpty()) {
+            return;
+        }
+
+        if (shouldUseSyntheticBlockDropRouting()
+                && dispatchSyntheticBlockDropEvent(player, block, location, itemStacks,
+                itemSpawnReason)) {
+            return;
+        }
+
+        if (shouldUseDropQueueRouting() && pushDropQueueIfPresent(player, location, itemStacks)) {
+            return;
+        }
+
+        spawnItemsFromCollection(player, location, itemStacks, itemSpawnReason);
+    }
+
+    /**
+     * Appends an unspawned item carrier to a block drop event.
+     *
+     * @param event the block drop event receiving the additional drop
+     * @param itemStack the item to expose through the event
+     * @return true if the carrier item was added to the event
+     */
+    public static boolean appendBlockDropEventItem(@NotNull BlockDropItemEvent event,
+            @NotNull ItemStack itemStack) {
+        if (itemStack.getType() == Material.AIR) {
+            return false;
+        }
+
+        final Location blockLocation = event.getBlock().getLocation();
+
+        if (blockLocation.getWorld() == null) {
+            return false;
+        }
+
+        final Item eventItem = (Item) blockLocation.getWorld().createEntity(blockLocation,
+                Item.class);
+        eventItem.setItemStack(itemStack);
+        event.getItems().add(eventItem);
+        return true;
+    }
+
     private static void setItemNameModern(ItemMeta itemMeta, Component name) {
         try {
             customName.invoke(itemMeta, name);
         } catch (IllegalAccessException | InvocationTargetException e) {
             mcMMO.p.getLogger().severe("Failed to set item name: " + e.getMessage());
             throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean dispatchSyntheticBlockDropEvent(@NotNull Player player,
+            @NotNull Block block,
+            @NotNull Location location,
+            @NotNull Collection<ItemStack> itemStacks,
+            @NotNull ItemSpawnReason itemSpawnReason) {
+        final BlockState blockState = block.getState();
+        final BlockDropItemEvent event = new BlockDropItemEvent(block, blockState, player,
+                new ArrayList<>(itemStacks.size()));
+        boolean appendedAnyDrops = false;
+
+        for (ItemStack itemStack : itemStacks) {
+            appendedAnyDrops |= appendBlockDropEventItem(event, itemStack);
+        }
+
+        if (!appendedAnyDrops) {
+            return false;
+        }
+
+        mcMMO.p.getServer().getPluginManager().callEvent(event);
+
+        if (event.isCancelled()) {
+            return true;
+        }
+
+        for (Item eventItem : event.getItems()) {
+            spawnItem(player, location, eventItem.getItemStack(), itemSpawnReason);
+        }
+
+        return true;
+    }
+
+    private static boolean hasPluginEnabled(@NotNull String pluginName) {
+        return mcMMO.p.getServer().getPluginManager().isPluginEnabled(pluginName);
+    }
+
+    private static void initializeCompatibilityRoutingIfNeeded() {
+        if (compatibilityRoutingInitialized) {
+            return;
+        }
+
+        synchronized (ItemUtils.class) {
+            if (!compatibilityRoutingInitialized) {
+                refreshCompatibilityRouting();
+            }
         }
     }
 

--- a/src/main/java/com/gmail/nossr50/util/MetadataConstants.java
+++ b/src/main/java/com/gmail/nossr50/util/MetadataConstants.java
@@ -47,6 +47,7 @@ public class MetadataConstants {
     public static final @NotNull String METADATA_KEY_BOW_FORCE = "mcMMO: Bow Force";
     public static final @NotNull String METADATA_KEY_ARROW_DISTANCE = "mcMMO: Arrow Distance";
     public static final @NotNull String METADATA_KEY_BONUS_DROPS = "mcMMO: Double Drops";
+    public static final @NotNull String METADATA_KEY_QUEUED_BLOCK_DROPS = "mcMMO: Queued Block Drops";
     public static final @NotNull String METADATA_KEY_DISARMED_ITEM = "mcMMO: Disarmed Item";
     public static final @NotNull String METADATA_KEY_PLAYER_DATA = "mcMMO: Player Data";
     public static final @NotNull String METADATA_KEY_DATABASE_COMMAND = "mcMMO: Processing Database Command";

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,7 +14,7 @@ author: nossr50
 authors: [ GJ, NuclearW, bm01, Glitchfinder, TfT_02, t00thpick1, Riking, electronicboy, kashike ]
 website: https://www.mcmmo.org
 main: com.gmail.nossr50.mcMMO
-softdepend: [ WorldGuard, CombatTag, HealthBar, PlaceholderAPI, ProtocolLib ]
+softdepend: [ WorldGuard, CombatTag, HealthBar, PlaceholderAPI, ProtocolLib, EcoEnchants, ExcellentEnchants ]
 load: POSTWORLD
 folia-supported: true
 api-version: 1.13

--- a/src/test/java/com/gmail/nossr50/listeners/BlockListenerTest.java
+++ b/src/test/java/com/gmail/nossr50/listeners/BlockListenerTest.java
@@ -1,0 +1,82 @@
+package com.gmail.nossr50.listeners;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gmail.nossr50.MMOTestEnvironment;
+import com.gmail.nossr50.api.ItemSpawnReason;
+import com.gmail.nossr50.api.exceptions.InvalidSkillException;
+import com.gmail.nossr50.mcMMO;
+import com.gmail.nossr50.util.ItemUtils;
+import com.gmail.nossr50.util.MetadataConstants;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Item;
+import org.bukkit.event.block.BlockDropItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class BlockListenerTest extends MMOTestEnvironment {
+    private static final Logger logger = Logger.getLogger(BlockListenerTest.class.getName());
+
+    @BeforeEach
+    void setUp() throws InvalidSkillException {
+        mockBaseEnvironment(logger);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanUpStaticMocks();
+    }
+
+    @Test
+    void queuedDropsShouldBeAddedToBlockDropEventAndMetadataRemoved() {
+        Block block = mock(Block.class);
+        BlockState blockState = mock(BlockState.class);
+        BlockDropItemEvent event = mock(BlockDropItemEvent.class);
+        ItemStack queuedDrop = new ItemStack(Material.CAKE);
+        Item queuedItemEntity = mock(Item.class);
+        List<Item> eventItems = new ArrayList<>();
+
+        when(event.isCancelled()).thenReturn(false);
+        when(event.getBlock()).thenReturn(block);
+        when(event.getBlockState()).thenReturn(blockState);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getItems()).thenReturn(eventItems);
+        when(block.getType()).thenReturn(Material.SAND);
+        when(block.getMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS)).thenReturn(
+                List.of(new FixedMetadataValue(mcMMO.p, List.of(queuedDrop))));
+        when(block.getMetadata(MetadataConstants.METADATA_KEY_BONUS_DROPS)).thenReturn(List.of());
+        when(block.hasMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS)).thenReturn(
+                true);
+        when(block.hasMetadata(MetadataConstants.METADATA_KEY_BONUS_DROPS)).thenReturn(false);
+        when(queuedItemEntity.getItemStack()).thenReturn(queuedDrop);
+
+        try (MockedStatic<ItemUtils> mockedItemUtils = org.mockito.Mockito.mockStatic(
+                ItemUtils.class)) {
+            mockedItemUtils.when(() -> ItemUtils.appendBlockDropEventItem(eq(event), eq(queuedDrop)))
+                    .thenAnswer(invocation -> {
+                        eventItems.add(queuedItemEntity);
+                        return true;
+                    });
+
+            new BlockListener(mcMMO.p).onBlockDropItemEvent(event);
+        }
+
+        assertSame(queuedItemEntity, eventItems.get(0));
+        verify(block).removeMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS, mcMMO.p);
+        verify(queuedItemEntity, never()).remove();
+    }
+}

--- a/src/test/java/com/gmail/nossr50/skills/excavation/ExcavationTest.java
+++ b/src/test/java/com/gmail/nossr50/skills/excavation/ExcavationTest.java
@@ -13,6 +13,8 @@ import com.gmail.nossr50.api.exceptions.InvalidSkillException;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.datatypes.skills.SubSkillType;
 import com.gmail.nossr50.datatypes.treasure.ExcavationTreasure;
+import com.gmail.nossr50.util.ItemUtils;
+import com.gmail.nossr50.util.MetadataConstants;
 import com.gmail.nossr50.util.skills.RankUtils;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,10 +23,14 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.bukkit.metadata.FixedMetadataValue;
 
 class ExcavationTest extends MMOTestEnvironment {
     private static final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(
@@ -78,7 +84,7 @@ class ExcavationTest extends MMOTestEnvironment {
 
         // verify ExcavationManager.processExcavationBonusesOnBlock was called
         verify(excavationManager, atLeastOnce()).processExcavationBonusesOnBlock(
-                any(ExcavationTreasure.class), any(Location.class));
+                eq(block), any(ExcavationTreasure.class), any(Location.class));
     }
 
     @Test
@@ -96,8 +102,54 @@ class ExcavationTest extends MMOTestEnvironment {
 
         // verify ExcavationManager.processExcavationBonusesOnBlock was called
         verify(excavationManager, never()).processExcavationBonusesOnBlock(
+                eq(block),
                 any(ExcavationTreasure.class),
                 any(Location.class));
+    }
+
+    @Test
+    void excavationBonusesShouldQueueTreasureOnBlockMetadata() {
+        Block block = Mockito.mock(Block.class);
+        when(block.hasMetadata(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS)).thenReturn(
+                false);
+        ExcavationTreasure treasure = new ExcavationTreasure(new ItemStack(Material.CAKE), 1, 100,
+                1);
+        ExcavationManager excavationManager = new ExcavationManager(mmoPlayer);
+        Location location = new Location(world, 0, 0, 0);
+
+        excavationManager.processExcavationBonusesOnBlock(block, treasure, location);
+
+        ArgumentCaptor<FixedMetadataValue> metadataCaptor = ArgumentCaptor.forClass(
+                FixedMetadataValue.class);
+        verify(block).setMetadata(eq(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS),
+                metadataCaptor.capture());
+
+        Object metadataValue = metadataCaptor.getValue().value();
+        Assertions.assertInstanceOf(List.class, metadataValue);
+        @SuppressWarnings("unchecked")
+        List<ItemStack> queuedDrops = (List<ItemStack>) metadataValue;
+        org.junit.jupiter.api.Assertions.assertEquals(1, queuedDrops.size());
+        org.junit.jupiter.api.Assertions.assertEquals(Material.CAKE, queuedDrops.get(0).getType());
+    }
+
+    @Test
+    void excavationBonusesShouldUseEcoDropQueueWhenAvailable() {
+        Block block = Mockito.mock(Block.class);
+        ExcavationTreasure treasure = new ExcavationTreasure(new ItemStack(Material.CAKE), 1, 100,
+                1);
+        ExcavationManager excavationManager = new ExcavationManager(mmoPlayer);
+        Location location = new Location(world, 0, 0, 0);
+
+        try (MockedStatic<ItemUtils> mockedItemUtils = Mockito.mockStatic(ItemUtils.class)) {
+            mockedItemUtils.when(ItemUtils::shouldUseDropQueueRouting).thenReturn(true);
+            mockedItemUtils.when(() -> ItemUtils.pushDropQueueIfPresent(any(), any(), any()))
+                    .thenReturn(true);
+
+            excavationManager.processExcavationBonusesOnBlock(block, treasure, location);
+        }
+
+        verify(block, never()).setMetadata(eq(MetadataConstants.METADATA_KEY_QUEUED_BLOCK_DROPS),
+                any());
     }
 
     private List<ExcavationTreasure> getGuaranteedTreasureDrops() {

--- a/src/test/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingTest.java
+++ b/src/test/java/com/gmail/nossr50/skills/woodcutting/WoodcuttingTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
@@ -17,8 +18,10 @@ import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.datatypes.skills.SubSkillType;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.BlockUtils;
+import com.gmail.nossr50.util.ItemUtils;
 import com.gmail.nossr50.util.skills.RankUtils;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -111,6 +114,46 @@ class WoodcuttingTest extends MMOTestEnvironment {
 
         // verify bonus drops were not spawned
         Mockito.verify(woodcuttingManager, Mockito.times(0)).spawnHarvestLumberBonusDrops(block);
+    }
+
+    @Test
+    void blockDropEventRoutingShouldMarkBonusMetadataInsteadOfSpawningDrops() {
+        mmoPlayer.modifySkill(PrimarySkillType.WOODCUTTING, 1000);
+        Mockito.when(advancedConfig.getMaximumProbability(SubSkillType.WOODCUTTING_CLEAN_CUTS))
+                .thenReturn(0D);
+
+        Block block = mock(Block.class);
+        Mockito.when(block.getType()).thenReturn(Material.OAK_LOG);
+
+        try (MockedStatic<BlockUtils> mockedBlockUtils = mockStatic(BlockUtils.class)) {
+            woodcuttingManager.processBonusDropCheck(block, true);
+
+            mockedBlockUtils.verify(() -> BlockUtils.markDropsAsBonus(block, 1));
+            Mockito.verify(woodcuttingManager, never()).spawnHarvestLumberBonusDrops(block);
+        }
+    }
+
+    @Test
+    void ecoDropQueueRoutingShouldBypassBonusMetadata() {
+        mmoPlayer.modifySkill(PrimarySkillType.WOODCUTTING, 1000);
+        Mockito.when(advancedConfig.getMaximumProbability(SubSkillType.WOODCUTTING_CLEAN_CUTS))
+                .thenReturn(0D);
+
+        Block block = mock(Block.class);
+        Mockito.when(block.getType()).thenReturn(Material.OAK_LOG);
+        Mockito.when(block.getDrops(any())).thenReturn(List.of(new ItemStack(Material.OAK_LOG)));
+
+        try (MockedStatic<BlockUtils> mockedBlockUtils = mockStatic(BlockUtils.class);
+                MockedStatic<ItemUtils> mockedItemUtils = mockStatic(ItemUtils.class)) {
+            mockedItemUtils.when(ItemUtils::shouldUseDropQueueRouting).thenReturn(true);
+            mockedItemUtils.when(() -> ItemUtils.pushDropQueueIfPresent(eq(player), any(),
+                    any())).thenReturn(true);
+
+            woodcuttingManager.processBonusDropCheck(block, true);
+
+            mockedBlockUtils.verifyNoInteractions();
+            Mockito.verify(woodcuttingManager, never()).spawnHarvestLumberBonusDrops(block);
+        }
     }
 
     @Test
@@ -229,6 +272,24 @@ class WoodcuttingTest extends MMOTestEnvironment {
                 "treeFellerReachedThreshold should remain false");
 
         mockedBlockUtils.close();
+    }
+
+    @Test
+    void treeFellerShouldRouteDisplacedDropsThroughCompatibilityRouter() throws Exception {
+        Block block = mock(Block.class);
+        Mockito.when(block.getType()).thenReturn(Material.OAK_LOG);
+        Mockito.when(block.getDrops(any())).thenReturn(List.of(new ItemStack(Material.OAK_LOG)));
+
+        Method method = WoodcuttingManager.class.getDeclaredMethod("dropTreeFellerDisplacedItems",
+                Block.class, Player.class, ItemStack.class);
+        method.setAccessible(true);
+
+        try (MockedStatic<ItemUtils> mockedItemUtils = mockStatic(ItemUtils.class)) {
+            method.invoke(woodcuttingManager, block, player, itemInMainHand);
+
+            mockedItemUtils.verify(() -> ItemUtils.routeBlockDrops(eq(player), eq(block), any(),
+                    any(), eq(com.gmail.nossr50.api.ItemSpawnReason.TREE_FELLER_DISPLACED_BLOCK)));
+        }
     }
 
 }

--- a/src/test/java/com/gmail/nossr50/util/ItemUtilsTest.java
+++ b/src/test/java/com/gmail/nossr50/util/ItemUtilsTest.java
@@ -4,17 +4,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.gmail.nossr50.MMOTestEnvironment;
+import com.gmail.nossr50.api.ItemSpawnReason;
 import com.gmail.nossr50.api.exceptions.InvalidSkillException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import org.bukkit.Material;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Item;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +37,7 @@ class ItemUtilsTest extends MMOTestEnvironment {
     @BeforeEach
     void setUp() throws InvalidSkillException {
         mockBaseEnvironment(logger);
+        ItemUtils.clearCompatibilityRoutingCache();
     }
 
     @AfterEach
@@ -67,6 +79,94 @@ class ItemUtilsTest extends MMOTestEnvironment {
         assertNull(storageContents.get()[0],
                 "Material-based removal should consume the renamed seed from storage.");
         verify(playerInventory, never()).removeItem(any(ItemStack.class));
+    }
+
+    @Test
+    void routeBlockDropsShouldRemoveItemsConsumedBySyntheticBlockDropEvent() {
+        final Block block = mock(Block.class);
+        final BlockState blockState = mock(BlockState.class);
+        final Location location = new Location(world, 1.0, 2.0, 3.0);
+        final Item keptItem = mock(Item.class);
+        final Item telekinizedItem = mock(Item.class);
+        final Location blockLocation = new Location(world, 10.0, 64.0, 10.0);
+
+        when(block.getState()).thenReturn(blockState);
+        when(block.getLocation()).thenReturn(blockLocation);
+        when(pluginManager.isPluginEnabled("ExcellentEnchants")).thenReturn(true);
+        when(pluginManager.isPluginEnabled("EcoEnchants")).thenReturn(true);
+        when(world.createEntity(eq(blockLocation), eq(Item.class))).thenReturn(keptItem,
+                telekinizedItem);
+        when(keptItem.getItemStack()).thenReturn(new ItemStack(Material.OAK_LOG));
+        when(telekinizedItem.getItemStack()).thenReturn(new ItemStack(Material.STICK));
+        doAnswer(invocation -> {
+            final Event event = invocation.getArgument(0);
+
+            if (event instanceof BlockDropItemEvent blockDropItemEvent) {
+                blockDropItemEvent.getItems().remove(telekinizedItem);
+            }
+
+            return event;
+        }).when(pluginManager).callEvent(any(Event.class));
+
+        ItemUtils.routeBlockDrops(player, block, location,
+                List.of(new ItemStack(Material.OAK_LOG), new ItemStack(Material.STICK)),
+                ItemSpawnReason.TREE_FELLER_DISPLACED_BLOCK);
+
+        verify(world, times(1)).dropItem(eq(location), any(ItemStack.class));
+    }
+
+    @Test
+    void routeBlockDropsShouldNotSpawnItemsWhenSyntheticBlockDropEventIsCancelled() {
+        final Block block = mock(Block.class);
+        final BlockState blockState = mock(BlockState.class);
+        final Location location = new Location(world, 4.0, 5.0, 6.0);
+        final Item firstItem = mock(Item.class);
+        final Item secondItem = mock(Item.class);
+        final Location blockLocation = new Location(world, 11.0, 64.0, 11.0);
+
+        when(block.getState()).thenReturn(blockState);
+        when(block.getLocation()).thenReturn(blockLocation);
+        when(pluginManager.isPluginEnabled("ExcellentEnchants")).thenReturn(true);
+        when(world.createEntity(eq(blockLocation), eq(Item.class))).thenReturn(firstItem,
+                secondItem);
+        doAnswer(invocation -> {
+            final Event event = invocation.getArgument(0);
+
+            if (event instanceof BlockDropItemEvent blockDropItemEvent) {
+                blockDropItemEvent.setCancelled(true);
+            }
+
+            return event;
+        }).when(pluginManager).callEvent(any(Event.class));
+
+        ItemUtils.routeBlockDrops(player, block, location,
+                List.of(new ItemStack(Material.OAK_LOG), new ItemStack(Material.STICK)),
+                ItemSpawnReason.TREE_FELLER_DISPLACED_BLOCK);
+
+        verify(world, never()).dropItem(eq(location), any(ItemStack.class));
+    }
+
+    @Test
+    void routeBlockDropsShouldSkipSyntheticBlockDropEventWithoutCompatibilityPlugins() {
+        final Block block = mock(Block.class);
+        final Location location = new Location(world, 7.0, 8.0, 9.0);
+        final AtomicBoolean sawSyntheticBlockDropEvent = new AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            final Event event = invocation.getArgument(0);
+
+            if (event instanceof BlockDropItemEvent) {
+                sawSyntheticBlockDropEvent.set(true);
+            }
+
+            return event;
+        }).when(pluginManager).callEvent(any(Event.class));
+
+        ItemUtils.routeBlockDrops(player, block, location,
+                List.of(new ItemStack(Material.OAK_LOG)), ItemSpawnReason.TREE_FELLER_DISPLACED_BLOCK);
+
+        assertFalse(sawSyntheticBlockDropEvent.get(),
+                "Synthetic BlockDropItemEvent routing should only run for supported compatibility plugins.");
     }
 
     private ItemStack createRenamedSeedStack() {


### PR DESCRIPTION
Tries to fix https://github.com/mcMMO-Dev/mcMMO/issues/5279 by having mcmmo to look for ExcellentEnchants and EcoEnchants. This should improve other plugins behavior with mcmmo too...

EcoEnchants has it's own drop queue and ExcellentEnchants listens to drop events, so i had to comply with both cases. 

I'm not familiar with the rules for explicitly targetting other plugins, i added both to plugin.yml's softdepend field.