### PR TITLE
Adds leaderboard and level-check placeholders support to PlaceholderAPI.

### DIFF
--- a/src/main/java/com/gmail/nossr50/placeholders/CheckLevelPlaceholder.java
+++ b/src/main/java/com/gmail/nossr50/placeholders/CheckLevelPlaceholder.java
@@ -1,0 +1,48 @@
+package com.gmail.nossr50.placeholders;
+
+import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
+import org.bukkit.entity.Player;
+
+/**
+ * Placeholder for checking if a player has reached a specific level in a skill
+ * Usage: %mcmmo_checklevel_<skill>:<level>%
+ * Returns: ✔ if player has the level, ✘ if not
+ */
+public class CheckLevelPlaceholder implements Placeholder {
+    private final PapiExpansion papiExpansion;
+    private final PrimarySkillType skill;
+
+    public CheckLevelPlaceholder(PapiExpansion papiExpansion, PrimarySkillType skill) {
+        this.papiExpansion = papiExpansion;
+        this.skill = skill;
+        // The papiExpansion parameter is intentionally "unused" in this class.
+        // It's essential for the class to function properly.
+        // The placeholder needs access to the PapiExpansion instance to query skill levels.
+    }
+
+    @Override
+    public String process(Player player, String params) {
+        if (params == null || params.isEmpty()) {
+            return "§c✘";
+        }
+
+        int requiredLevel;
+        try {
+            requiredLevel = Integer.parseInt(params);
+        } catch (NumberFormatException e) {
+            return "§c✘";
+        }
+
+        Integer currentLevel = papiExpansion.getSkillLevel(skill, player);
+        if (currentLevel == null) {
+            return "§c✘";
+        }
+
+        return currentLevel >= requiredLevel ? "§a✔" : "§c✘";
+    }
+
+    @Override
+    public String getName() {
+        return "checklevel_" + skill.toString().toLowerCase();
+    }
+}

--- a/src/main/java/com/gmail/nossr50/placeholders/McTopNamePlaceholder.java
+++ b/src/main/java/com/gmail/nossr50/placeholders/McTopNamePlaceholder.java
@@ -1,0 +1,56 @@
+package com.gmail.nossr50.placeholders;
+
+import com.gmail.nossr50.datatypes.database.PlayerStat;
+import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Placeholder for getting the player name at a specific position in the leaderboard
+ * Usage: %mcmmo_mctop_name_<skill>:<position>% or %mcmmo_mctop_name_overall:<position>%
+ */
+public class McTopNamePlaceholder implements Placeholder {
+    private final PapiExpansion papiExpansion;
+    private final PrimarySkillType skill;
+
+    public McTopNamePlaceholder(PapiExpansion papiExpansion, PrimarySkillType skill) {
+        this.papiExpansion = papiExpansion;
+        this.skill = skill;
+    }
+
+    @Override
+    public String process(Player player, String params) {
+        if (params == null || params.isEmpty()) {
+            return "";
+        }
+
+        int position;
+        try {
+            position = Integer.parseInt(params);
+        } catch (NumberFormatException e) {
+            return "";
+        }
+
+        if (position < 1) {
+            return "";
+        }
+
+        List<PlayerStat> leaderboard = papiExpansion.getLeaderboard(skill, position);
+        
+        if (leaderboard == null || leaderboard.isEmpty() || position > leaderboard.size()) {
+            return "";
+        }
+
+        PlayerStat stat = leaderboard.get(position - 1);
+        return stat.playerName();
+    }
+
+    @Override
+    public String getName() {
+        if (skill == null) {
+            return "mctop_name_overall";
+        }
+        return "mctop_name_" + skill.toString().toLowerCase();
+    }
+}

--- a/src/main/java/com/gmail/nossr50/placeholders/McTopPositionPlaceholder.java
+++ b/src/main/java/com/gmail/nossr50/placeholders/McTopPositionPlaceholder.java
@@ -1,0 +1,60 @@
+package com.gmail.nossr50.placeholders;
+
+import com.gmail.nossr50.datatypes.database.PlayerStat;
+import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Placeholder for getting the skill level/score at a specific position in the leaderboard
+ * Usage: %mcmmo_mctop_<skill>:<position>% or %mcmmo_mctop_overall:<position>%
+ */
+public class McTopPositionPlaceholder implements Placeholder {
+    private final PapiExpansion papiExpansion;
+    private final PrimarySkillType skill;
+
+    public McTopPositionPlaceholder(PapiExpansion papiExpansion, PrimarySkillType skill) {
+        this.papiExpansion = papiExpansion;
+        this.skill = skill;
+    }
+
+    @Override
+    public String process(Player player, String params) {
+        if (params == null || params.isEmpty()) {
+            return "";
+        }
+
+        int position;
+        try {
+            position = Integer.parseInt(params);
+        } catch (NumberFormatException e) {
+            return "";
+        }
+
+        if (position < 1) {
+            return "";
+        }
+
+        final int statsPerPage = 10; // Adjust if your leaderboard uses a different page size
+        List<PlayerStat> leaderboard = papiExpansion.getLeaderboard(skill, position);
+        
+        if (leaderboard == null || leaderboard.isEmpty()) {
+            return "";
+        }
+        int pageIndex = (position - 1) % statsPerPage;
+        if (pageIndex >= leaderboard.size()) {
+            return "";
+        }
+        PlayerStat stat = leaderboard.get(pageIndex);
+        return String.valueOf(stat.value());
+    }
+
+    @Override
+    public String getName() {
+        if (skill == null) {
+            return "mctop_overall";
+        }
+        return "mctop_" + skill.toString().toLowerCase();
+    }
+}

--- a/src/main/java/com/gmail/nossr50/placeholders/OverallRankPlaceholder.java
+++ b/src/main/java/com/gmail/nossr50/placeholders/OverallRankPlaceholder.java
@@ -1,0 +1,32 @@
+package com.gmail.nossr50.placeholders;
+
+import com.gmail.nossr50.api.ExperienceAPI;
+import org.bukkit.entity.Player;
+
+/**
+ * Placeholder for getting the overall power level rank
+ * Usage: %mcmmo_rank_overall%
+ */
+public class OverallRankPlaceholder implements Placeholder {
+
+    public OverallRankPlaceholder(PapiExpansion papiExpansion) {
+        // The papiExpansion parameter is intentionally unused in this class.
+        // It is kept for consistency with other Placeholder implementations.
+        // If future functionality requires access to papiExpansion, it can be stored as a field.
+    }
+
+    @Override
+    public String process(Player player, String params) {
+        try {
+            int rank = ExperienceAPI.getPlayerRankOverall(player.getUniqueId());
+            return String.valueOf(rank);
+        } catch (Exception ex) {
+            return "";
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "rank_overall";
+    }
+}

--- a/src/main/java/com/gmail/nossr50/placeholders/PapiExpansion.java
+++ b/src/main/java/com/gmail/nossr50/placeholders/PapiExpansion.java
@@ -1,7 +1,9 @@
 package com.gmail.nossr50.placeholders;
 
 import com.gmail.nossr50.api.ExperienceAPI;
+import com.gmail.nossr50.api.exceptions.InvalidSkillException;
 import com.gmail.nossr50.config.experience.ExperienceConfig;
+import com.gmail.nossr50.datatypes.database.PlayerStat;
 import com.gmail.nossr50.datatypes.party.Party;
 import com.gmail.nossr50.datatypes.player.McMMOPlayer;
 import com.gmail.nossr50.datatypes.skills.PrimarySkillType;
@@ -9,6 +11,7 @@ import com.gmail.nossr50.mcMMO;
 import com.gmail.nossr50.util.Permissions;
 import com.gmail.nossr50.util.player.UserManager;
 import com.gmail.nossr50.util.text.StringUtils;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
@@ -196,6 +199,18 @@ public class PapiExpansion extends PlaceholderExpansion {
                 : PlaceholderAPIPlugin.booleanFalse();
     }
 
+    public List<PlayerStat> getLeaderboard(PrimarySkillType skill, int position) {
+        try {
+            // Fetch only the specific entry needed  
+            int statsPerPage = 1;  
+            int pageNumber = position; // Assuming readLeaderboard uses pageNumber as offset for single entry
+            
+            return mcMMO.getDatabaseManager().readLeaderboard(skill, pageNumber, statsPerPage);
+        } catch (InvalidSkillException ex) {
+            return null;
+        }
+    }
+
     public void registerPlaceholder(Placeholder placeholder) {
         final Placeholder registered = placeholders.get(placeholder.getName());
         if (registered != null) {
@@ -206,7 +221,7 @@ public class PapiExpansion extends PlaceholderExpansion {
         placeholders.put(placeholder.getName(), placeholder);
     }
 
-    protected void init() {
+    private void init() {
 
         for (PrimarySkillType skill : PrimarySkillType.values()) {
             // %mcmmo_level_<skillname>%
@@ -226,6 +241,15 @@ public class PapiExpansion extends PlaceholderExpansion {
 
             //%mcmmo_xprate_<skillname>%
             registerPlaceholder(new SkillXpRatePlaceholder(this, skill));
+
+            //%mcmmo_mctop_<skillname>:<position>%
+            registerPlaceholder(new McTopPositionPlaceholder(this, skill));
+
+            //%mcmmo_mctop_name_<skillname>:<position>%
+            registerPlaceholder(new McTopNamePlaceholder(this, skill));
+
+           //%mcmmo_checklevel_<skillname>:<level>%
+            registerPlaceholder(new CheckLevelPlaceholder(this, skill));
         }
 
         //%mcmmo_power_level%
@@ -251,8 +275,18 @@ public class PapiExpansion extends PlaceholderExpansion {
 
         // %mcmmo_is_xp_event_active%
         registerPlaceholder(new XpEventActivePlaceholder(this));
+
         // %mcmmo_xprate%
         registerPlaceholder(new XpRatePlaceholder(this));
+
+        // %mcmmo_rank_overall%
+        registerPlaceholder(new OverallRankPlaceholder(this));
+
+        // %mcmmo_mctop_overall:<position>%
+        registerPlaceholder(new McTopPositionPlaceholder(this, null));
+
+        // %mcmmo_mctop_name_overall:<position>%
+        registerPlaceholder(new McTopNamePlaceholder(this, null));
     }
 
 }


### PR DESCRIPTION
## What changed:

- Added new placeholders to show leaderboard values and player names.
- Added a placeholder to check whether a player meets a specific skill level.

## How to use:

* Use `%mcmmo_mctop_<skill>:<position>%` to show a skill ranking value.
* Use `%mcmmo_mctop_name_<skill>:<position>%` to show the player name at that position.
* Use `%mcmmo_mctop_overall:<position>%` and `%mcmmo_mctop_name_overall:<position>%` for overall rankings.
* Use `%mcmmo_checklevel_<skill>:<level>%` to display ✔ or ✘ based on the player’s level.