### PR TITLE
Fix entities keeping their health bars after unload

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -26,6 +26,7 @@ import com.gmail.nossr50.util.BlockUtils;
 import com.gmail.nossr50.util.ItemUtils;
 import com.gmail.nossr50.util.MetadataConstants;
 import com.gmail.nossr50.util.Misc;
+import com.gmail.nossr50.util.MobHealthbarUtils;
 import com.gmail.nossr50.util.Permissions;
 import com.gmail.nossr50.util.player.NotificationManager;
 import com.gmail.nossr50.util.player.UserManager;
@@ -78,6 +79,7 @@ import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.world.EntitiesUnloadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -761,6 +763,17 @@ public class EntityListener implements Listener {
         }
 
         mcMMO.getTransientMetadataTools().cleanLivingEntityMetadata(entity);
+    }
+
+    @EventHandler
+    public void onEntitiesUnload(EntitiesUnloadEvent event) {
+        for (final Entity entity : event.getEntities()) {
+            if (entity instanceof LivingEntity livingEntity) {
+                // Remove any eventual health bar the mob might have.
+                // This event fires early enough where we can still modify entity state and clean up the display name.
+                MobHealthbarUtils.restoreNameFromSnapshot(livingEntity);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where you could hit an entity to trigger the health bar, unload the chunk (e.g. by disconnecting), and the entity would retain the health bar indefinitely.