### PR TITLE
gitleaks hits old Jenkins marker in history (optional purge script)

### DIFF
--- a/docs/security/metrics-official-key-git-history.md
+++ b/docs/security/metrics-official-key-git-history.md
@@ -1,0 +1,20 @@
+# Old Jenkins build marker in git history
+
+`master` is fine. Metrics code is gone.
+
+Full history scans (gitleaks, etc.) still flag a 32-char hex string in old commits (~2013 through metrics removal). That is not a bStats API key. It was a hardcoded value compared against a `.jenkins` resource so the old mcStats graph could report whether a build came from official CI.
+
+See `8aabe1c14` in `mcMMO.java` if you want the original context.
+
+## Do you need to do anything?
+
+Probably not. Nothing on `master` reads or sends it. There is no bStats credential to rotate.
+
+If you want a clean `gitleaks detect --log-opts="--all"` on a mirror clone, an admin can:
+
+1. Mirror clone `mcMMO-Dev/mcMMO`
+2. Run `scripts/purge-metrics-official-key-history.sh`
+3. Confirm gitleaks clean
+4. `git push --mirror --force` and tell contributors to re-clone
+
+Normal merge does not rewrite history. This PR is docs + a helper script only.

--- a/scripts/purge-metrics-official-key-history.sh
+++ b/scripts/purge-metrics-official-key-history.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPLACEMENTS="$(mktemp)"
+trap 'rm -f "$REPLACEMENTS"' EXIT
+
+cat >"$REPLACEMENTS" <<'EOF'
+literal:e14cfacdd442a953343ebd8529138680==>REDACTED_JENKINS_BUILD_MARKER
+EOF
+
+command -v git-filter-repo >/dev/null || exit 127
+
+git filter-repo --force --replace-text "$REPLACEMENTS"


### PR DESCRIPTION
`master` is clean. Metrics are long gone.

gitleaks on `--all` still flags a hex string from 2013-era metrics code. It is not a bStats API key. It was a hardcoded Jenkins build fingerprint (`officialKey` compared to `.jenkins`) so old graphs could report official CI builds.

No rotation needed. Low priority.

This PR adds a short note + `scripts/purge-metrics-official-key-history.sh` if you ever want to scrub it from history for scan hygiene. I cannot force-push your remote.

`.md` / `.sh` are force-added because your `.gitignore` ignores them.