### PR TITLE
Workaround possible race condition in TamingManager

### DIFF
--- a/src/main/java/com/gmail/nossr50/mcMMO.java
+++ b/src/main/java/com/gmail/nossr50/mcMMO.java
@@ -50,6 +50,7 @@ import com.gmail.nossr50.skills.repair.repairables.SimpleRepairableManager;
 import com.gmail.nossr50.skills.salvage.salvageables.Salvageable;
 import com.gmail.nossr50.skills.salvage.salvageables.SalvageableManager;
 import com.gmail.nossr50.skills.salvage.salvageables.SimpleSalvageableManager;
+import com.gmail.nossr50.skills.taming.TamingManager;
 import com.gmail.nossr50.util.ChimaeraWing;
 import com.gmail.nossr50.util.EnchantmentMapper;
 import com.gmail.nossr50.util.LogFilter;
@@ -237,6 +238,9 @@ public class mcMMO extends JavaPlugin {
             if (!noErrorsInConfigFiles) {
                 return;
             }
+
+            //Hacky stuff used as a band-aid
+            TamingManager.initStaticCaches();
 
             if (getServer().getName().equals("Cauldron") || getServer().getName().equals("MCPC+")) {
                 checkModConfigs();

--- a/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/taming/TamingManager.java
@@ -63,12 +63,9 @@ public class TamingManager extends SkillManager {
 
         //Init per-player tracking of summoned entities
         mcMMO.getTransientEntityTracker().initPlayer(mmoPlayer.getPlayer());
-
-        //Hacky stuff used as a band-aid
-        initStaticCaches();
     }
 
-    private void initStaticCaches() {
+    public static void initStaticCaches() {
         //TODO: Temporary static cache, will be changed in 2.2
         //This is shared between instances of TamingManager
         if (summoningItems == null) {

--- a/src/test/java/com/gmail/nossr50/skills/taming/TamingManagerTest.java
+++ b/src/test/java/com/gmail/nossr50/skills/taming/TamingManagerTest.java
@@ -114,6 +114,7 @@ class TamingManagerTest extends MMOTestEnvironment {
         }
 
         tamingManager = Mockito.spy(new TamingManager(mmoPlayer));
+        TamingManager.initStaticCaches();
     }
 
     @AfterEach


### PR DESCRIPTION
A bandaid patch for a bandaid patch, fixes a race condition that can happen when multiple players are logging in at the same time after a server restart. Multiple threads will be able to pass the null checks inside initStaticCaches and update the same map, the computeIfAbsent inside getTamingCOTWMaterial is ultimately where a CME was triggered for me. This PR moves that initialization to happen during startup after the config successfully loads to avoid that.