### PR TITLE
Refactor scoreboards to packet-based impl for Folia/Canvas compatibility

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,13 +1,20 @@
 Version 2.2.055
+    Added scoreboard support for Folia servers (See notes)
     Fixed the 'mcmmo.perks.xp.25percentboost' permission and its per-skill child nodes not being registered (See notes)
     Fixed Maces Cripple playing an extra anvil break sound that could not be disabled in sounds.yml (See notes)
     Fixed Super Breaker and Tree Feller mishandling durability on items with a custom max_damage component (See notes)
     Fixed Tree Feller ignoring durability damage changes made by other plugins via PlayerItemDamageEvent
     Improved performance when players gain skill XP (See notes)
     Improved performance when taking smelted items out of furnaces (See notes)
+    (API) McMMOScoreboardObjectiveEvent is only fired on non-Folia servers (See notes)
+    (Codebase) Added scoreboard-library 2.8.0 as a shaded dependency for the packet-based scoreboard implementation
+    (Codebase) Added ViaVersion to plugin.yml softdepend
     (Codebase) Added unit tests covering the power level cap and skill level cap checks
 
     NOTES:
+    Scoreboards on Folia (and Folia forks like Canvas) now use a packet-based implementation, since the Bukkit scoreboard API is not safe to use there. Paper and Spigot servers keep the existing Bukkit scoreboard implementation and are unaffected.
+    If a Folia server runs a newer Minecraft version than this mcMMO build supports for packet scoreboards (currently the 26.2.x line), scoreboards are disabled with a startup warning until mcMMO updates.
+    (API) The packet-based implementation still fires McMMOScoreboardMakeboardEvent and McMMOScoreboardRevertEvent, but there is no Bukkit Objective on Folia so McMMOScoreboardObjectiveEvent is not fired there.
     The mcmmo.perks.xp.25percentboost permission family now behaves like the 10, 50, and 150 percent variants; previously only mcmmo.perks.xp.25percentboost.all had any effect.
     Gaining XP now does much less repeated work per gain, which reduces mcMMO's share of server thread time on busy servers; no behavior or config changes are involved.
     Taking smelted items out of a furnace no longer searches the full server recipe list every time.

--- a/pom.xml
+++ b/pom.xml
@@ -190,9 +190,15 @@
                             <include>net.kyori:adventure-text-serializer-craftbukkit</include>
                             <include>co.aikar:acf-bukkit</include>
                             <include>com.tcoded:FoliaLib</include>
+                            <include>net.megavex:scoreboard-library-api</include>
+                            <include>net.megavex:scoreboard-library-implementation</include>
                         </includes>
                     </artifactSet>
                     <relocations>
+                        <relocation>
+                            <pattern>net.megavex.scoreboardlibrary</pattern>
+                            <shadedPattern>com.gmail.nossr50.mcmmo.scoreboard</shadedPattern>
+                        </relocation>
                         <relocation>
                             <pattern>net.kyori</pattern>
                             <shadedPattern>com.gmail.nossr50.mcmmo.kyori</shadedPattern>
@@ -299,6 +305,17 @@
         </repository>
     </repositories>
     <dependencies>
+        <dependency>
+            <groupId>net.megavex</groupId>
+            <artifactId>scoreboard-library-api</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.megavex</groupId>
+            <artifactId>scoreboard-library-implementation</artifactId>
+            <version>2.8.0</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/src/main/java/com/gmail/nossr50/events/scoreboard/McMMOScoreboardObjectiveEvent.java
+++ b/src/main/java/com/gmail/nossr50/events/scoreboard/McMMOScoreboardObjectiveEvent.java
@@ -5,6 +5,15 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Scoreboard;
 
+/**
+ * Fired when mcMMO's Bukkit scoreboard backend registers or unregisters the sidebar objective.
+ * <p>
+ * This event is backend-specific:
+ * <ul>
+ *     <li>Fired by the Bukkit backend (non-Folia servers).</li>
+ *     <li>Not fired by packet/no-op backends, which have no Bukkit {@link Objective}.</li>
+ * </ul>
+ */
 public class McMMOScoreboardObjectiveEvent extends McMMOScoreboardEvent implements Cancellable {
     protected boolean cancelled;
 

--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -269,6 +269,13 @@ public class mcMMO extends JavaPlugin {
                             20, 20 * 60 * 30);
                 }
             } else {
+                // Load the packet-based scoreboard library before registering events/commands
+                // that may touch ScoreboardManager. Guarded by the same config as onDisable's
+                // teardown; falls back to a no-op library on unsupported server versions.
+                if (generalConfig.getScoreboardsEnabled()) {
+                    ScoreboardManager.init();
+                }
+
                 registerEvents();
                 registerCoreSkills();
                 registerCustomRecipes();

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardManager.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardManager.java
@@ -11,33 +11,34 @@ import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.LogUtils;
 import com.gmail.nossr50.util.Misc;
+import com.gmail.nossr50.util.PaperUtil;
 import com.gmail.nossr50.util.player.UserManager;
+import com.gmail.nossr50.util.scoreboards.backend.BukkitScoreboardBackend;
+import com.gmail.nossr50.util.scoreboards.backend.NoopScoreboardBackend;
+import com.gmail.nossr50.util.scoreboards.backend.PlayerBoard;
+import com.gmail.nossr50.util.scoreboards.backend.PacketScoreboardBackend;
+import com.gmail.nossr50.util.scoreboards.backend.ScoreboardBackend;
+import com.gmail.nossr50.util.scoreboards.backend.ScoreboardBackendSelector;
+import com.gmail.nossr50.util.scoreboards.backend.ScoreboardBackendType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import net.megavex.scoreboardlibrary.api.objective.ScoreboardObjective;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.DisplaySlot;
-import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Scoreboard;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Manages the Scoreboards used to display a variety of mcMMO related information to the player
  */
 public class ScoreboardManager {
-    static final Map<String, ScoreboardWrapper> PLAYER_SCOREBOARDS = new HashMap<>();
-
-    // do not localize; these are internal identifiers
-    static final String SIDEBAR_OBJECTIVE = "mcmmo_sidebar";
-    static final String POWER_OBJECTIVE = "mcmmo_pwrlvl";
+    static final Map<String, ScoreboardWrapper> PLAYER_SCOREBOARDS = new ConcurrentHashMap<>();
 
     static final String HEADER_STATS = LocaleLoader.getString("Scoreboard.Header.PlayerStats");
     static final String HEADER_COOLDOWNS = LocaleLoader.getString(
@@ -58,10 +59,16 @@ public class ScoreboardManager {
     static final Map<SuperAbilityType, String> abilityLabelsColored;
     static final Map<SuperAbilityType, String> abilityLabelsSkill;
 
-    public static final String DISPLAY_NAME = "powerLevel";
+    private static ScoreboardBackend backend;
+    private static ScoreboardBackendType backendType = ScoreboardBackendType.NOOP;
 
     /*
-     * Initializes the static properties of this class
+     * Initializes the static label maps for our scoreboards.
+     *
+     * Note: backend resources are not loaded here. Loading packet adapters can fail on unsupported
+     * server versions, and doing that inside a static initializer would turn failures into
+     * ExceptionInInitializerError on first access. Backends are initialized explicitly via
+     * {@link #init()} during onEnable, guarded by the scoreboards-enabled config.
      */
     static {
         /*
@@ -155,7 +162,57 @@ public class ScoreboardManager {
         abilityLabelsSkill = abilityLabelSkillBuilder.build();
     }
 
-    private static final List<String> dirtyPowerLevels = new ArrayList<>();
+    private static final Set<String> dirtyPowerLevels = ConcurrentHashMap.newKeySet();
+
+    public static void init() {
+        if (backend != null) {
+            return;
+        }
+
+        if (!mcMMO.p.getGeneralConfig().getScoreboardsEnabled()) {
+            backendType = ScoreboardBackendType.NOOP;
+            backend = new NoopScoreboardBackend();
+            backend.init();
+            return;
+        }
+
+        final boolean isFolia = PaperUtil.isFolia();
+        final ScoreboardBackendType selectedType = ScoreboardBackendSelector.select(
+                isFolia,
+                mcMMO.getMinecraftGameVersion());
+        backendType = selectedType;
+
+        switch (selectedType) {
+            case BUKKIT -> backend = new BukkitScoreboardBackend();
+            case PACKET -> backend = new PacketScoreboardBackend();
+            case NOOP -> {
+                backend = new NoopScoreboardBackend();
+                mcMMO.p.getLogger().warning(
+                        "Folia detected on unsupported Minecraft version "
+                                + mcMMO.getMinecraftGameVersion().getVersionStr()
+                                + " (supported packet scoreboard max is "
+                                + ScoreboardBackendSelector.MAX_PACKET_VERSION_STRING
+                                + "). Scoreboards are disabled to avoid Folia async scoreboard issues. "
+                                + "Please update mcMMO.");
+            }
+        }
+
+        try {
+            backend.init();
+        } catch (RuntimeException e) {
+            if (selectedType == ScoreboardBackendType.PACKET) {
+                mcMMO.p.getLogger().warning(
+                        "Packet scoreboard backend failed to initialize ("
+                                + e.getMessage()
+                                + "). Falling back to a Folia-safe no-op scoreboard backend.");
+                backendType = ScoreboardBackendType.NOOP;
+                backend = new NoopScoreboardBackend();
+                backend.init();
+            } else {
+                throw e;
+            }
+        }
+    }
 
     public enum SidebarType {
         NONE,
@@ -194,35 +251,40 @@ public class ScoreboardManager {
 
     // Called by PlayerJoinEvent listener
     public static void setupPlayer(Player player) {
+        ensureBackendReady();
         teardownPlayer(player);
-
         PLAYER_SCOREBOARDS.put(player.getName(), makeNewScoreboard(player));
         dirtyPowerLevels.add(player.getName());
+
+        if (mcMMO.p.getGeneralConfig().getPowerLevelTagsEnabled() && backend.isPowerLevelTagActive()) {
+            backend.setupPowerLevelTag(player);
+        }
     }
 
     // Called by PlayerQuitEvent listener and OnPlayerTeleport under certain circumstances
     public static void teardownPlayer(Player player) {
+        ensureBackendReady();
+
         if (player == null) {
             return;
         }
 
-        //Hacky world blacklist fix
-        if (player.isOnline() && player.isValid()) {
-            if (Bukkit.getServer().getScoreboardManager() != null) {
-                player.setScoreboard(Bukkit.getServer().getScoreboardManager().getMainScoreboard());
-            }
+        if (isBukkitBackendActive() && player.isOnline() && player.isValid()
+                && Bukkit.getScoreboardManager() != null) {
+            player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
         }
 
-        if (getWrapper(player) != null) {
-            ScoreboardWrapper wrapper = PLAYER_SCOREBOARDS.remove(player.getName());
-            if (wrapper.revertTask != null) {
-                wrapper.revertTask.cancel();
-            }
+        backend.removePowerLevelTag(player);
+
+        ScoreboardWrapper wrapper = PLAYER_SCOREBOARDS.remove(player.getName());
+        if (wrapper != null) {
+            wrapper.close();
         }
     }
 
     // Called in onDisable()
     public static void teardownAll() {
+        ensureBackendReady();
         ImmutableList<Player> onlinePlayers = ImmutableList.copyOf(
                 mcMMO.p.getServer().getOnlinePlayers());
         LogUtils.debug(mcMMO.p.getLogger(),
@@ -230,15 +292,19 @@ public class ScoreboardManager {
         for (Player player : onlinePlayers) {
             teardownPlayer(player);
         }
+
+        if (backend != null) {
+            backend.shutdown();
+        }
+        backend = null;
+        backendType = ScoreboardBackendType.NOOP;
     }
 
     // Called by ScoreboardWrapper when its Player logs off and an action tries to be performed
     public static void cleanup(ScoreboardWrapper wrapper) {
+        ensureBackendReady();
         PLAYER_SCOREBOARDS.remove(wrapper.playerName);
-
-        if (wrapper.revertTask != null) {
-            wrapper.revertTask.cancel();
-        }
+        wrapper.close();
     }
 
     // Called by internal level-up event listener
@@ -323,27 +389,7 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeSkill(skill);
-
-            changeScoreboard(wrapper, mcMMO.p.getGeneralConfig().getSkillScoreboardTime());
-        }
-    }
-
-    public static void retryLastSkillBoard(Player player) {
-        final McMMOPlayer mmoPlayer = UserManager.getPlayer(player);
-        PrimarySkillType primarySkillType = mmoPlayer.getLastSkillShownScoreboard();
-
-        ScoreboardWrapper wrapper = getWrapper(player);
-
-        if (wrapper == null) {
-            setupPlayer(player);
-            wrapper = getWrapper(player);
-        }
-
-        if (wrapper != null) {
-            wrapper.setOldScoreboard();
-            wrapper.setTypeSkill(primarySkillType);
 
             changeScoreboard(wrapper, mcMMO.p.getGeneralConfig().getSkillScoreboardTime());
         }
@@ -359,7 +405,6 @@ public class ScoreboardManager {
                 return;
             }
 
-            wrapper.setOldScoreboard();
             wrapper.setTypeSkill(skill);
             changeScoreboard(wrapper, mcMMO.p.getGeneralConfig().getSkillLevelUpTime());
         }
@@ -372,14 +417,13 @@ public class ScoreboardManager {
             return;
         }
 
-        wrapper.setOldScoreboard();
         wrapper.setTypeSelfStats();
 
         changeScoreboard(wrapper, mcMMO.p.getGeneralConfig().getStatsScoreboardTime());
     }
 
     public static void enablePlayerInspectScoreboard(@NotNull Player player,
-            @NotNull PlayerProfile targetProfile) {
+                                                     @NotNull PlayerProfile targetProfile) {
         ScoreboardWrapper wrapper = getWrapper(player);
 
         if (wrapper == null) {
@@ -388,7 +432,6 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeInspectStats(targetProfile);
 
             changeScoreboard(wrapper, mcMMO.p.getGeneralConfig().getInspectScoreboardTime());
@@ -396,7 +439,7 @@ public class ScoreboardManager {
     }
 
     public static void enablePlayerInspectScoreboard(@NotNull Player player,
-            @NotNull McMMOPlayer targetMcMMOPlayer) {
+                                                     @NotNull McMMOPlayer targetMcMMOPlayer) {
         ScoreboardWrapper wrapper = getWrapper(player);
 
         if (wrapper == null) {
@@ -405,7 +448,6 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeInspectStats(targetMcMMOPlayer);
 
             changeScoreboard(wrapper, mcMMO.p.getGeneralConfig().getInspectScoreboardTime());
@@ -421,7 +463,6 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeCooldowns();
 
             changeScoreboard(wrapper, mcMMO.p.getGeneralConfig().getCooldownScoreboardTime());
@@ -429,7 +470,7 @@ public class ScoreboardManager {
     }
 
     public static void showPlayerRankScoreboard(Player player,
-            Map<PrimarySkillType, Integer> rank) {
+                                                Map<PrimarySkillType, Integer> rank) {
         ScoreboardWrapper wrapper = getWrapper(player);
 
         if (wrapper == null) {
@@ -438,7 +479,6 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeSelfRank();
             wrapper.acceptRankData(rank);
 
@@ -447,7 +487,7 @@ public class ScoreboardManager {
     }
 
     public static void showPlayerRankScoreboardOthers(Player player, String targetName,
-            Map<PrimarySkillType, Integer> rank) {
+                                                      Map<PrimarySkillType, Integer> rank) {
         ScoreboardWrapper wrapper = getWrapper(player);
 
         if (wrapper == null) {
@@ -456,7 +496,6 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeInspectRank(targetName);
             wrapper.acceptRankData(rank);
 
@@ -465,7 +504,7 @@ public class ScoreboardManager {
     }
 
     public static void showTopScoreboard(Player player, PrimarySkillType skill, int pageNumber,
-            List<PlayerStat> stats) {
+                                         List<PlayerStat> stats) {
 
         ScoreboardWrapper wrapper = getWrapper(player);
 
@@ -475,7 +514,6 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeTop(skill, pageNumber);
             wrapper.acceptLeaderboardData(stats);
 
@@ -484,7 +522,7 @@ public class ScoreboardManager {
     }
 
     public static void showTopPowerScoreboard(Player player, int pageNumber,
-            List<PlayerStat> stats) {
+                                              List<PlayerStat> stats) {
         ScoreboardWrapper wrapper = getWrapper(player);
 
         if (wrapper == null) {
@@ -493,7 +531,6 @@ public class ScoreboardManager {
         }
 
         if (wrapper != null) {
-            wrapper.setOldScoreboard();
             wrapper.setTypeTopPower(pageNumber);
             wrapper.acceptLeaderboardData(stats);
 
@@ -502,11 +539,18 @@ public class ScoreboardManager {
     }
 
     public static @Nullable ScoreboardWrapper getWrapper(Player player) {
-        if (PLAYER_SCOREBOARDS.get(player.getName()) == null) {
-            makeNewScoreboard(player);
+        ScoreboardWrapper wrapper = PLAYER_SCOREBOARDS.get(player.getName());
+
+        if (wrapper == null) {
+            // Lazily set the player up. We must go through setupPlayer (not a bare
+            // makeNewScoreboard) so the created wrapper is actually stored in the map - otherwise
+            // its packet Sidebar would be created and immediately leaked, since the packet sidebar
+            // holds a native resource that must be close()d (unlike the old Bukkit board).
+            setupPlayer(player);
+            wrapper = PLAYER_SCOREBOARDS.get(player.getName());
         }
 
-        return PLAYER_SCOREBOARDS.get(player.getName());
+        return wrapper;
     }
 
     // **** Helper methods **** //
@@ -515,10 +559,10 @@ public class ScoreboardManager {
      * @return false if power levels are disabled
      */
     public static boolean powerLevelHeartbeat() {
-        Objective mainObjective = getPowerLevelObjective();
+        ensureBackendReady();
 
-        if (mainObjective == null) {
-            return false; // indicates
+        if (!backend.isPowerLevelTagActive()) {
+            return false;
         }
 
         for (String playerName : dirtyPowerLevels) {
@@ -528,14 +572,8 @@ public class ScoreboardManager {
                 continue;
             }
 
-            Player player = mmoPlayer.getPlayer();
-            int power = mmoPlayer.getPowerLevel();
-
-            mainObjective.getScore(playerName).setScore(power);
-
-            for (ScoreboardWrapper wrapper : PLAYER_SCOREBOARDS.values()) {
-                wrapper.updatePowerLevel(player, power);
-            }
+            final int power = mmoPlayer.getPowerLevel();
+            backend.setPowerLevel(playerName, power);
         }
 
         dirtyPowerLevels.clear();
@@ -543,49 +581,24 @@ public class ScoreboardManager {
     }
 
     /**
-     * Gets or creates the power level objective on the main targetBoard.
+     * Gets or creates the packet-based below-name power level objective.
      * <p/>
-     * If power levels are disabled, the objective is deleted and null is returned.
+     * If power levels are disabled, the objective manager is closed and null is returned.
      *
-     * @return the main targetBoard objective, or null if disabled
+     * @return the power level objective, or null if disabled
      */
-    public static @Nullable Objective getPowerLevelObjective() {
-        if (!mcMMO.p.getGeneralConfig().getPowerLevelTagsEnabled()) {
-            if (getScoreboardManager() == null) {
-                return null;
-            }
-
-            Objective objective = getScoreboardManager().getMainScoreboard()
-                    .getObjective(POWER_OBJECTIVE);
-
-            if (objective != null) {
-                objective.unregister();
-                LogUtils.debug(mcMMO.p.getLogger(),
-                        "Removed leftover targetBoard objects from Power Level Tags.");
-            }
-
-            return null;
-        }
-
-        if (getScoreboardManager() == null) {
-            return null;
-        }
-
-        Objective powerObjective = getScoreboardManager().getMainScoreboard()
-                .getObjective(POWER_OBJECTIVE);
-
-        if (powerObjective == null) {
-            powerObjective = getScoreboardManager().getMainScoreboard()
-                    .registerNewObjective(POWER_OBJECTIVE, "dummy", DISPLAY_NAME);
-            powerObjective.setDisplayName(TAG_POWER_LEVEL);
-            powerObjective.setDisplaySlot(DisplaySlot.BELOW_NAME);
-        }
-
-        return powerObjective;
+    public static @Nullable ScoreboardObjective getPowerLevelObjective() {
+        ensureBackendReady();
+        return backend.getPacketPowerLevelObjective();
     }
 
-    public @Nullable
-    static org.bukkit.scoreboard.ScoreboardManager getScoreboardManager() {
+    /**
+     * @deprecated The packet-based sidebar no longer uses Bukkit's {@link
+     * org.bukkit.scoreboard.ScoreboardManager}; this method has no internal callers and is kept
+     * only as a thin pass-through for backwards compatibility.
+     */
+    @Deprecated
+    public static @Nullable org.bukkit.scoreboard.ScoreboardManager getScoreboardManager() {
         return mcMMO.p.getServer().getScoreboardManager();
     }
 
@@ -598,37 +611,81 @@ public class ScoreboardManager {
     }
 
     public static boolean isBoardShown(String playerName) {
-        return PLAYER_SCOREBOARDS.get(playerName).isBoardShown();
+        ScoreboardWrapper wrapper = PLAYER_SCOREBOARDS.get(playerName);
+        return wrapper != null && wrapper.isBoardShown();
     }
 
     public static void clearBoard(String playerName) {
-        PLAYER_SCOREBOARDS.get(playerName).tryRevertBoard();
+        ScoreboardWrapper wrapper = PLAYER_SCOREBOARDS.get(playerName);
+        if (wrapper != null) {
+            wrapper.tryRevertBoard();
+        }
     }
 
     public static void keepBoard(String playerName) {
-        PLAYER_SCOREBOARDS.get(playerName).cancelRevert();
+        ScoreboardWrapper wrapper = PLAYER_SCOREBOARDS.get(playerName);
+        if (wrapper != null) {
+            wrapper.cancelRevert();
+        }
     }
 
     public static void setRevertTimer(String playerName, int seconds) {
-        PLAYER_SCOREBOARDS.get(playerName)
-                .showBoardAndScheduleRevert(seconds * Misc.TICK_CONVERSION_FACTOR);
+        ScoreboardWrapper wrapper = PLAYER_SCOREBOARDS.get(playerName);
+        if (wrapper != null) {
+            wrapper.showBoardAndScheduleRevert(seconds * Misc.TICK_CONVERSION_FACTOR);
+        }
     }
 
     public static boolean isPlayerBoardSetup(@NotNull String playerName) {
         return PLAYER_SCOREBOARDS.get(playerName) != null;
     }
 
-    public static @Nullable ScoreboardWrapper makeNewScoreboard(Player player) {
-        if (getScoreboardManager() == null) {
-            return null;
+    public static @NotNull ScoreboardWrapper makeNewScoreboard(Player player) {
+        ensureBackendReady();
+
+        final Scoreboard eventTargetBoard = backend.createEventTargetBoard(player);
+        final Scoreboard currentBoard = player.getScoreboard();
+        McMMOScoreboardMakeboardEvent event = new McMMOScoreboardMakeboardEvent(
+                eventTargetBoard, currentBoard, player,
+                ScoreboardEventReason.CREATING_NEW_SCOREBOARD);
+        player.getServer().getPluginManager().callEvent(event);
+
+        final Player targetPlayer = event.getTargetPlayer();
+        final Scoreboard targetBoard = event.getTargetBoard() == null
+                ? currentBoard
+                : event.getTargetBoard();
+        final PlayerBoard playerBoard = backend.createPlayerBoard(targetPlayer, targetBoard);
+        return new ScoreboardWrapper(targetPlayer, playerBoard);
+    }
+
+    public static @NotNull ScoreboardBackend getBackend() {
+        ensureBackendReady();
+        return backend;
+    }
+
+    public static @NotNull ScoreboardBackendType getBackendType() {
+        ensureBackendReady();
+        return backendType;
+    }
+
+    public static boolean isBukkitBackendActive() {
+        return getBackendType() == ScoreboardBackendType.BUKKIT;
+    }
+
+    public static void onPlayerBoardClosed(@NotNull String playerName) {
+        ensureBackendReady();
+        backend.onPlayerBoardClosed(playerName);
+    }
+
+    private static void ensureBackendReady() {
+        if (backend == null) {
+            init();
         }
 
-        //Call our custom event
-        Scoreboard scoreboard = getScoreboardManager().getNewScoreboard();
-        McMMOScoreboardMakeboardEvent event = new McMMOScoreboardMakeboardEvent(scoreboard,
-                player.getScoreboard(), player, ScoreboardEventReason.CREATING_NEW_SCOREBOARD);
-        player.getServer().getPluginManager().callEvent(event);
-        //Use the values from the event
-        return new ScoreboardWrapper(event.getTargetPlayer(), event.getTargetBoard());
+        if (backend == null) {
+            backend = new NoopScoreboardBackend();
+            backendType = ScoreboardBackendType.NOOP;
+            backend.init();
+        }
     }
 }

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardWrapper.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/ScoreboardWrapper.java
@@ -1,89 +1,64 @@
 package com.gmail.nossr50.util.scoreboards;
 
-import static java.util.Objects.requireNonNull;
-
 import com.gmail.nossr50.datatypes.database.PlayerStat;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.player.PlayerProfile;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
 import com.gmail.nossr50.datatypes.skills.SuperAbilityType;
-import com.gmail.nossr50.events.scoreboard.McMMOScoreboardObjectiveEvent;
 import com.gmail.nossr50.events.scoreboard.McMMOScoreboardRevertEvent;
 import com.gmail.nossr50.events.scoreboard.ScoreboardEventReason;
-import com.gmail.nossr50.events.scoreboard.ScoreboardObjectiveEventReason;
 import com.gmail.nossr50.locale.LocaleLoader;
 import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.LogUtils;
 import com.gmail.nossr50.util.Misc;
-import com.gmail.nossr50.util.player.NotificationManager;
 import com.gmail.nossr50.util.player.UserManager;
 import com.gmail.nossr50.util.scoreboards.ScoreboardManager.SidebarType;
+import com.gmail.nossr50.util.scoreboards.backend.PlayerBoard;
+import com.gmail.nossr50.util.scoreboards.backend.SidebarLine;
 import com.gmail.nossr50.util.skills.SkillTools;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
-import java.util.List;
-import java.util.Map;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.DisplaySlot;
-import org.bukkit.scoreboard.Objective;
-import org.bukkit.scoreboard.Score;
 import org.bukkit.scoreboard.Scoreboard;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wraps a backend-specific player board for a single player.
+ */
 public class ScoreboardWrapper {
-    public static final String SIDE_OBJECTIVE = "mcMMO_sideObjective";
-    public static final String POWER_OBJECTIVE = "mcMMO_powerObjective";
+    private static final int MAX_LINES = 15;
+
     // Initialization variables
     public final String playerName;
     public final Player player;
-    private final Scoreboard scoreboard;
+    private final PlayerBoard playerBoard;
     private boolean tippedKeep = false;
     private boolean tippedClear = false;
+    private Scoreboard oldBoard = null;
 
     // Internal usage variables (should exist)
     private SidebarType sidebarType;
-    private Objective sidebarObjective;
-    private Objective powerObjective;
 
     // Parameter variables (May be null / invalid)
-    private Scoreboard oldBoard = null;
     public String targetPlayer = null;
     public PrimarySkillType targetSkill = null;
     private PlayerProfile targetProfile = null;
     public int leaderboardPage = -1;
-    private boolean registered = false;
 
-    public ScoreboardWrapper(Player player, Scoreboard scoreboard) {
+    // Data supplied by the manager for RANK/TOP boards, consumed by render()
+    private Map<PrimarySkillType, Integer> rankData = null;
+    private List<PlayerStat> leaderboardData = null;
+
+    public ScoreboardWrapper(Player player, PlayerBoard playerBoard) {
         this.player = player;
         this.playerName = player.getName();
-        this.scoreboard = scoreboard;
-        initBoard();
-    }
-
-    private void initBoard() {
-        sidebarType = SidebarType.NONE;
-        if (registered) {
-            //Make sure our references are pointed at the right things
-            sidebarObjective = scoreboard.getObjective(ScoreboardManager.SIDEBAR_OBJECTIVE);
-            powerObjective = scoreboard.getObjective(ScoreboardManager.POWER_OBJECTIVE);
-        } else {
-            //Register Objectives
-            sidebarObjective = this.scoreboard.registerNewObjective(
-                    ScoreboardManager.SIDEBAR_OBJECTIVE, "dummy", SIDE_OBJECTIVE);
-            powerObjective = this.scoreboard.registerNewObjective(ScoreboardManager.POWER_OBJECTIVE,
-                    "dummy", POWER_OBJECTIVE);
-            registered = true;
-        }
-
-        if (mcMMO.p.getGeneralConfig().getPowerLevelTagsEnabled()) {
-            powerObjective.setDisplayName(ScoreboardManager.TAG_POWER_LEVEL);
-            powerObjective.setDisplaySlot(DisplaySlot.BELOW_NAME);
-
-            for (McMMOPlayer mmoPlayer : UserManager.getPlayers()) {
-                powerObjective.getScore(mmoPlayer.getProfile().getPlayerName())
-                        .setScore(mmoPlayer.getPowerLevel());
-            }
-        }
+        this.sidebarType = SidebarType.NONE;
+        this.playerBoard = playerBoard;
     }
 
     public WrappedTask updateTask = null;
@@ -91,7 +66,7 @@ public class ScoreboardWrapper {
     private class ScoreboardQuickUpdate implements Runnable {
         @Override
         public void run() {
-            updateSidebar();
+            render();
             updateTask = null;
         }
     }
@@ -120,7 +95,6 @@ public class ScoreboardWrapper {
         }
     }
 
-
     public void doSidebarUpdateSoon() {
         if (updateTask == null) {
             // To avoid spamming the scheduler, store the instance and run 2 ticks later
@@ -144,7 +118,9 @@ public class ScoreboardWrapper {
             try {
                 cooldownTask.cancel();
             } catch (Exception e) {
-                e.printStackTrace();
+                LogUtils.debug(mcMMO.p.getLogger(),
+                        "Unable to cancel cooldown scoreboard task for " + playerName + ": "
+                                + e.getMessage());
             }
 
             cooldownTask = null;
@@ -163,35 +139,10 @@ public class ScoreboardWrapper {
         return sidebarType == SidebarType.STATS_BOARD;
     }
 
-    /**
-     * Set the old targetBoard, for use in reverting.
-     */
-    public void setOldScoreboard() {
-        Player player = mcMMO.p.getServer().getPlayerExact(playerName);
-
-        if (player == null) {
-            ScoreboardManager.cleanup(this);
-            return;
-        }
-
-        Scoreboard previousBoard = player.getScoreboard();
-
-        if (previousBoard == scoreboard) { // Already displaying it
-            if (this.oldBoard == null) {
-                // (Shouldn't happen) Use failsafe value - we're already displaying our board, but we don't have the one we should revert to
-                if (mcMMO.p.getServer().getScoreboardManager() != null) {
-                    this.oldBoard = mcMMO.p.getServer().getScoreboardManager().getMainScoreboard();
-                }
-            }
-        } else {
-            this.oldBoard = previousBoard;
-        }
-    }
-
     public void showBoardWithNoRevert() {
-        Player player = mcMMO.p.getServer().getPlayerExact(playerName);
+        final Player onlinePlayer = mcMMO.p.getServer().getPlayerExact(playerName);
 
-        if (player == null) {
+        if (onlinePlayer == null) {
             ScoreboardManager.cleanup(this);
             return;
         }
@@ -200,14 +151,24 @@ public class ScoreboardWrapper {
             revertTask.cancel();
         }
 
-        player.setScoreboard(scoreboard);
+        final boolean alreadyShown = playerBoard.isShown();
+        final Scoreboard previousBoard = playerBoard.show();
+
+        if (ScoreboardManager.isBukkitBackendActive()) {
+            if (alreadyShown && oldBoard == null && Bukkit.getScoreboardManager() != null) {
+                oldBoard = Bukkit.getScoreboardManager().getMainScoreboard();
+            } else if (!alreadyShown) {
+                oldBoard = previousBoard;
+            }
+        }
+
         revertTask = null;
     }
 
     public void showBoardAndScheduleRevert(int ticks) {
-        Player player = mcMMO.p.getServer().getPlayerExact(playerName);
+        final Player onlinePlayer = mcMMO.p.getServer().getPlayerExact(playerName);
 
-        if (player == null) {
+        if (onlinePlayer == null) {
             ScoreboardManager.cleanup(this);
             return;
         }
@@ -216,18 +177,24 @@ public class ScoreboardWrapper {
             revertTask.cancel();
         }
 
-        player.setScoreboard(scoreboard);
-        revertTask = mcMMO.p.getFoliaLib().getScheduler()
-                .runAtEntityLater(player, new ScoreboardChangeTask(), ticks);
+        final boolean alreadyShown = playerBoard.isShown();
+        final Scoreboard previousBoard = playerBoard.show();
+        if (ScoreboardManager.isBukkitBackendActive()) {
+            if (alreadyShown && oldBoard == null && Bukkit.getScoreboardManager() != null) {
+                oldBoard = Bukkit.getScoreboardManager().getMainScoreboard();
+            } else if (!alreadyShown) {
+                oldBoard = previousBoard;
+            }
+        }
 
-        // TODO is there any way to do the time that looks acceptable?
-        // player.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Timer", StringUtils.capitalize(sidebarType.toString().toLowerCase(Locale.ENGLISH)), ticks / 20F));
+        revertTask = mcMMO.p.getFoliaLib().getScheduler()
+                .runAtEntityLater(onlinePlayer, new ScoreboardChangeTask(), ticks);
 
         if (UserManager.getPlayer(playerName) == null) {
             return;
         }
 
-        PlayerProfile profile = UserManager.getPlayer(player).getProfile();
+        PlayerProfile profile = UserManager.getPlayer(onlinePlayer).getProfile();
 
         if (profile.getScoreboardTipsShown() >= mcMMO.p.getGeneralConfig().getTipsAmount()) {
             return;
@@ -235,37 +202,50 @@ public class ScoreboardWrapper {
 
         if (!tippedKeep) {
             tippedKeep = true;
-            player.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Tip.Keep"));
+            onlinePlayer.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Tip.Keep"));
         } else if (!tippedClear) {
             tippedClear = true;
-            player.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Tip.Clear"));
+            onlinePlayer.sendMessage(LocaleLoader.getString("Commands.Scoreboard.Tip.Clear"));
             profile.increaseTipsShown();
         }
     }
 
     public void tryRevertBoard() {
-        Player player = mcMMO.p.getServer().getPlayerExact(playerName);
+        Player onlinePlayer = mcMMO.p.getServer().getPlayerExact(playerName);
 
-        if (player == null) {
+        if (onlinePlayer == null) {
             ScoreboardManager.cleanup(this);
             return;
         }
 
-        if (oldBoard != null) {
-            if (player.getScoreboard() == scoreboard) {
-                /*
-                  Call the revert scoreboard custom event
-                 */
-                McMMOScoreboardRevertEvent event = new McMMOScoreboardRevertEvent(oldBoard,
-                        player.getScoreboard(), player, ScoreboardEventReason.REVERTING_BOARD);
-                player.getServer().getPluginManager().callEvent(event);
-                //Modify the player based on the event
-                event.getTargetPlayer().setScoreboard(event.getTargetBoard());
+        if (ScoreboardManager.isBukkitBackendActive()) {
+            if (oldBoard != null && isBoardShown()) {
+                McMMOScoreboardRevertEvent event = new McMMOScoreboardRevertEvent(
+                        oldBoard,
+                        onlinePlayer.getScoreboard(),
+                        onlinePlayer,
+                        ScoreboardEventReason.REVERTING_BOARD);
+                onlinePlayer.getServer().getPluginManager().callEvent(event);
+                onlinePlayer = event.getTargetPlayer();
+                playerBoard.hide(onlinePlayer, event.getTargetBoard());
                 oldBoard = null;
-            } else {
-                LogUtils.debug(mcMMO.p.getLogger(), "Not reverting targetBoard for " + playerName
-                        + " - targetBoard was changed by another plugin (Consider disabling the mcMMO scoreboards if you don't want them!)");
+            } else if (oldBoard != null) {
+                LogUtils.debug(mcMMO.p.getLogger(),
+                        "Not reverting scoreboard for "
+                                + playerName
+                                + " - scoreboard was changed by another plugin.");
             }
+        } else if (isBoardShown()) {
+            McMMOScoreboardRevertEvent event = new McMMOScoreboardRevertEvent(
+                    onlinePlayer.getScoreboard(),
+                    onlinePlayer.getScoreboard(),
+                    onlinePlayer,
+                    ScoreboardEventReason.REVERTING_BOARD);
+            onlinePlayer.getServer().getPluginManager().callEvent(event);
+            onlinePlayer = event.getTargetPlayer();
+            playerBoard.hide(onlinePlayer, event.getTargetBoard());
+        } else {
+            playerBoard.hide(onlinePlayer, null);
         }
 
         cancelRevert();
@@ -275,17 +255,19 @@ public class ScoreboardWrapper {
         targetSkill = null;
         targetProfile = null;
         leaderboardPage = -1;
+        rankData = null;
+        leaderboardData = null;
     }
 
     public boolean isBoardShown() {
-        Player player = mcMMO.p.getServer().getPlayerExact(playerName);
+        Player onlinePlayer = mcMMO.p.getServer().getPlayerExact(playerName);
 
-        if (player == null) {
+        if (onlinePlayer == null) {
             ScoreboardManager.cleanup(this);
             return false;
         }
 
-        return player.getScoreboard() == scoreboard;
+        return playerBoard.isShown();
     }
 
     public void cancelRevert() {
@@ -295,6 +277,25 @@ public class ScoreboardWrapper {
 
         revertTask.cancel();
         revertTask = null;
+    }
+
+    /**
+     * Releases backend resources and scheduled tasks.
+     */
+    public void close() {
+        try {
+            stopCooldownUpdating();
+            cancelRevert();
+            if (updateTask != null) {
+                updateTask.cancel();
+                updateTask = null;
+            }
+        } catch (Exception ignored) {
+            // best-effort task cleanup
+        }
+
+        playerBoard.close();
+        ScoreboardManager.onPlayerBoardClosed(playerName);
     }
 
     // Board Type Changing 'API' methods
@@ -415,68 +416,40 @@ public class ScoreboardWrapper {
                 startPosition, endPosition));
     }
 
-    // Setup for after a board type change
+    /**
+     * Sets the sidebar title and re-renders. Replaces the old register/unregister objective flow.
+     */
     protected void loadObjective(String displayName) {
-        //Unregister objective
-        McMMOScoreboardObjectiveEvent unregisterEvent = callObjectiveEvent(
-                ScoreboardObjectiveEventReason.UNREGISTER_THIS_OBJECTIVE);
-        if (!unregisterEvent.isCancelled()) {
-            try {
-                sidebarObjective.unregister();
-            } catch (IllegalStateException e) {
-                final McMMOPlayer mmoPlayer = UserManager.getPlayer(player);
-
-                LogUtils.debug(mcMMO.p.getLogger(),
-                        "Recovering scoreboard for player: " + player.getName());
-
-                if (mmoPlayer.isDebugMode()) {
-                    NotificationManager.sendPlayerInformationChatOnlyPrefixed(player,
-                            "Scoreboard.Recovery");
-                }
-
-                initBoard(); //Start over
-                mcMMO.p.getFoliaLib().getScheduler()
-                        .runAtEntity(player, t -> ScoreboardManager.retryLastSkillBoard(player));
-            }
-        }
-
-        //Register objective
-        McMMOScoreboardObjectiveEvent registerEvent = callObjectiveEvent(
-                ScoreboardObjectiveEventReason.REGISTER_NEW_OBJECTIVE);
-        if (!registerEvent.isCancelled()) {
-            sidebarObjective = registerEvent.getTargetBoard()
-                    .registerNewObjective(ScoreboardManager.SIDEBAR_OBJECTIVE, "dummy",
-                            SIDE_OBJECTIVE);
-        }
-
-        if (displayName.length() > 32) {
-            displayName = displayName.substring(0, 32);
-        }
-
-        sidebarObjective.setDisplayName(displayName);
-
-        updateSidebar();
-        // Do last! Minimize packets!
-        sidebarObjective.setDisplaySlot(DisplaySlot.SIDEBAR);
-    }
-
-    private McMMOScoreboardObjectiveEvent callObjectiveEvent(
-            ScoreboardObjectiveEventReason reason) {
-        McMMOScoreboardObjectiveEvent event = new McMMOScoreboardObjectiveEvent(sidebarObjective,
-                reason, scoreboard, scoreboard, player, ScoreboardEventReason.OBJECTIVE);
-        player.getServer().getPluginManager().callEvent(event);
-        return event;
+        playerBoard.setTitle(displayName);
+        render();
     }
 
     /**
-     * Load new values into the sidebar.
+     * Pushes an ordered list of rows to the active backend board.
      */
-    private void updateSidebar() {
+    private void drawLines(List<SidebarLine> lines) {
+        int count = Math.min(lines.size(), MAX_LINES);
+        List<SidebarLine> toRender = lines;
+
+        if (count != lines.size()) {
+            toRender = new ArrayList<>(lines.subList(0, count));
+        }
+
+        playerBoard.draw(toRender);
+    }
+
+    /**
+     * Recomputes and redraws every row based on the current {@link SidebarType}. Replaces the old
+     * {@code updateSidebar()}; the data sources and per-type logic mirror the original board.
+     */
+    private void render() {
         if (updateTask != null) {
             try {
                 updateTask.cancel();
             } catch (Exception e) {
-                e.printStackTrace();
+                LogUtils.debug(mcMMO.p.getLogger(),
+                        "Unable to cancel sidebar update task for " + playerName + ": "
+                                + e.getMessage());
             }
 
             updateTask = null;
@@ -499,161 +472,170 @@ public class ScoreboardWrapper {
             return;
         }
 
+        final List<SidebarLine> lines = new ArrayList<>();
+
         switch (sidebarType) {
             case NONE:
                 break;
 
             case SKILL_BOARD:
-                requireNonNull(targetSkill);
-
-                if (!SkillTools.isChildSkill(targetSkill)) {
-                    int currentXP = mmoPlayer.getSkillXpLevel(targetSkill);
-
-                    sidebarObjective.getScore(ScoreboardManager.LABEL_CURRENT_XP)
-                            .setScore(currentXP);
-                    sidebarObjective.getScore(ScoreboardManager.LABEL_REMAINING_XP)
-                            .setScore(mmoPlayer.getXpToLevel(targetSkill) - currentXP);
-                } else {
-                    for (PrimarySkillType parentSkill : mcMMO.p.getSkillTools()
-                            .getChildSkillParents(targetSkill)) {
-                        sidebarObjective.getScore(ScoreboardManager.skillLabels.get(parentSkill))
-                                .setScore(mmoPlayer.getSkillLevel(parentSkill));
-                    }
-                }
-
-                sidebarObjective.getScore(ScoreboardManager.LABEL_LEVEL)
-                        .setScore(mmoPlayer.getSkillLevel(targetSkill));
-
-                if (mcMMO.p.getSkillTools().getSuperAbility(targetSkill) != null) {
-                    boolean stopUpdating;
-
-                    if (targetSkill == PrimarySkillType.MINING) {
-                        // Special-Case: Mining has two abilities, both with cooldowns
-                        Score cooldownSB = sidebarObjective.getScore(
-                                ScoreboardManager.abilityLabelsSkill.get(
-                                        SuperAbilityType.SUPER_BREAKER));
-                        Score cooldownBM = sidebarObjective.getScore(
-                                ScoreboardManager.abilityLabelsSkill.get(
-                                        SuperAbilityType.BLAST_MINING));
-                        int secondsSB = Math.max(
-                                mmoPlayer.calculateTimeRemaining(SuperAbilityType.SUPER_BREAKER),
-                                0);
-                        int secondsBM = Math.max(
-                                mmoPlayer.calculateTimeRemaining(SuperAbilityType.BLAST_MINING), 0);
-
-                        cooldownSB.setScore(secondsSB);
-                        cooldownBM.setScore(secondsBM);
-
-                        stopUpdating = (secondsSB == 0 && secondsBM == 0);
-                    } else {
-                        SuperAbilityType ability = mcMMO.p.getSkillTools()
-                                .getSuperAbility(targetSkill);
-                        Score cooldown = sidebarObjective.getScore(
-                                ScoreboardManager.abilityLabelsSkill.get(ability));
-                        int seconds = Math.max(mmoPlayer.calculateTimeRemaining(ability), 0);
-
-                        cooldown.setScore(seconds);
-
-                        stopUpdating = seconds == 0;
-                    }
-
-                    if (stopUpdating) {
-                        stopCooldownUpdating();
-                    } else {
-                        startCooldownUpdating();
-                    }
-                }
+                renderSkill(player, mmoPlayer, lines);
                 break;
 
             case COOLDOWNS_BOARD:
-                boolean anyCooldownsActive = false;
-
-                for (SuperAbilityType ability : SuperAbilityType.values()) {
-                    int seconds = Math.max(mmoPlayer.calculateTimeRemaining(ability), 0);
-
-                    if (seconds != 0) {
-                        anyCooldownsActive = true;
-                    }
-
-                    sidebarObjective.getScore(ScoreboardManager.abilityLabelsColored.get(ability))
-                            .setScore(seconds);
-                }
-
-                if (anyCooldownsActive) {
-                    startCooldownUpdating();
-                } else {
-                    stopCooldownUpdating();
-                }
+                renderCooldowns(mmoPlayer, lines);
                 break;
 
             case STATS_BOARD:
-                // Select the profile to read from
-                PlayerProfile newProfile;
-
-                if (targetProfile != null) {
-                    newProfile = targetProfile; // offline
-                } else if (targetPlayer == null) {
-                    newProfile = mmoPlayer.getProfile(); // self
-                } else {
-                    newProfile = UserManager.getPlayer(targetPlayer).getProfile(); // online
-                }
-
-                // Calculate power level here
-                int powerLevel = 0;
-                for (PrimarySkillType skill : SkillTools.NON_CHILD_SKILLS) { // Don't include child skills, makes the list too long
-                    int level = newProfile.getSkillLevel(skill);
-
-                    powerLevel += level;
-
-                    // TODO: Verify that this is what we want - calculated in power level but not displayed
-                    if (!mcMMO.p.getSkillTools().doesPlayerHaveSkillPermission(player, skill)) {
-                        continue;
-                    }
-
-                    sidebarObjective.getScore(ScoreboardManager.skillLabels.get(skill))
-                            .setScore(level);
-                }
-
-                sidebarObjective.getScore(ScoreboardManager.LABEL_POWER_LEVEL).setScore(powerLevel);
+                renderStats(player, mmoPlayer, lines);
                 break;
 
             case RANK_BOARD:
+                renderRank(player, lines);
+                break;
+
             case TOP_BOARD:
-                /*
-                 * @see #acceptRankData(Map<PrimarySkillType, Integer> rank)
-                 * @see #acceptLeaderboardData(List<PlayerStat> stats)
-                 */
+                renderLeaderboard(lines);
                 break;
 
             default:
                 break;
         }
+
+        drawLines(lines);
     }
 
-    public void acceptRankData(Map<PrimarySkillType, Integer> rankData) {
-        Integer rank;
-        Player player = mcMMO.p.getServer().getPlayerExact(playerName);
+    private void renderSkill(Player player, McMMOPlayer mmoPlayer, List<SidebarLine> lines) {
+        if (!SkillTools.isChildSkill(targetSkill)) {
+            int currentXP = mmoPlayer.getSkillXpLevel(targetSkill);
+            lines.add(new SidebarLine(ScoreboardManager.LABEL_LEVEL,
+                    mmoPlayer.getSkillLevel(targetSkill)));
+            lines.add(new SidebarLine(ScoreboardManager.LABEL_CURRENT_XP, currentXP));
+            lines.add(new SidebarLine(ScoreboardManager.LABEL_REMAINING_XP,
+                    mmoPlayer.getXpToLevel(targetSkill) - currentXP));
+        } else {
+            for (PrimarySkillType parentSkill : mcMMO.p.getSkillTools()
+                    .getChildSkillParents(targetSkill)) {
+                lines.add(new SidebarLine(ScoreboardManager.skillLabels.get(parentSkill),
+                        mmoPlayer.getSkillLevel(parentSkill)));
+            }
+            lines.add(new SidebarLine(ScoreboardManager.LABEL_LEVEL,
+                    mmoPlayer.getSkillLevel(targetSkill)));
+        }
+
+        if (mcMMO.p.getSkillTools().getSuperAbility(targetSkill) != null) {
+            boolean stopUpdating;
+
+            if (targetSkill == PrimarySkillType.MINING) {
+                // Special-Case: Mining has two abilities, both with cooldowns
+                int secondsSB = Math.max(
+                        mmoPlayer.calculateTimeRemaining(SuperAbilityType.SUPER_BREAKER), 0);
+                int secondsBM = Math.max(
+                        mmoPlayer.calculateTimeRemaining(SuperAbilityType.BLAST_MINING), 0);
+
+                lines.add(new SidebarLine(
+                        ScoreboardManager.abilityLabelsSkill.get(SuperAbilityType.SUPER_BREAKER),
+                        secondsSB));
+                lines.add(new SidebarLine(
+                        ScoreboardManager.abilityLabelsSkill.get(SuperAbilityType.BLAST_MINING),
+                        secondsBM));
+
+                stopUpdating = (secondsSB == 0 && secondsBM == 0);
+            } else {
+                SuperAbilityType ability = mcMMO.p.getSkillTools().getSuperAbility(targetSkill);
+                int seconds = Math.max(mmoPlayer.calculateTimeRemaining(ability), 0);
+
+                lines.add(new SidebarLine(ScoreboardManager.abilityLabelsSkill.get(ability),
+                        seconds));
+
+                stopUpdating = seconds == 0;
+            }
+
+            if (stopUpdating) {
+                stopCooldownUpdating();
+            } else {
+                startCooldownUpdating();
+            }
+        }
+    }
+
+    private void renderCooldowns(McMMOPlayer mmoPlayer, List<SidebarLine> lines) {
+        boolean anyCooldownsActive = false;
+
+        for (SuperAbilityType ability : SuperAbilityType.values()) {
+            int seconds = Math.max(mmoPlayer.calculateTimeRemaining(ability), 0);
+
+            if (seconds != 0) {
+                anyCooldownsActive = true;
+            }
+
+            lines.add(new SidebarLine(ScoreboardManager.abilityLabelsColored.get(ability), seconds));
+        }
+
+        if (anyCooldownsActive) {
+            startCooldownUpdating();
+        } else {
+            stopCooldownUpdating();
+        }
+    }
+
+    private void renderStats(Player player, McMMOPlayer mmoPlayer, List<SidebarLine> lines) {
+        // Select the profile to read from
+        PlayerProfile newProfile;
+
+        if (targetProfile != null) {
+            newProfile = targetProfile; // offline
+        } else if (targetPlayer == null) {
+            newProfile = mmoPlayer.getProfile(); // self
+        } else {
+            newProfile = UserManager.getPlayer(targetPlayer).getProfile(); // online
+        }
+
+        int powerLevel = 0;
+        // Don't include child skills, makes the list too long
+        for (PrimarySkillType skill : SkillTools.NON_CHILD_SKILLS) {
+            int level = newProfile.getSkillLevel(skill);
+            powerLevel += level;
+
+            if (!mcMMO.p.getSkillTools().doesPlayerHaveSkillPermission(player, skill)) {
+                continue;
+            }
+
+            lines.add(new SidebarLine(ScoreboardManager.skillLabels.get(skill), level));
+        }
+
+        // Sort skills by level descending to mirror the old score-sorted Bukkit board
+        lines.sort((a, b) -> Integer.compare(b.value(), a.value()));
+        lines.add(new SidebarLine(ScoreboardManager.LABEL_POWER_LEVEL, powerLevel));
+    }
+
+    private void renderRank(Player player, List<SidebarLine> lines) {
+        if (rankData == null) {
+            return;
+        }
 
         for (PrimarySkillType skill : SkillTools.NON_CHILD_SKILLS) {
             if (!mcMMO.p.getSkillTools().doesPlayerHaveSkillPermission(player, skill)) {
                 continue;
             }
 
-            rank = rankData.get(skill);
-
+            Integer rank = rankData.get(skill);
             if (rank != null) {
-                sidebarObjective.getScore(ScoreboardManager.skillLabels.get(skill)).setScore(rank);
+                lines.add(new SidebarLine(ScoreboardManager.skillLabels.get(skill), rank));
             }
         }
 
-        rank = rankData.get(null);
-
-        if (rank != null) {
-            sidebarObjective.getScore(ScoreboardManager.LABEL_POWER_LEVEL).setScore(rank);
+        Integer powerRank = rankData.get(null);
+        if (powerRank != null) {
+            lines.add(new SidebarLine(ScoreboardManager.LABEL_POWER_LEVEL, powerRank));
         }
     }
 
-    public void acceptLeaderboardData(@NotNull List<PlayerStat> leaderboardData) {
+    private void renderLeaderboard(List<SidebarLine> lines) {
+        if (leaderboardData == null) {
+            return;
+        }
+
         for (PlayerStat stat : leaderboardData) {
             String name = stat.playerName();
 
@@ -661,11 +643,20 @@ public class ScoreboardWrapper {
                 name = ChatColor.GOLD + "--You--";
             }
 
-            sidebarObjective.getScore(name).setScore(stat.value());
+            lines.add(new SidebarLine(name, stat.value()));
         }
+
+        // Highest score at the top
+        lines.sort((a, b) -> Integer.compare(b.value(), a.value()));
     }
 
-    public void updatePowerLevel(Player player, int newPowerLevel) {
-        powerObjective.getScore(player.getName()).setScore(newPowerLevel);
+    public void acceptRankData(Map<PrimarySkillType, Integer> rankData) {
+        this.rankData = rankData;
+        render();
+    }
+
+    public void acceptLeaderboardData(@NotNull List<PlayerStat> leaderboardData) {
+        this.leaderboardData = leaderboardData;
+        render();
     }
 }

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/BukkitPlayerBoard.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/BukkitPlayerBoard.java
@@ -1,0 +1,175 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import com.gmail.nossr50.events.scoreboard.McMMOScoreboardObjectiveEvent;
+import com.gmail.nossr50.events.scoreboard.ScoreboardEventReason;
+import com.gmail.nossr50.events.scoreboard.ScoreboardObjectiveEventReason;
+import com.gmail.nossr50.locale.LocaleLoader;
+import com.gmail.nossr50.mcMMO;
+import com.gmail.nossr50.util.player.UserManager;
+import com.gmail.nossr50.datatypes.player.McMMOPlayer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BukkitPlayerBoard implements PlayerBoard {
+    private static final String SIDEBAR_OBJECTIVE = "mcmmo_sidebar";
+    private static final String SIDE_OBJECTIVE = "mcMMO_sideObjective";
+    private static final String POWER_OBJECTIVE = "mcmmo_pwrlvl";
+
+    private final @NotNull Player owner;
+    private @NotNull Scoreboard scoreboard;
+    private final Set<String> renderedEntries;
+    private @Nullable Objective sidebarObjective;
+    private @Nullable Objective powerObjective;
+
+    public BukkitPlayerBoard(final @NotNull Player owner, final @NotNull Scoreboard scoreboard) {
+        this.owner = owner;
+        this.scoreboard = scoreboard;
+        this.renderedEntries = new HashSet<>();
+        this.sidebarObjective = scoreboard.getObjective(SIDEBAR_OBJECTIVE);
+        this.powerObjective = null;
+        setupPowerObjectiveIfEnabled();
+    }
+
+    @Override
+    public @Nullable Scoreboard show() {
+        final Scoreboard previousBoard = owner.getScoreboard();
+        owner.setScoreboard(scoreboard);
+        return previousBoard;
+    }
+
+    @Override
+    public void hide(final @NotNull Player targetPlayer, final @Nullable Scoreboard targetBoard) {
+        if (targetBoard != null) {
+            targetPlayer.setScoreboard(targetBoard);
+            return;
+        }
+
+        if (Bukkit.getScoreboardManager() != null) {
+            targetPlayer.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+        }
+    }
+
+    @Override
+    public boolean isShown() {
+        return owner.getScoreboard() == scoreboard;
+    }
+
+    @Override
+    public void setTitle(final @NotNull String displayName) {
+        final McMMOScoreboardObjectiveEvent unregisterEvent = callObjectiveEvent(
+                ScoreboardObjectiveEventReason.UNREGISTER_THIS_OBJECTIVE);
+        if (!unregisterEvent.isCancelled() && sidebarObjective != null) {
+            try {
+                sidebarObjective.unregister();
+            } catch (IllegalStateException e) {
+                mcMMO.p.getLogger().fine("Ignoring stale sidebar objective while updating bukkit scoreboard for "
+                        + owner.getName() + ": " + e.getMessage());
+            }
+        }
+
+        final McMMOScoreboardObjectiveEvent registerEvent = callObjectiveEvent(
+                ScoreboardObjectiveEventReason.REGISTER_NEW_OBJECTIVE);
+
+        if (!registerEvent.isCancelled()) {
+            scoreboard = registerEvent.getTargetBoard();
+            Objective existingObjective = scoreboard.getObjective(SIDEBAR_OBJECTIVE);
+
+            if (existingObjective != null) {
+                try {
+                    existingObjective.unregister();
+                } catch (IllegalStateException e) {
+                    mcMMO.p.getLogger().fine("Ignoring stale existing objective while replacing bukkit scoreboard for "
+                            + owner.getName() + ": " + e.getMessage());
+                }
+            }
+
+            sidebarObjective = scoreboard.registerNewObjective(SIDEBAR_OBJECTIVE, "dummy", SIDE_OBJECTIVE);
+        }
+
+        if (sidebarObjective == null) {
+            return;
+        }
+
+        final String safeDisplayName = displayName.length() > 32
+                ? displayName.substring(0, 32)
+                : displayName;
+        sidebarObjective.setDisplayName(safeDisplayName);
+        sidebarObjective.setDisplaySlot(DisplaySlot.SIDEBAR);
+        resetRenderedEntries();
+    }
+
+    @Override
+    public void draw(final @NotNull List<SidebarLine> lines) {
+        if (sidebarObjective == null) {
+            return;
+        }
+
+        resetRenderedEntries();
+        final int count = Math.min(lines.size(), 15);
+        for (int i = 0; i < count; i++) {
+            final SidebarLine line = lines.get(i);
+            sidebarObjective.getScore(line.label()).setScore(line.value());
+            renderedEntries.add(line.label());
+        }
+    }
+
+    public void updatePowerLevel(final @NotNull String playerName, final int powerLevel) {
+        if (powerObjective != null) {
+            powerObjective.getScore(playerName).setScore(powerLevel);
+        }
+    }
+
+    private @NotNull McMMOScoreboardObjectiveEvent callObjectiveEvent(
+            final @NotNull ScoreboardObjectiveEventReason reason) {
+        final McMMOScoreboardObjectiveEvent event = new McMMOScoreboardObjectiveEvent(
+                sidebarObjective,
+                reason,
+                scoreboard,
+                scoreboard,
+                owner,
+                ScoreboardEventReason.OBJECTIVE);
+        owner.getServer().getPluginManager().callEvent(event);
+        return event;
+    }
+
+    private void resetRenderedEntries() {
+        for (String entry : renderedEntries) {
+            scoreboard.resetScores(entry);
+        }
+        renderedEntries.clear();
+    }
+
+    private void setupPowerObjectiveIfEnabled() {
+        if (!mcMMO.p.getGeneralConfig().getPowerLevelTagsEnabled()) {
+            return;
+        }
+
+        Objective existingPowerObjective = scoreboard.getObjective(POWER_OBJECTIVE);
+        if (existingPowerObjective == null) {
+            existingPowerObjective = scoreboard.registerNewObjective(POWER_OBJECTIVE, "dummy", "mcMMO_powerObjective");
+        }
+
+        existingPowerObjective.setDisplayName(LocaleLoader.getString("Scoreboard.Header.PowerLevel"));
+        existingPowerObjective.setDisplaySlot(DisplaySlot.BELOW_NAME);
+
+        for (McMMOPlayer mmoPlayer : UserManager.getPlayers()) {
+            existingPowerObjective.getScore(mmoPlayer.getProfile().getPlayerName())
+                    .setScore(mmoPlayer.getPowerLevel());
+        }
+
+        this.powerObjective = existingPowerObjective;
+    }
+
+    @Override
+    public void close() {
+        renderedEntries.clear();
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/BukkitScoreboardBackend.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/BukkitScoreboardBackend.java
@@ -1,0 +1,160 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import com.gmail.nossr50.mcMMO;
+import com.gmail.nossr50.util.LogUtils;
+import com.gmail.nossr50.locale.LocaleLoader;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import net.megavex.scoreboardlibrary.api.objective.ScoreboardObjective;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BukkitScoreboardBackend implements ScoreboardBackend {
+    // Fixed name for compatibility: this objective lives on the main scoreboard, which is
+    // persisted to the world's scoreboard data. Reusing the historical name means servers
+    // upgrading from older mcMMO builds keep their existing objective instead of accumulating
+    // orphans after crashes or restarts.
+    private static final String POWER_OBJECTIVE = "mcmmo_pwrlvl";
+    private static final String DISPLAY_NAME = "powerLevel";
+
+    private final Map<String, BukkitPlayerBoard> activeBoards = new ConcurrentHashMap<>();
+    private @Nullable Objective powerObjective;
+
+    @Override
+    public @NotNull ScoreboardBackendType getType() {
+        return ScoreboardBackendType.BUKKIT;
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public @NotNull Scoreboard createEventTargetBoard(final @NotNull Player player) {
+        final ScoreboardManager scoreboardManager = Bukkit.getScoreboardManager();
+        if (scoreboardManager == null) {
+            return player.getScoreboard();
+        }
+        return scoreboardManager.getNewScoreboard();
+    }
+
+    @Override
+    public @NotNull PlayerBoard createPlayerBoard(final @NotNull Player player,
+            final @NotNull Scoreboard eventTargetBoard) {
+        final BukkitPlayerBoard playerBoard = new BukkitPlayerBoard(player, eventTargetBoard);
+        activeBoards.put(player.getName(), playerBoard);
+        return playerBoard;
+    }
+
+    @Override
+    public void setupPowerLevelTag(final @NotNull Player player) {
+        // No action required. BukkitPlayerBoard creates its local below-name objective during setup.
+    }
+
+    @Override
+    public void removePowerLevelTag(final @NotNull Player player) {
+        final Objective objective = getOrCreatePowerObjective();
+
+        if (objective != null) {
+            objective.getScoreboard().resetScores(player.getName());
+        }
+    }
+
+    @Override
+    public void setPowerLevel(final @NotNull String playerName, final int powerLevel) {
+        final Objective objective = getOrCreatePowerObjective();
+
+        if (objective != null) {
+            objective.getScore(playerName).setScore(powerLevel);
+        }
+
+        for (BukkitPlayerBoard board : activeBoards.values()) {
+            board.updatePowerLevel(playerName, powerLevel);
+        }
+    }
+
+    @Override
+    public boolean isPowerLevelTagActive() {
+        return getOrCreatePowerObjective() != null;
+    }
+
+    @Override
+    public void onPlayerBoardClosed(final @NotNull String playerName) {
+        activeBoards.remove(playerName);
+    }
+
+    @Override
+    public @Nullable ScoreboardObjective getPacketPowerLevelObjective() {
+        return null;
+    }
+
+    private @Nullable Objective getOrCreatePowerObjective() {
+        if (!mcMMO.p.getGeneralConfig().getPowerLevelTagsEnabled()) {
+            unregisterLeftoverPowerObjective();
+            powerObjective = null;
+            return null;
+        }
+
+        final ScoreboardManager scoreboardManager = Bukkit.getScoreboardManager();
+        if (scoreboardManager == null) {
+            return null;
+        }
+
+        final Scoreboard mainScoreboard = scoreboardManager.getMainScoreboard();
+        Objective objective = mainScoreboard.getObjective(POWER_OBJECTIVE);
+
+        if (objective == null) {
+            objective = mainScoreboard.registerNewObjective(POWER_OBJECTIVE, "dummy", DISPLAY_NAME);
+            objective.setDisplayName(LocaleLoader.getString("Scoreboard.Header.PowerLevel"));
+            objective.setDisplaySlot(DisplaySlot.BELOW_NAME);
+        }
+
+        powerObjective = objective;
+        return objective;
+    }
+
+    /**
+     * Unregisters the power level objective from the main scoreboard, including a leftover
+     * objective persisted in the world's scoreboard data from a previous run.
+     */
+    private void unregisterLeftoverPowerObjective() {
+        final ScoreboardManager scoreboardManager = Bukkit.getScoreboardManager();
+        if (scoreboardManager == null) {
+            return;
+        }
+
+        final Objective leftoverObjective = scoreboardManager.getMainScoreboard()
+                .getObjective(POWER_OBJECTIVE);
+        if (leftoverObjective != null) {
+            try {
+                leftoverObjective.unregister();
+                LogUtils.debug(mcMMO.p.getLogger(),
+                        "Removed leftover power level objective from the main scoreboard.");
+            } catch (IllegalStateException ignored) {
+            }
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        for (BukkitPlayerBoard board : activeBoards.values()) {
+            board.close();
+        }
+        activeBoards.clear();
+
+        if (powerObjective != null) {
+            try {
+                powerObjective.unregister();
+            } catch (IllegalStateException e) {
+                LogUtils.debug(mcMMO.p.getLogger(), "Power objective was already unregistered.");
+            }
+        }
+        powerObjective = null;
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/NoopPlayerBoard.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/NoopPlayerBoard.java
@@ -1,0 +1,38 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import java.util.List;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class NoopPlayerBoard implements PlayerBoard {
+    public NoopPlayerBoard(final @NotNull Player player) {
+    }
+
+    @Override
+    public @Nullable Scoreboard show() {
+        return null;
+    }
+
+    @Override
+    public void hide(final @NotNull Player targetPlayer, final @Nullable Scoreboard targetBoard) {
+    }
+
+    @Override
+    public boolean isShown() {
+        return false;
+    }
+
+    @Override
+    public void setTitle(final @NotNull String displayName) {
+    }
+
+    @Override
+    public void draw(final @NotNull List<SidebarLine> lines) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/NoopScoreboardBackend.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/NoopScoreboardBackend.java
@@ -1,0 +1,59 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import net.megavex.scoreboardlibrary.api.objective.ScoreboardObjective;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class NoopScoreboardBackend implements ScoreboardBackend {
+    @Override
+    public @NotNull ScoreboardBackendType getType() {
+        return ScoreboardBackendType.NOOP;
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public @NotNull Scoreboard createEventTargetBoard(final @NotNull Player player) {
+        return player.getScoreboard();
+    }
+
+    @Override
+    public @NotNull PlayerBoard createPlayerBoard(final @NotNull Player player,
+            final @NotNull Scoreboard eventTargetBoard) {
+        return new NoopPlayerBoard(player);
+    }
+
+    @Override
+    public void setupPowerLevelTag(final @NotNull Player player) {
+    }
+
+    @Override
+    public void removePowerLevelTag(final @NotNull Player player) {
+    }
+
+    @Override
+    public void setPowerLevel(final @NotNull String playerName, final int powerLevel) {
+    }
+
+    @Override
+    public boolean isPowerLevelTagActive() {
+        return false;
+    }
+
+    @Override
+    public void onPlayerBoardClosed(final @NotNull String playerName) {
+    }
+
+    @Override
+    public @Nullable ScoreboardObjective getPacketPowerLevelObjective() {
+        return null;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/PacketPlayerBoard.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/PacketPlayerBoard.java
@@ -1,0 +1,66 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.megavex.scoreboardlibrary.api.objective.ScoreFormat;
+import net.megavex.scoreboardlibrary.api.sidebar.Sidebar;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PacketPlayerBoard implements PlayerBoard {
+    private final @NotNull Player owner;
+    private final @NotNull Sidebar sidebar;
+    private final LegacyComponentSerializer serializer = LegacyComponentSerializer.legacySection();
+
+    public PacketPlayerBoard(final @NotNull Player owner, final @NotNull Sidebar sidebar) {
+        this.owner = owner;
+        this.sidebar = sidebar;
+    }
+
+    @Override
+    public @Nullable Scoreboard show() {
+        sidebar.addPlayer(owner);
+        return null;
+    }
+
+    @Override
+    public void hide(final @NotNull Player targetPlayer, final @Nullable Scoreboard targetBoard) {
+        sidebar.removePlayer(targetPlayer);
+    }
+
+    @Override
+    public boolean isShown() {
+        return sidebar.players().contains(owner);
+    }
+
+    @Override
+    public void setTitle(final @NotNull String displayName) {
+        final String safeDisplayName = displayName.length() > 32
+                ? displayName.substring(0, 32)
+                : displayName;
+        sidebar.title(serializer.deserialize(safeDisplayName));
+    }
+
+    @Override
+    public void draw(final @NotNull List<SidebarLine> lines) {
+        final int count = Math.min(lines.size(), Sidebar.MAX_LINES);
+        sidebar.clearLines();
+
+        for (int i = 0; i < count; i++) {
+            final SidebarLine line = lines.get(i);
+            final Component component = serializer.deserialize(line.label() == null ? "" : line.label());
+            sidebar.line(i, component, ScoreFormat.fixed(Component.text(line.value(), NamedTextColor.RED)));
+        }
+    }
+
+    @Override
+    public void close() {
+        if (!sidebar.closed()) {
+            sidebar.close();
+        }
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/PacketScoreboardBackend.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/PacketScoreboardBackend.java
@@ -1,0 +1,158 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import com.gmail.nossr50.locale.LocaleLoader;
+import com.gmail.nossr50.mcMMO;
+import java.util.ArrayList;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.megavex.scoreboardlibrary.api.ScoreboardLibrary;
+import net.megavex.scoreboardlibrary.api.exception.NoPacketAdapterAvailableException;
+import net.megavex.scoreboardlibrary.api.objective.ObjectiveDisplaySlot;
+import net.megavex.scoreboardlibrary.api.objective.ObjectiveManager;
+import net.megavex.scoreboardlibrary.api.objective.ScoreboardObjective;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PacketScoreboardBackend implements ScoreboardBackend {
+    private static final LegacyComponentSerializer LEGACY = LegacyComponentSerializer.legacySection();
+    // Randomized per server start so it can never collide with a leftover objective of the same
+    // name on a client - e.g. the old Bukkit implementation's 'mcmmo_pwrlvl' lingering after an
+    // in-place upgrade, or another plugin's objective. Nothing is persisted server-side, so a
+    // fresh name each startup leaves no orphans behind. Kept within 16 chars ("mcmmo_pwr_" (10)
+    // + 5 hex = 15): Java 1.18 (21w37a) removed the objective name length cap, but older
+    // clients connecting through ViaVersion still enforce it.
+    private static final String POWER_OBJECTIVE = "mcmmo_pwr_" + java.util.UUID.randomUUID()
+            .toString().replace("-", "").substring(0, 5);
+
+    private @Nullable ScoreboardLibrary scoreboardLibrary;
+    private @Nullable ObjectiveManager powerLevelObjectiveManager;
+    private @Nullable ScoreboardObjective powerLevelObjective;
+
+    @Override
+    public @NotNull ScoreboardBackendType getType() {
+        return ScoreboardBackendType.PACKET;
+    }
+
+    @Override
+    public void init() {
+        try {
+            scoreboardLibrary = ScoreboardLibrary.loadScoreboardLibrary(mcMMO.p);
+        } catch (NoPacketAdapterAvailableException e) {
+            throw new RuntimeException("No packet adapter available for scoreboard-library", e);
+        }
+    }
+
+    @Override
+    public @NotNull Scoreboard createEventTargetBoard(final @NotNull Player player) {
+        return player.getScoreboard();
+    }
+
+    @Override
+    public @NotNull PlayerBoard createPlayerBoard(final @NotNull Player player,
+            final @NotNull Scoreboard eventTargetBoard) {
+        if (scoreboardLibrary == null || scoreboardLibrary.closed()) {
+            return new NoopPlayerBoard(player);
+        }
+
+        return new PacketPlayerBoard(player, scoreboardLibrary.createSidebar(15));
+    }
+
+    @Override
+    public void setupPowerLevelTag(final @NotNull Player player) {
+        final ScoreboardObjective objective = getOrCreatePowerLevelObjective();
+
+        if (objective == null || powerLevelObjectiveManager == null || powerLevelObjectiveManager.closed()) {
+            return;
+        }
+
+        powerLevelObjectiveManager.addPlayer(player);
+    }
+
+    @Override
+    public void removePowerLevelTag(final @NotNull Player player) {
+        if (powerLevelObjectiveManager == null || powerLevelObjectiveManager.closed()) {
+            return;
+        }
+
+        // removePlayer() needs a live connection; skipping it when the player has already
+        // disconnected avoids an NPE in scoreboard-library's async tick (weak-key playerMap
+        // GC race).
+        if (player.isOnline()) {
+            powerLevelObjectiveManager.removePlayer(player);
+        }
+
+        // Score removal is name-based and safe for offline players; always run it so departed
+        // players don't accumulate in the objective's score map and flood joining players with
+        // a large initial packet burst.
+        if (powerLevelObjective != null) {
+            powerLevelObjective.removeScore(player.getName());
+        }
+    }
+
+    @Override
+    public void setPowerLevel(final @NotNull String playerName, final int powerLevel) {
+        final ScoreboardObjective objective = getOrCreatePowerLevelObjective();
+
+        if (objective != null) {
+            objective.score(playerName, powerLevel);
+        }
+    }
+
+    @Override
+    public boolean isPowerLevelTagActive() {
+        return getOrCreatePowerLevelObjective() != null;
+    }
+
+    @Override
+    public void onPlayerBoardClosed(final @NotNull String playerName) {
+    }
+
+    @Override
+    public @Nullable ScoreboardObjective getPacketPowerLevelObjective() {
+        return getOrCreatePowerLevelObjective();
+    }
+
+    private @Nullable ScoreboardObjective getOrCreatePowerLevelObjective() {
+        if (!mcMMO.p.getGeneralConfig().getPowerLevelTagsEnabled()) {
+            if (powerLevelObjectiveManager != null && !powerLevelObjectiveManager.closed()) {
+                powerLevelObjectiveManager.close();
+            }
+
+            powerLevelObjectiveManager = null;
+            powerLevelObjective = null;
+            return null;
+        }
+
+        if (scoreboardLibrary == null || scoreboardLibrary.closed()) {
+            return null;
+        }
+
+        if (powerLevelObjectiveManager == null || powerLevelObjectiveManager.closed()) {
+            powerLevelObjectiveManager = scoreboardLibrary.createObjectiveManager();
+            powerLevelObjective = powerLevelObjectiveManager.create(POWER_OBJECTIVE);
+            powerLevelObjective.value(LEGACY.deserialize(
+                    LocaleLoader.getString("Scoreboard.Header.PowerLevel")));
+            powerLevelObjectiveManager.display(ObjectiveDisplaySlot.belowName(), powerLevelObjective);
+            powerLevelObjectiveManager.addPlayers(new ArrayList<>(mcMMO.p.getServer().getOnlinePlayers()));
+        }
+
+        return powerLevelObjective;
+    }
+
+    @Override
+    public void shutdown() {
+        if (powerLevelObjectiveManager != null && !powerLevelObjectiveManager.closed()) {
+            powerLevelObjectiveManager.close();
+        }
+
+        powerLevelObjectiveManager = null;
+        powerLevelObjective = null;
+
+        if (scoreboardLibrary != null && !scoreboardLibrary.closed()) {
+            scoreboardLibrary.close();
+        }
+
+        scoreboardLibrary = null;
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/PlayerBoard.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/PlayerBoard.java
@@ -1,0 +1,21 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import java.util.List;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface PlayerBoard {
+    @Nullable Scoreboard show();
+
+    void hide(@NotNull Player targetPlayer, @Nullable Scoreboard targetBoard);
+
+    boolean isShown();
+
+    void setTitle(@NotNull String displayName);
+
+    void draw(@NotNull List<SidebarLine> lines);
+
+    void close();
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackend.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackend.java
@@ -1,0 +1,31 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import net.megavex.scoreboardlibrary.api.objective.ScoreboardObjective;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface ScoreboardBackend {
+    @NotNull ScoreboardBackendType getType();
+
+    void init();
+
+    @NotNull Scoreboard createEventTargetBoard(@NotNull Player player);
+
+    @NotNull PlayerBoard createPlayerBoard(@NotNull Player player, @NotNull Scoreboard eventTargetBoard);
+
+    void setupPowerLevelTag(@NotNull Player player);
+
+    void removePowerLevelTag(@NotNull Player player);
+
+    void setPowerLevel(@NotNull String playerName, int powerLevel);
+
+    boolean isPowerLevelTagActive();
+
+    void onPlayerBoardClosed(@NotNull String playerName);
+
+    @Nullable ScoreboardObjective getPacketPowerLevelObjective();
+
+    void shutdown();
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackendSelector.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackendSelector.java
@@ -1,0 +1,37 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import com.gmail.nossr50.util.platform.MinecraftGameVersion;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+public final class ScoreboardBackendSelector {
+    // Highest Minecraft release line verified against the bundled scoreboard-library version.
+    // The whole patch line is allowed (e.g. 26.2.1) since patch releases do not change
+    // scoreboard packets; scoreboard-library also probes unmarked versions at init and mcMMO
+    // falls back to the no-op backend if that probe fails.
+    public static final int MAX_PACKET_MAJOR = 26;
+    public static final int MAX_PACKET_MINOR = 2;
+    public static final String MAX_PACKET_VERSION_STRING = "26.2.x";
+
+    private ScoreboardBackendSelector() {
+    }
+
+    public static @NotNull ScoreboardBackendType select(final boolean isFolia,
+            final @NotNull MinecraftGameVersion version) {
+        final MinecraftGameVersion gameVersion = Objects.requireNonNull(version,
+                "version cannot be null");
+
+        if (!isFolia) {
+            return ScoreboardBackendType.BUKKIT;
+        }
+
+        final boolean versionWithinPacketSupport = !gameVersion.isAtLeast(
+                MAX_PACKET_MAJOR,
+                MAX_PACKET_MINOR + 1,
+                0);
+
+        return versionWithinPacketSupport
+                ? ScoreboardBackendType.PACKET
+                : ScoreboardBackendType.NOOP;
+    }
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackendType.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackendType.java
@@ -1,0 +1,7 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+public enum ScoreboardBackendType {
+    BUKKIT,
+    PACKET,
+    NOOP
+}

--- a/src/main/java/com/gmail/nossr50/util/scoreboards/backend/SidebarLine.java
+++ b/src/main/java/com/gmail/nossr50/util/scoreboards/backend/SidebarLine.java
@@ -1,0 +1,4 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+public record SidebarLine(String label, int value) {
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,7 +14,7 @@ author: nossr50
 authors: [ GJ, NuclearW, bm01, Glitchfinder, TfT_02, t00thpick1, Riking, electronicboy, kashike ]
 website: https://www.mcmmo.org
 main: com.gmail.nossr50.mcMMO
-softdepend: [ WorldGuard, CombatTag, HealthBar, PlaceholderAPI, ProtocolLib ]
+softdepend: [ WorldGuard, CombatTag, HealthBar, PlaceholderAPI, ProtocolLib, ViaVersion ]
 load: POSTWORLD
 folia-supported: true
 api-version: 1.20.5

--- a/src/test/java/com/gmail/nossr50/util/scoreboards/backend/NoopScoreboardBackendTest.java
+++ b/src/test/java/com/gmail/nossr50/util/scoreboards/backend/NoopScoreboardBackendTest.java
@@ -1,0 +1,35 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.junit.jupiter.api.Test;
+
+class NoopScoreboardBackendTest {
+    @Test
+    void noopBackendMethodsShouldBeSafeNoOps() {
+        // Given - A noop backend with a mocked player and scoreboard
+        final NoopScoreboardBackend backend = new NoopScoreboardBackend();
+        final Player player = mock(Player.class);
+        final Scoreboard scoreboard = mock(Scoreboard.class);
+        when(player.getScoreboard()).thenReturn(scoreboard);
+
+        // When - Running no-op operations
+        backend.init();
+        final PlayerBoard playerBoard = backend.createPlayerBoard(player, scoreboard);
+
+        // Then - No operation throws and all expected no-op values are returned
+        assertThatCode(() -> playerBoard.setTitle("test")).doesNotThrowAnyException();
+        assertThatCode(() -> playerBoard.draw(java.util.List.of())).doesNotThrowAnyException();
+        assertThatCode(() -> playerBoard.show()).doesNotThrowAnyException();
+        assertThatCode(() -> playerBoard.hide(player, scoreboard)).doesNotThrowAnyException();
+        assertThatCode(playerBoard::close).doesNotThrowAnyException();
+        assertThat(playerBoard.isShown()).isFalse();
+        assertThat(backend.isPowerLevelTagActive()).isFalse();
+        assertThat(backend.getPacketPowerLevelObjective()).isNull();
+    }
+}

--- a/src/test/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackendSelectorTest.java
+++ b/src/test/java/com/gmail/nossr50/util/scoreboards/backend/ScoreboardBackendSelectorTest.java
@@ -1,0 +1,76 @@
+package com.gmail.nossr50.util.scoreboards.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gmail.nossr50.util.platform.MinecraftGameVersion;
+import org.junit.jupiter.api.Test;
+
+class ScoreboardBackendSelectorTest {
+    @Test
+    void selectShouldReturnBukkitWhenServerIsNotFolia() {
+        // Given - A non-Folia server with any version
+        final MinecraftGameVersion gameVersion = new MinecraftGameVersion(99, 9, 9);
+
+        // When - Selecting a backend
+        final ScoreboardBackendType backendType = ScoreboardBackendSelector.select(false, gameVersion);
+
+        // Then - Bukkit backend is always selected
+        assertThat(backendType).isEqualTo(ScoreboardBackendType.BUKKIT);
+    }
+
+    @Test
+    void selectShouldReturnPacketWhenFoliaAndVersionAtOrBelowSupportedCap() {
+        // Given - Folia with a version at the supported cap
+        final MinecraftGameVersion gameVersion = new MinecraftGameVersion(26, 2, 0);
+
+        // When - Selecting a backend
+        final ScoreboardBackendType backendType = ScoreboardBackendSelector.select(true, gameVersion);
+
+        // Then - Packet backend is selected
+        assertThat(backendType).isEqualTo(ScoreboardBackendType.PACKET);
+    }
+
+    @Test
+    void selectShouldReturnPacketWhenFoliaAndVersionIsPatchOfSupportedLine() {
+        // Given - Folia with a patch release of the supported line; patch releases do not
+        // change scoreboard packets so the whole line stays supported
+        final MinecraftGameVersion gameVersion = new MinecraftGameVersion(26, 2, 3);
+
+        // When - Selecting a backend
+        final ScoreboardBackendType backendType = ScoreboardBackendSelector.select(true, gameVersion);
+
+        // Then - Packet backend is selected
+        assertThat(backendType).isEqualTo(ScoreboardBackendType.PACKET);
+    }
+
+    @Test
+    void selectShouldReturnNoopWhenFoliaAndVersionAboveSupportedCap() {
+        // Given - Folia with an unsupported newer version
+        final MinecraftGameVersion gameVersion = new MinecraftGameVersion(26, 3, 0);
+
+        // When - Selecting a backend
+        final ScoreboardBackendType backendType = ScoreboardBackendSelector.select(true, gameVersion);
+
+        // Then - Noop backend is selected
+        assertThat(backendType).isEqualTo(ScoreboardBackendType.NOOP);
+    }
+
+    @Test
+    void selectShouldNeverReturnBukkitWhenServerIsFolia() {
+        // Given - Multiple Folia versions across supported and unsupported ranges
+        final MinecraftGameVersion oldVersion = new MinecraftGameVersion(1, 20, 5);
+        final MinecraftGameVersion supportedCap = new MinecraftGameVersion(26, 2, 0);
+        final MinecraftGameVersion unsupportedVersion = new MinecraftGameVersion(27, 0, 0);
+
+        // When - Selecting backends
+        final ScoreboardBackendType oldResult = ScoreboardBackendSelector.select(true, oldVersion);
+        final ScoreboardBackendType capResult = ScoreboardBackendSelector.select(true, supportedCap);
+        final ScoreboardBackendType unsupportedResult = ScoreboardBackendSelector.select(true,
+                unsupportedVersion);
+
+        // Then - Folia never selects Bukkit
+        assertThat(oldResult).isIn(ScoreboardBackendType.PACKET, ScoreboardBackendType.NOOP);
+        assertThat(capResult).isIn(ScoreboardBackendType.PACKET, ScoreboardBackendType.NOOP);
+        assertThat(unsupportedResult).isIn(ScoreboardBackendType.PACKET, ScoreboardBackendType.NOOP);
+    }
+}


### PR DESCRIPTION
Replace Bukkit Scoreboard/Objective API with scoreboard-library (packet-based)
  to support Folia and Canvas. Key changes:

  - ScoreboardWrapper: sidebar now uses packet-based Sidebar; remove/revert board is sidebar.removePlayer() instead of player.setScoreboard()
  - ScoreboardManager: load ScoreboardLibrary in init() with NoopScoreboardLibrary fallback; randomize POWER_OBJECTIVE name per startup to avoid colliding with leftover objectives from the old Bukkit impl on client reconnect
  - ScoreboardManager: fix getWrapper() leaking Sidebar resources when wrapper was not stored in map; fix double task cancel in teardownPlayer/cleanup
  - ScoreboardManager: call removeScore() on player quit so offline players do not accumulate in the scores map and flood new players with a large initial packet burst
  - ScoreboardManager: guard removePlayer() with isOnline() to avoid NPE in scoreboard-library's async tick (weak-key playerMap GC race)
  - McMMOScoreboardMakeboardEvent and McMMOScoreboardRevertEvent are still fired for API compatibility; McMMOScoreboardObjectiveEvent is deprecated (no Bukkit Objective exists in the packet impl)
  - pom.xml: fix shade includes for scoreboard-library (scoreboard-library-api + scoreboard-library-implementation); add ViaVersion to softdepend