### PR TITLE
Fix excavation treasures not dropping

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/BlockListener.java
@@ -30,7 +30,6 @@ import com.gmail.nossr50.util.sounds.SoundManager;
 import com.gmail.nossr50.util.sounds.SoundType;
 import com.gmail.nossr50.worldguard.WorldGuardManager;
 import com.gmail.nossr50.worldguard.WorldGuardUtils;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -164,13 +163,13 @@ public class BlockListener implements Listener {
             final Player excavationPlayer = event.getPlayer();
             final McMMOPlayer excavationMmoPlayer = UserManager.getPlayer(excavationPlayer);
             if (excavationMmoPlayer != null
-                    && BlockUtils.affectedByGigaDrillBreaker(block)
+                    && BlockUtils.affectedByGigaDrillBreaker(event.getBlockState())
                     && ItemUtils.isShovel(excavationPlayer.getInventory().getItemInMainHand())
                     && mcMMO.p.getSkillTools().doesPlayerHaveSkillPermission(
                             excavationPlayer, PrimarySkillType.EXCAVATION)
                     && !mcMMO.getUserBlockTracker().isIneligible(block)) {
                 final List<ItemStack> treasureDrops = excavationMmoPlayer.getExcavationManager()
-                        .rollAndCollectTreasureDrops(block);
+                        .rollAndCollectTreasureDrops(event.getBlockState());
                 if (!treasureDrops.isEmpty()) {
                     final World blockWorld = block.getWorld();
                     final Location dropLocation = block.getLocation().add(0.5, 0.5, 0.5);

--- a/src/main/java/com/gmail/nossr50/skills/excavation/Excavation.java
+++ b/src/main/java/com/gmail/nossr50/skills/excavation/Excavation.java
@@ -19,11 +19,10 @@ public class Excavation {
      * @return the list of treasures that could be found
      */
     protected static List<ExcavationTreasure> getTreasures(final Material material) {
-        String friendly = getMaterialConfigString(material);
-        if (TreasureConfig.getInstance().excavationMap.containsKey(friendly)) {
-            return TreasureConfig.getInstance().excavationMap.get(friendly);
-        }
-        return new ArrayList<>();
+        final String friendly = getMaterialConfigString(material);
+
+        final List<ExcavationTreasure> treasures = TreasureConfig.getInstance().excavationMap.get(friendly);
+        return treasures != null ? treasures : new ArrayList<>();
     }
 
     /**

--- a/src/main/java/com/gmail/nossr50/skills/excavation/Excavation.java
+++ b/src/main/java/com/gmail/nossr50/skills/excavation/Excavation.java
@@ -6,9 +6,26 @@ import com.gmail.nossr50.config.treasure.TreasureConfig;
 import com.gmail.nossr50.datatypes.treasure.ExcavationTreasure;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 
 public class Excavation {
+    /**
+     * Get the list of possible {@link ExcavationTreasure|ExcavationTreasures} obtained from a given
+     * material.
+     *
+     * @param material The {@link Material} to check for treasures
+     * @return the list of treasures that could be found
+     */
+    protected static List<ExcavationTreasure> getTreasures(final Material material) {
+        String friendly = getMaterialConfigString(material);
+        if (TreasureConfig.getInstance().excavationMap.containsKey(friendly)) {
+            return TreasureConfig.getInstance().excavationMap.get(friendly);
+        }
+        return new ArrayList<>();
+    }
+
     /**
      * Get the list of possible {@link ExcavationTreasure|ExcavationTreasures} obtained from a given
      * block.
@@ -16,11 +33,7 @@ public class Excavation {
      * @param block The {@link Block} to check for treasures
      * @return the list of treasures that could be found
      */
-    protected static List<ExcavationTreasure> getTreasures(Block block) {
-        String friendly = getMaterialConfigString(block.getBlockData().getMaterial());
-        if (TreasureConfig.getInstance().excavationMap.containsKey(friendly)) {
-            return TreasureConfig.getInstance().excavationMap.get(friendly);
-        }
-        return new ArrayList<>();
+    protected static List<ExcavationTreasure> getTreasures(final Block block) {
+        return getTreasures(block.getType());
     }
 }

--- a/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/excavation/ExcavationManager.java
@@ -51,10 +51,9 @@ public class ExcavationManager extends SkillManager {
         // Treasure drops are rolled inside BlockDropItemEvent via rollAndCollectTreasureDrops()
     }
 
-    @Deprecated(forRemoval = true, since = "2.2.024")
     public List<ExcavationTreasure> getTreasures(@NotNull BlockState blockState) {
         requireNonNull(blockState, "blockState cannot be null");
-        return getTreasures(blockState.getBlock());
+        return Excavation.getTreasures(blockState.getType());
     }
 
     public List<ExcavationTreasure> getTreasures(@NotNull Block block) {
@@ -79,21 +78,21 @@ public class ExcavationManager extends SkillManager {
      * preserving the legacy behaviour where {@link #excavationBlockCheck} was called three
      * times for the centre block (once normally and twice inside {@link #gigaDrillBreaker}).
      *
-     * @param block the block that was broken
+     * @param blockState the block that was broken
      * @return list of treasure {@link ItemStack}s from all successful rolls
      */
-    public @NotNull List<ItemStack> rollAndCollectTreasureDrops(@NotNull Block block) {
+    public @NotNull List<ItemStack> rollAndCollectTreasureDrops(@NotNull BlockState blockState) {
         if (!Permissions.isSubSkillEnabled(getPlayer(), SubSkillType.EXCAVATION_ARCHAEOLOGY)) {
             return List.of();
         }
 
-        final List<ExcavationTreasure> treasures = getTreasures(block);
+        final List<ExcavationTreasure> treasures = getTreasures(blockState);
         if (treasures.isEmpty()) {
             return List.of();
         }
 
         final int skillLevel = getSkillLevel();
-        final Location centerOfBlock = Misc.getBlockCenter(block);
+        final Location centerOfBlock = Misc.getBlockCenter(blockState.getLocation());
 
         // GDB called excavationBlockCheck 3 times (1 regular + 2 via gigaDrillBreaker),
         // giving 3 independent treasure rolls for the centre block. Mirror that here.
@@ -124,7 +123,7 @@ public class ExcavationManager extends SkillManager {
 
     /**
      * @deprecated Treasure drops are now handled via
-     *     {@link #rollAndCollectTreasureDrops(Block)} inside
+     *     {@link #rollAndCollectTreasureDrops(BlockState)} inside
      *     {@link org.bukkit.event.block.BlockDropItemEvent} so they are visible to
      *     Telekinesis-style enchant plugins.
      */

--- a/src/test/java/com/gmail/nossr50/skills/excavation/ExcavationTest.java
+++ b/src/test/java/com/gmail/nossr50/skills/excavation/ExcavationTest.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
@@ -69,9 +69,8 @@ class ExcavationTest extends MMOTestEnvironment {
         // Given: player has enough skill and a guaranteed treasure
         mmoPlayer.modifySkill(PrimarySkillType.EXCAVATION, 1000);
 
-        final Block block = Mockito.mock(Block.class);
+        final BlockState block = Mockito.mock(BlockState.class);
         when(block.getType()).thenReturn(Material.SAND);
-        when(block.getDrops(any())).thenReturn(null);
         when(block.getLocation()).thenReturn(new Location(world, 0, 64, 0));
 
         final ExcavationManager excavationManager = Mockito.spy(new ExcavationManager(mmoPlayer));
@@ -91,9 +90,8 @@ class ExcavationTest extends MMOTestEnvironment {
         // Given: a treasure that can never drop (0% chance)
         mmoPlayer.modifySkill(PrimarySkillType.EXCAVATION, 1000);
 
-        final Block block = Mockito.mock(Block.class);
+        final BlockState block = Mockito.mock(BlockState.class);
         when(block.getType()).thenReturn(Material.SAND);
-        when(block.getDrops(any())).thenReturn(null);
         when(block.getLocation()).thenReturn(new Location(world, 0, 64, 0));
 
         final ExcavationManager excavationManager = Mockito.spy(new ExcavationManager(mmoPlayer));
@@ -130,7 +128,7 @@ class ExcavationTest extends MMOTestEnvironment {
             // Given: player has enough skill and a guaranteed treasure exists for this block
             mmoPlayer.modifySkill(PrimarySkillType.EXCAVATION, 1000);
 
-            final Block block = Mockito.mock(Block.class);
+            final BlockState block = Mockito.mock(BlockState.class);
             when(block.getType()).thenReturn(Material.SAND);
             when(block.getLocation()).thenReturn(new Location(world, 1, 64, 1));
 
@@ -154,7 +152,7 @@ class ExcavationTest extends MMOTestEnvironment {
             // Given: a treasure that can never drop (0% chance)
             mmoPlayer.modifySkill(PrimarySkillType.EXCAVATION, 1000);
 
-            final Block block = Mockito.mock(Block.class);
+            final BlockState block = Mockito.mock(BlockState.class);
             when(block.getType()).thenReturn(Material.SAND);
             when(block.getLocation()).thenReturn(new Location(world, 2, 64, 2));
 


### PR DESCRIPTION
Fixes a bug from yesterday's commit https://github.com/mcMMO-Dev/mcMMO/commit/ce021dbe129c912820f28649d6c4050ed80abe13 that caused excavation treasures to not work anymore. The problem was that in the block drop item event the block is already air, so affectedByGigaDrillBreaker would always be false and the treasure drops would also be empty if that were to pass. The solution to this is to use the block state provided by the event, which does reflect the block that used to be there.