### PR TITLE
Add a configurable option for additional destructible items in treefeller

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/AdvancedConfig.java
@@ -876,6 +876,10 @@ public class AdvancedConfig extends BukkitConfig {
                 true);
     }
 
+    public List<String> getAdditionalTreeFellerDestructibleWhiteList() {
+        return config.getStringList("Skills.Woodcutting.TreeFeller.Additional_Destructible_Items_White_List");
+    }
+
     /* MACES */
     public double getCrushBaseDamage() {
         return config.getDouble("Skills.Maces.Crush.Base_Damage", 0.5D);

--- a/src/main/java/com/gmail/nossr50/util/MaterialMapStore.java
+++ b/src/main/java/com/gmail/nossr50/util/MaterialMapStore.java
@@ -4,6 +4,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.List;
+
+import com.gmail.nossr50.mcMMO;
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
 
@@ -1141,6 +1144,11 @@ public class MaterialMapStore {
         treeFellerDestructibleWhiteList.add("warped_wart_block");
         treeFellerDestructibleWhiteList.add("brown_mushroom_block");
         treeFellerDestructibleWhiteList.add("red_mushroom_block");
+
+        List<String> additional = mcMMO.p.getAdvancedConfig().getAdditionalTreeFellerDestructibleWhiteList();
+        if (!additional.isEmpty()) {
+            treeFellerDestructibleWhiteList.addAll(additional);
+        }
     }
 
     private void fillMossyWhiteList() {

--- a/src/main/resources/advanced.yml
+++ b/src/main/resources/advanced.yml
@@ -645,6 +645,7 @@ Skills:
         TreeFeller:
             Knock_On_Wood:
                 Add_XP_Orbs_To_Drops: true
+            Additional_Destructible_Items_White_List: []
 
         # Triple Drops
         CleanCuts:


### PR DESCRIPTION
On some custom maps, trees include items other than the hardcoded list of items (such as leaves)
Adding a config option to extend the list fixes that