### PR TITLE
Add wildcard and namespaced fishing enchantment filters

### DIFF
--- a/src/main/java/com/gmail/nossr50/config/treasure/FishingTreasureConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/treasure/FishingTreasureConfig.java
@@ -443,7 +443,7 @@ public class FishingTreasureConfig extends BukkitConfig {
         for (final String str : enchantListStr) {
             boolean foundMatch = false;
             for (final Enchantment enchantment : Enchantment.values()) {
-                if (matchesEnchantmentPattern(str, enchantment.getKey().getKey())) {
+                if (matchesEnchantmentPattern(str, enchantment.getKey().toString())) {
                     permissiveList.add(enchantment);
                     foundMatch = true;
                 }
@@ -459,23 +459,31 @@ public class FishingTreasureConfig extends BukkitConfig {
     }
 
     /**
-     * Matches an enchantment key against a config pattern. The asterisk is the only wildcard and
-     * matches zero or more characters; all other characters are matched literally.
+     * Matches an enchantment key against a config pattern. A missing namespace defaults to
+     * {@code minecraft:}. The asterisk is the only wildcard and matches zero or more characters;
+     * all other characters are matched literally.
      */
     @VisibleForTesting
     static boolean matchesEnchantmentPattern(@NotNull String pattern,
             @NotNull String enchantmentKey) {
+        final String normalizedPattern = pattern.indexOf(':') >= 0
+                ? pattern
+                : "minecraft:" + pattern;
+        final String normalizedEnchantmentKey = enchantmentKey.indexOf(':') >= 0
+                ? enchantmentKey
+                : "minecraft:" + enchantmentKey;
+
         int patternIndex = 0;
         int keyIndex = 0;
         int wildcardIndex = -1;
         int wildcardMatchIndex = 0;
 
-        while (keyIndex < enchantmentKey.length()) {
-            if (patternIndex < pattern.length()
-                    && (pattern.charAt(patternIndex) == '*'
-                    || Character.toLowerCase(pattern.charAt(patternIndex))
-                    == Character.toLowerCase(enchantmentKey.charAt(keyIndex)))) {
-                if (pattern.charAt(patternIndex) == '*') {
+        while (keyIndex < normalizedEnchantmentKey.length()) {
+            if (patternIndex < normalizedPattern.length()
+                    && (normalizedPattern.charAt(patternIndex) == '*'
+                    || Character.toLowerCase(normalizedPattern.charAt(patternIndex))
+                    == Character.toLowerCase(normalizedEnchantmentKey.charAt(keyIndex)))) {
+                if (normalizedPattern.charAt(patternIndex) == '*') {
                     wildcardIndex = patternIndex++;
                     wildcardMatchIndex = keyIndex;
                 } else {
@@ -490,10 +498,11 @@ public class FishingTreasureConfig extends BukkitConfig {
             }
         }
 
-        while (patternIndex < pattern.length() && pattern.charAt(patternIndex) == '*') {
+        while (patternIndex < normalizedPattern.length()
+                && normalizedPattern.charAt(patternIndex) == '*') {
             patternIndex++;
         }
-        return patternIndex == pattern.length();
+        return patternIndex == normalizedPattern.length();
     }
 
     private void loadEnchantments() {

--- a/src/main/java/com/gmail/nossr50/config/treasure/FishingTreasureConfig.java
+++ b/src/main/java/com/gmail/nossr50/config/treasure/FishingTreasureConfig.java
@@ -440,13 +440,12 @@ public class FishingTreasureConfig extends BukkitConfig {
             return;
         }
 
-        for (String str : enchantListStr) {
+        for (final String str : enchantListStr) {
             boolean foundMatch = false;
-            for (Enchantment enchantment : Enchantment.values()) {
-                if (enchantment.getKey().getKey().equalsIgnoreCase(str)) {
+            for (final Enchantment enchantment : Enchantment.values()) {
+                if (matchesEnchantmentPattern(str, enchantment.getKey().getKey())) {
                     permissiveList.add(enchantment);
                     foundMatch = true;
-                    break;
                 }
             }
 
@@ -457,6 +456,44 @@ public class FishingTreasureConfig extends BukkitConfig {
                                 + str);
             }
         }
+    }
+
+    /**
+     * Matches an enchantment key against a config pattern. The asterisk is the only wildcard and
+     * matches zero or more characters; all other characters are matched literally.
+     */
+    @VisibleForTesting
+    static boolean matchesEnchantmentPattern(@NotNull String pattern,
+            @NotNull String enchantmentKey) {
+        int patternIndex = 0;
+        int keyIndex = 0;
+        int wildcardIndex = -1;
+        int wildcardMatchIndex = 0;
+
+        while (keyIndex < enchantmentKey.length()) {
+            if (patternIndex < pattern.length()
+                    && (pattern.charAt(patternIndex) == '*'
+                    || Character.toLowerCase(pattern.charAt(patternIndex))
+                    == Character.toLowerCase(enchantmentKey.charAt(keyIndex)))) {
+                if (pattern.charAt(patternIndex) == '*') {
+                    wildcardIndex = patternIndex++;
+                    wildcardMatchIndex = keyIndex;
+                } else {
+                    patternIndex++;
+                    keyIndex++;
+                }
+            } else if (wildcardIndex >= 0) {
+                patternIndex = wildcardIndex + 1;
+                keyIndex = ++wildcardMatchIndex;
+            } else {
+                return false;
+            }
+        }
+
+        while (patternIndex < pattern.length() && pattern.charAt(patternIndex) == '*') {
+            patternIndex++;
+        }
+        return patternIndex == pattern.length();
     }
 
     private void loadEnchantments() {

--- a/src/main/resources/fishing_treasures.yml
+++ b/src/main/resources/fishing_treasures.yml
@@ -285,6 +285,7 @@ Fishing:
         Rarity: LEGENDARY
 # Uncomment the below 3 lines to use the Whitelist, Alternatively rename it Enchantments_Blacklist to use the blacklist
 # NOTE: Enchantments_Whitelist and Enchantments_Blacklist only do anything for Enchanted_Books at the moment, you can't use it with any other treasure definition
+# An asterisk (*) can be used as a wildcard to match zero or more characters in an enchantment name (for example, "*_PROTECTION").
 #        Enchantments_Whitelist:
 #            - Fortune
 #            - Protection

--- a/src/main/resources/fishing_treasures.yml
+++ b/src/main/resources/fishing_treasures.yml
@@ -285,7 +285,8 @@ Fishing:
         Rarity: LEGENDARY
 # Uncomment the below 3 lines to use the Whitelist, Alternatively rename it Enchantments_Blacklist to use the blacklist
 # NOTE: Enchantments_Whitelist and Enchantments_Blacklist only do anything for Enchanted_Books at the moment, you can't use it with any other treasure definition
-# An asterisk (*) can be used as a wildcard to match zero or more characters in an enchantment name (for example, "*_PROTECTION").
+# Namespaces are optional and default to minecraft:; an asterisk (*) matches zero or more
+# characters in the namespace or name (for example, "minecraft:*_PROTECTION" or "custom:*").
 #        Enchantments_Whitelist:
 #            - Fortune
 #            - Protection

--- a/src/test/java/com/gmail/nossr50/config/treasure/FishingTreasureConfigTest.java
+++ b/src/test/java/com/gmail/nossr50/config/treasure/FishingTreasureConfigTest.java
@@ -189,7 +189,13 @@ class FishingTreasureConfigTest {
                 "protection_*,fire_protection,false",
                 "fortune,looting,false",
                 "*,mending,true",
-                "mending,*,false"
+                "mending,*,false",
+                "minecraft:mending,minecraft:mending,true",
+                "mending,minecraft:mending,true",
+                "custom:enchant_name,custom:enchant_name,true",
+                "custom:*,custom:enchant_name,true",
+                "custom:*,minecraft:mending,false",
+                "minecraft:*,custom:enchant_name,false"
         })
         void matchesWildcardEnchantmentKeys(final String pattern, final String enchantmentKey,
                 final boolean expected) {

--- a/src/test/java/com/gmail/nossr50/config/treasure/FishingTreasureConfigTest.java
+++ b/src/test/java/com/gmail/nossr50/config/treasure/FishingTreasureConfigTest.java
@@ -9,6 +9,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class FishingTreasureConfigTest {
@@ -173,6 +174,27 @@ class FishingTreasureConfigTest {
             assertThat(config.getInt("Shake.MOOSHROOM.MILK_BUCKET.Amount"))
                     .as("Amount should be copied faithfully to MOOSHROOM")
                     .isEqualTo(1);
+        }
+    }
+
+    @Nested
+    class EnchantmentPatterns {
+
+        @ParameterizedTest
+        @CsvSource({
+                "fortune,fortune,true",
+                "FORTUNE,fortune,true",
+                "*_protection,blast_protection,true",
+                "protection_*,protection_fire,true",
+                "protection_*,fire_protection,false",
+                "fortune,looting,false",
+                "*,mending,true",
+                "mending,*,false"
+        })
+        void matchesWildcardEnchantmentKeys(final String pattern, final String enchantmentKey,
+                final boolean expected) {
+            assertThat(FishingTreasureConfig.matchesEnchantmentPattern(pattern, enchantmentKey))
+                    .isEqualTo(expected);
         }
     }
 
@@ -521,4 +543,3 @@ class FishingTreasureConfigTest {
         }
     }
 }
-


### PR DESCRIPTION
## Objective

Fishing treasure enchantment filters for enchanted books did not accept complete `namespace:key` identifiers or allow selecting groups of custom enchantments. This change adds namespace and wildcard support while preserving the existing shorthand syntax.

## Changes

- Accept identifiers such as `minecraft:mending` and `custom:enchant_name`.
- Default to `minecraft:` when no namespace is specified.
- Support `*` as a wildcard matching zero or more characters, including filters such as `custom:*` and `minecraft:*_PROTECTION`.
- Apply the same behavior to `Enchantments_Whitelist` and `Enchantments_Blacklist`.
- Document the syntax in `fishing_treasures.yml`.
- Add tests covering exact names, shorthand syntax, namespaces, wildcards, and namespace separation.

## Validation

- `git diff --check` passed.
- Independent namespace and wildcard edge-case checks passed.
- Maven tests could not be run because Maven is not installed in the environment.
