### PR TITLE
implemented a persistent ability-use disabled flag on the PlayerProfile

### DIFF
--- a/src/main/java/com/gmail/nossr50/datatypes/player/McMMOPlayer.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/player/McMMOPlayer.java
@@ -103,7 +103,6 @@ public class McMMOPlayer implements Identified {
     private boolean displaySkillNotifications = true;
     private boolean debugMode;
 
-    private boolean abilityUse = true;
     private boolean godMode;
     private boolean chatSpy = false; //Off by default
 
@@ -426,11 +425,11 @@ public class McMMOPlayer implements Identified {
     }
 
     public boolean getAbilityUse() {
-        return abilityUse;
+        return !profile.isAbilityUseDisabled();
     }
 
     public void toggleAbilityUse() {
-        abilityUse = !abilityUse;
+        profile.toggleAbilityUseDisabled();
     }
 
     /*

--- a/src/main/java/com/gmail/nossr50/datatypes/player/PlayerProfile.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/player/PlayerProfile.java
@@ -460,4 +460,17 @@ public class PlayerProfile {
 
         return sum / parents.size();
     }
+
+    /*
+     * Settings
+     */
+
+    public boolean isAbilityUseDisabled() {
+        return uniquePlayerData.getOrDefault(UniqueDataType.ABILITY_USE_DISABLED, 0) > 0;
+    }
+
+    public void toggleAbilityUseDisabled() {
+        markProfileDirty();
+        uniquePlayerData.put(UniqueDataType.ABILITY_USE_DISABLED, isAbilityUseDisabled() ? 0 : 1);
+    }
 }

--- a/src/main/java/com/gmail/nossr50/datatypes/player/UniqueDataType.java
+++ b/src/main/java/com/gmail/nossr50/datatypes/player/UniqueDataType.java
@@ -1,5 +1,6 @@
 package com.gmail.nossr50.datatypes.player;
 
 public enum UniqueDataType {
-    CHIMAERA_WING_DATS
+    CHIMAERA_WING_DATS,
+    ABILITY_USE_DISABLED,
 }


### PR DESCRIPTION
Hey there!

Some players on our server prefer to have the ability-use-mode (`/mcability`) disabled long-term. Currently, they have to run the command after each login, so I implemented a persistent flag on the `PlayerProfile`, using the already-existing `UniqueDataType`.

The reason as to why I went with a disable-flag is that it does not break backwards-compatibility. The default-value of the flag is zero, thus ability-use is not disabled, just as it wasn't in the past, after logging in. The only difference is that the setting now sticks long-term.

I hope I explained the use-case well enough. Always happy to further discuss!