### PR TITLE
Add option to toggle receiving conflicting enchants from magic hunter

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/GeneralConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/GeneralConfig.java
@@ -812,6 +812,10 @@ public class GeneralConfig extends BukkitConfig {
         return config.getDouble("Skills.Fishing.Lure_Modifier", 4.0D);
     }
 
+    public boolean getFishingAllowConflictingEnchants() {
+        return config.getBoolean("Skills.Fishing.Allow_Conflicting_Enchants", false);
+    }
+
     /* Mining */
     public Material getDetonatorItem() {
         return Material.matchMaterial(

--- a/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/fishing/FishingManager.java
@@ -52,6 +52,7 @@ import org.bukkit.entity.Sheep;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
@@ -691,11 +692,24 @@ public class FishingManager extends SkillManager {
 
         int specificChance = 1;
 
+        outer:
         for (EnchantmentTreasure enchantmentTreasure : possibleEnchants) {
             Enchantment possibleEnchantment = enchantmentTreasure.getEnchantment();
 
-            if (treasureDrop.getItemMeta().hasConflictingEnchant(possibleEnchantment)
-                    || Misc.getRandom().nextInt(specificChance) != 0) {
+            if (!mcMMO.p.getGeneralConfig().getFishingAllowConflictingEnchants()) {
+                final ItemMeta meta = treasureDrop.getItemMeta();
+                if (meta != null && meta.hasConflictingEnchant(possibleEnchantment)) {
+                    continue;
+                }
+
+                for (final Enchantment existingEnchantment : enchants.keySet()) {
+                    if (existingEnchantment.conflictsWith(possibleEnchantment)) {
+                        continue outer;
+                    }
+                }
+            }
+
+            if (Misc.getRandom().nextInt(specificChance) != 0) {
                 continue;
             }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -388,6 +388,8 @@ Skills:
         # Always catch fish, even when treasure is found
         Extra_Fish: false
         Lure_Modifier: 4.0
+        # Makes items with conflicting enchantments obtainable through Magic Hunter, such as armor pieces with multiple types of protection
+        Allow_Conflicting_Enchants: false
     Herbalism:
         Level_Cap: 0
         Prevent_AFK_Leveling: true


### PR DESCRIPTION
This PR adds a toggle for whether magic hunter can give you items with conflicting enchantments, such as multiple types of protection on a single armor piece.

Depending on who you ask this is either a bug or a feature, so the safest bet is to have a config option for it. The proposed default here is to have it off (leaning towards this being a bug rather than a feature), but if that isn't the case then I'll happily change that default here.